### PR TITLE
PAQ release note for 10.12.0 (PAB-2368)

### DIFF
--- a/content/release-10-12-0/streaming-analytics-10-12-0-bundle/10_12_0.md
+++ b/content/release-10-12-0/streaming-analytics-10-12-0-bundle/10_12_0.md
@@ -1,0 +1,18 @@
+---
+weight: 40
+title: Release 10.12.0
+layout: redirect
+---
+
+### Apama correlator version
+
+This release of Cumulocity IoT Streaming Analytics includes the Apama version 10.11.1 correlator. 
+See also [What's New In Apama 10.11.1](https://documentation.softwareag.com/apama/v10-11/apama10-11/apama-webhelp/index.html#page/apama-webhelp%2Fco-WhaNewInApa_10111_top.html) 
+in the Apama documentation.
+
+### Improvements for EPL apps
+
+The EPL samples that can be accessed from the EPL editor of the Streaming Analytics application have been revised 
+to make them more concise and to have a more narrow focus.
+See also [Developing apps with the Streaming Analytics application](https://cumulocity.com/guides/apama/analytics-introduction/#apama-epl-apps).
+

--- a/content/release-10-12-0/streaming-analytics-10-12-0-bundle/index.html
+++ b/content/release-10-12-0/streaming-analytics-10-12-0-bundle/index.html
@@ -1,0 +1,4 @@
+---
+title: 10.5.0
+headless: true
+---

--- a/content/release-10-12-0/streaming-analytics-10-12-0.md
+++ b/content/release-10-12-0/streaming-analytics-10-12-0.md
@@ -1,0 +1,6 @@
+---
+weight: 70
+title: Streaming Analytics
+layout: bundle
+---
+


### PR DESCRIPTION
Added new directory and files for Streaming Analytics 10.12.0. Gave the usual information on the correlator version, and added a release note for the revised EPL samples (PAB-2368). 
Note that the direct link to the Apama 10.11.1 release notes topic will only work after the Apama 10.11.1 doc has been published.