### PR TITLE
PAB-2880: Smart rules update in Streaming Analytics guide and User guide

### DIFF
--- a/content/apama/troubleshooting-bundle/alarms.md
+++ b/content/apama/troubleshooting-bundle/alarms.md
@@ -40,7 +40,6 @@ The following is a list of the alarms. The information further down below explai
 - [EPL app restore timeout on restart of Apama-ctrl](#eplapp_restore_timeout)
 - [Multiple extensions with the same name](#extension_error)
 - [Smart rule configuration failed](#smartrule_configuration_error)
-- [Smart rule configuration for substitution variable failed](#smartrule_configuration_warn)
 - [Smart rule restore failed](#smartrule_restore_failed)
 - [Connection to correlator lost](#lost_correlator_connection)
 - [The correlator queue is full](#application_queue_full)
@@ -297,20 +296,6 @@ This alarm is raised if a smart rule contains an invalid configuration.
 To diagnose the cause, download the diagnostics overview ZIP file as described in [Downloading diagnostics and logs](#diagnostics-download). Or, if that fails, log on as an administrator and look at the result of a GET request to */service/smartrule/smartrules?withPrivateRules=true*. Review the smart rules JSON and look for invalid smart rule configurations. Such smart rules need to be corrected.
 
 The Apama microservice log contains more details on the reason for the smart rule configuration failure. For example, it is invalid to configure an "On measurement threshold create alarm" smart rule with a data point that does not exist.
-
-
-
-<a name="smartrule_configuration_warn"></a>
-#### Smart rule configuration for substitution variable failed
-
-This alarm is raised if a smart rule contains an unrecognized or invalid configuration for a substitution variable.
-
-- Alarm type: `smartrule_configuration_warn`
-- Alarm text: &lt;Smart rule identifier&gt;: Smart rule &lt;warning message&gt; - &lt;original exception message&gt;
-- Alarm severity: WARNING
-
-The Apama microservice log also contains a warning message with the exception message.
-
 
 <a name="smartrule_restore_failed"></a>
 #### Smart rule restore failed

--- a/content/benutzerhandbuch/cockpit-de-bundle/smart-rules-collection.md
+++ b/content/benutzerhandbuch/cockpit-de-bundle/smart-rules-collection.md
@@ -900,8 +900,11 @@ Sie können diesen Mechanismus verwenden, um etwa Gerätenamen oder Alarmtexte i
   </tr>
 </table>
 
-> **Info:** Bei Verwendung von Apama für Smart Rules (angezeigt durch ein Abonnement von Apama-ctrl in <b>Anwendungen</b> > <b>Abonnierte Anwendungen</b> in der "Administration"-Anwendung) können Variablen für Uhrzeiten eine Zeitzone enthalten, in der die Uhrzeit angezeigt werden soll.
-So zeigt zum Beispiel die Variable #{time:TZ=America/New_York} die Uhrzeit entsprechend der Zeitzone für New York an. Siehe auch [Supported time zones]({{< link-apama-webhelp >}}/index.html#page/apama-webhelp%2Fco-DevApaAppInEpl_supported_time_zones.html) in der Apama-Dokumentation.
+> **Info:** Bei Verwendung von Apama für Smart Rules (angezeigt durch ein Abonnement von Apama-ctrl in <b>Anwendungen</b> > <b>Abonnierte Anwendungen</b> in der "Administration"-Anwendung) können Variablen für Uhrzeiten eine Zeitzone und ein Zeitformat für die Anzeige der Uhrzeit enthalten.
+So zeigt zum Beispiel die Variable #{time:TZ=America/New_York,FORMAT="HH:mm:ssZ"} die Uhrzeit entsprechend der Zeitzone für New York mit dem Format HH:mm:ssZ an. 
+Siehe auch [Supported time zones]({{< link-apama-webhelp >}}/index.html#page/apama-webhelp%2Fco-DevApaAppInEpl_supported_time_zones.html) 
+und [Format specification for the TimeFormat functions]({{< link-apama-webhelp >}}/index.html#page/apama-webhelp%2Fco-DevApaAppInEpl_format_specification_for_the_time_format_plug_in_functions.html)
+in der Apama-Dokumentation.
 
 **Alarmspezifische Felder**
 

--- a/content/users-guide/cockpit-bundle/smart-rules-collection.md
+++ b/content/users-guide/cockpit-bundle/smart-rules-collection.md
@@ -900,8 +900,12 @@ You can use this mechanism for example to insert device names or alarm text into
   </tr>
 </table>
 
-> **Info:** If using Apama for smart rules (shown by a subscription to Apama-ctrl in <b>Applications</b> > <b>Subscribed Applications</b> in the Administration application), variables for times can include a time zone to display the time in.
-The variable #{time:TZ=America/New_York} for example displays the time using the time zone for New York. See also [Supported time zones]({{< link-apama-webhelp >}}/index.html#page/apama-webhelp%2Fco-DevApaAppInEpl_supported_time_zones.html) in the Apama documentation.
+> **Info:** If using Apama for smart rules (shown by a subscription to Apama-ctrl in <b>Applications</b> > <b>Subscribed Applications</b> in the Administration application), 
+variables for times can include a time zone and time format to display the time in.
+The variable #{time:TZ=America/New_York,FORMAT="HH:mm:ssZ"} for example displays the time using the time zone for New York in the format HH:mm:ssZ. 
+See also [Supported time zones]({{< link-apama-webhelp >}}/index.html#page/apama-webhelp%2Fco-DevApaAppInEpl_supported_time_zones.html)
+and [Format specification for the TimeFormat functions]({{< link-apama-webhelp >}}/index.html#page/apama-webhelp%2Fco-DevApaAppInEpl_format_specification_for_the_time_format_plug_in_functions.html)
+in the Apama documentation.
 
 **Fields specific for alarms**
 


### PR DESCRIPTION
Removed an alarm in the Streaming Analytics guide.
Added the new FORMAT parameter for the #time specification to the User guide, and also in its German version.