### PR TITLE
Update shortcode files for Apama with the URLs for the 10.11 release

### DIFF
--- a/themes/c8ydocs/layouts/shortcodes/link-analytics-builder.html
+++ b/themes/c8ydocs/layouts/shortcodes/link-analytics-builder.html
@@ -1,1 +1,1 @@
-{{- "https://documentation.softwareag.com/apama/Analytics_Builder/pab10-10-0/apama-pab-webhelp/" -}}
+{{- "https://documentation.softwareag.com/apama/Analytics_Builder/pab10-11-0/apama-pab-webhelp/" -}}

--- a/themes/c8ydocs/layouts/shortcodes/link-apama-webhelp.html
+++ b/themes/c8ydocs/layouts/shortcodes/link-apama-webhelp.html
@@ -1,1 +1,1 @@
-{{- "https://documentation.softwareag.com/onlinehelp/Rohan/Apama/v10-7/apama10-7/apama-webhelp/" -}}
+{{- "https://documentation.softwareag.com/apama/v10-11/apama10-11/apama-webhelp/" -}}

--- a/themes/c8ydocs/layouts/shortcodes/link-apamadoc-api.html
+++ b/themes/c8ydocs/layouts/shortcodes/link-apamadoc-api.html
@@ -1,1 +1,1 @@
-{{- "https://documentation.softwareag.com/onlinehelp/Rohan/Apama/v10-7/apama10-7/ApamaDoc/" -}}
+{{- "https://documentation.softwareag.com/apama/v10-11/apama10-11/ApamaDoc/" -}}


### PR DESCRIPTION
These direct links for 10.11 already work (although the index pages for this version are still hidden on the doc website).