### PR TITLE
MTM-42020 Fixed left side navigation for 'support user access' link

### DIFF
--- a/content/users-guide/enterprise-tenant-bundle/managing-tenants.md
+++ b/content/users-guide/enterprise-tenant-bundle/managing-tenants.md
@@ -102,7 +102,7 @@ In the **Properties** tab, all fields are editable except of **ID**, **Domain/ U
 To change the tenant password, click **Change password**, enter the new password in the upcoming fields and click **Save**.
 
 <a name="user-access"></a>
-#### Support user access
+#### Support user access information
 
 At the right of the **Properties** tab, you can find information on the support user requests/access for the subtenants.
 


### PR DESCRIPTION
Fixed the left side navigation issue for the link `Support user access` under "Enterprise tenant" section.

The issue was that we have 2 ids with the same `support-user-access`, so the hyperlink was wrong. Fixed the issue by renaming the title to a different one resulting in non-conflicting id.
