### PR TITLE
Add a link to the list of times zones in the Apama documentation

### DIFF
--- a/content/benutzerhandbuch/cockpit-de-bundle/smart-rules-collection.md
+++ b/content/benutzerhandbuch/cockpit-de-bundle/smart-rules-collection.md
@@ -897,7 +897,7 @@ Sie können diesen Mechanismus verwenden, um etwa Gerätenamen oder Alarmtexte i
 </table>
 
 > **Info:** Bei Verwendung von Apama für Smart Rules (angezeigt durch ein Abonnement von Apama-ctrl in <b>Anwendungen</b> > <b>Abonnierte Anwendungen</b> in der "Administration"-Anwendung) können Variablen für Uhrzeiten eine Zeitzone enthalten, in der die Uhrzeit angezeigt werden soll.
-So zeigt zum Beispiel die Variable #{time:TZ=America/New_York} die Uhrzeit entsprechend der Zeitzone für New York an.
+So zeigt zum Beispiel die Variable #{time:TZ=America/New_York} die Uhrzeit entsprechend der Zeitzone für New York an. Siehe auch [Supported time zones]({{< link-apama-webhelp >}}/index.html#page/apama-webhelp%2Fco-DevApaAppInEpl_supported_time_zones.html) in der Apama-Dokumentation.
 
 **Alarmspezifische Felder**
 

--- a/content/users-guide/cockpit-bundle/smart-rules-collection.md
+++ b/content/users-guide/cockpit-bundle/smart-rules-collection.md
@@ -901,7 +901,7 @@ You can use this mechanism for example to insert device names or alarm text into
 </table>
 
 > **Info:** If using Apama for smart rules (shown by a subscription to Apama-ctrl in <b>Applications</b> > <b>Subscribed Applications</b> in the Administration application), variables for times can include a time zone to display the time in.
-The variable #{time:TZ=America/New_York} for example displays the time using the time zone for New York.
+The variable #{time:TZ=America/New_York} for example displays the time using the time zone for New York. See also [Supported time zones]({{< link-apama-webhelp >}}/index.html#page/apama-webhelp%2Fco-DevApaAppInEpl_supported_time_zones.html) in the Apama documentation.
 
 **Fields specific for alarms**
 


### PR DESCRIPTION
Did this in both the English and German User guide.
Guess we'll also want to cherry-pick this into 10.11.