### PR TITLE
Spelling Schwellenwert German User guide

### DIFF
--- a/content/benutzerhandbuch/cockpit-de-bundle/data-explorer.md
+++ b/content/benutzerhandbuch/cockpit-de-bundle/data-explorer.md
@@ -135,11 +135,11 @@ Die folgenden Felder können bearbeitet werden:
 </tr>
 <tr>
 <td style="text-align:left">Gelber Bereich min/max</td>
-<td style="text-align:left">Legt den Bereich fest, in welchem WENIGER WICHTIGE Alarme über eine Schwellwertregel ausgelöst werden.  </td>
+<td style="text-align:left">Legt den Bereich fest, in welchem WENIGER WICHTIGE Alarme über eine Schwellenwertregel ausgelöst werden.  </td>
 </tr>
 <tr>
 <td style="text-align:left">Roter Bereich min/max</td>
-<td style="text-align:left">Legt den Bereich fest, in welchem KRITISCHE Alarme über eine Schwellwertregel ausgelöst werden.</td>
+<td style="text-align:left">Legt den Bereich fest, in welchem KRITISCHE Alarme über eine Schwellenwertenregel ausgelöst werden.</td>
 </tr>
 <tr>
 <td style="text-align:left">Anzeige</td>

--- a/content/benutzerhandbuch/cockpit-de-bundle/data-point-library.md
+++ b/content/benutzerhandbuch/cockpit-de-bundle/data-point-library.md
@@ -10,7 +10,7 @@ Datenpunktattribute ähneln den Absatzformaten in Textverarbeitungsanwendungen. 
 
 Wie verwendet die Cockpit-Anwendung die Datenpunktbibliothek? Um die Standardvisualisierung für einen Datenpunkt wie Farbe oder Beschriftung zu finden, durchsucht die {{< product-c8y-iot >}}-Plattform die Datenpunktbibliothek und versucht, einen passenden Eintrag zu finden. Ein Eintrag gilt als "passend", wenn die Werte für Fragment und Serie in der Datenpunktbibliothek mit den Messwerten übereinstimmen. Bei einem passenden Eintrag werden die entsprechenden Datenpunktattribute für eine Standardvisualisierung verwendet.
 
-Darüber hinaus werden die Attribute der Datenpunktbibliothek von Geschäftsregeln verwendet: Die in der Datenpunktbibliothek konfigurierten roten und gelben Werte werden von Schwellwertregeln verwendet, um Alarme auszulösen.
+Darüber hinaus werden die Attribute der Datenpunktbibliothek von Geschäftsregeln verwendet: Die in der Datenpunktbibliothek konfigurierten roten und gelben Werte werden von Schwellenwertregeln verwendet, um Alarme auszulösen.
 
 Klicken Sie auf **Datenpunktbibliothek** im Menü **Konfiguration** im Navigator, um die Datenpunktbibliothek zu öffnen.
 

--- a/content/benutzerhandbuch/cockpit-de-bundle/smart-rules-collection.md
+++ b/content/benutzerhandbuch/cockpit-de-bundle/smart-rules-collection.md
@@ -60,12 +60,12 @@ Folgende Typen sind verfügbar:
 <td align="left">Tritt ein bestimmter Alarm auf, wird die spezifizierte Operation zum Gerät gesendet.</td>
 </tr>
 <tr>
-<td align="left"><a href="#threshold-explicit">Bei explizitem Schwellwert Alarm erzeugen</a></td>
-<td align="left">Wenn der Messwert den roten Bereich betritt oder verlässt, wird ein KRITISCHER Alarm erzeugt bzw. gelöscht. Die Regel ist ähnlich wie die Regel "Bei Schwellwertüberschreitung Alarm erzeugen". Allerdings wird der rote Schwellwert explizit bereitgestellt.</td>
+<td align="left"><a href="#threshold-explicit">Bei explizitem Schwellenwert Alarm erzeugen</a></td>
+<td align="left">Wenn der Messwert den roten Bereich betritt oder verlässt, wird ein KRITISCHER Alarm erzeugt bzw. gelöscht. Die Regel ist ähnlich wie die Regel "Bei Schwellenwertüberschreitung Alarm erzeugen". Allerdings wird der rote Schwellenwert explizit bereitgestellt.</td>
 </tr>
 <tr>
-<td align="left"><a href="#threshold-alarm">Bei Schwellwert Alarm erzeugen</a></td>
-<td align="left">Wenn der Messwert einen definierten roten oder gelben Bereich betritt oder verlässt, wird ein Alarm erzeugt bzw. gelöscht. Diese Regel nimmt die Schwellwerte aus dem Gerät oder aus der Datenpunktbibliothek:</td>
+<td align="left"><a href="#threshold-alarm">Bei Schwellenwert Alarm erzeugen</a></td>
+<td align="left">Wenn der Messwert einen definierten roten oder gelben Bereich betritt oder verlässt, wird ein Alarm erzeugt bzw. gelöscht. Diese Regel nimmt die Schwellenwerte aus dem Gerät oder aus der Datenpunktbibliothek:</td>
 </tr>
 </tbody>
 </table>
@@ -632,7 +632,7 @@ Weitere Informationen zum Aktivieren/Deaktivieren einer Smart Rule finden Sie un
 </table>
 
 <a name="threshold-alarm"></a>
-### Bei Schwellwert Alarm erzeugen
+### Bei Schwellenwert Alarm erzeugen
 
 **Funktionalität**
 
@@ -696,7 +696,7 @@ Wenn wir den gelben Bereich auf "[30;60)" und den roten Bereich auf "[50;90]" ei
 
 und der Messwert 55 beträgt, wird ein WENIGER WICHTIGER Alarm (gelb) erzeugt.
 
-Durch diese Mechanismen können globale Schwellwertbereiche in der Datenpunktbibliothek definiert werden. Diese globalen Werte können dann von Fall zu Fall für bestimmte Objekte überschrieben werden.
+Durch diese Mechanismen können globale Schwellenwertbereiche in der Datenpunktbibliothek definiert werden. Diese globalen Werte können dann von Fall zu Fall für bestimmte Objekte überschrieben werden.
 
 **Parameter**
 
@@ -725,7 +725,7 @@ Die Regel verwendet die folgenden Parameter:
 </tr>
 <tr>
 <td align="left">2</td>
-<td align="left">Bei Schwellwert</td>
+<td align="left">Bei Schwellenwert</td>
 <td align="left"><strong>Fragment/Series</strong>: Fragment/Series des Messwerts. Der eingehende Messwert muss exakt die gleichen Fragment/Series-Werte haben. Wenn eine Regel im Daten-Explorer erstellt wird, sind diese Felder bereits ausgefüllt. <br> <strong>Eintrag in der Datenpunktbibliothek</strong>: Name des Eintrags in der Datenpunktbibliothek. Wird verwendet, um die Standardwerte für den roten und gelben Bereich zu ermitteln, wenn diese nicht individuell konfiguriert wurden. Beachten Sie, dass die im Datenpunkt festgelegte Einheit hier nicht berücksichtigt wird.</td>
 </tr>
 <tr>
@@ -779,13 +779,13 @@ Sind in den zusammengeführten Parametern keine roten/gelben Bereiche definiert,
 
 * Prüfen Sie, ob der Alarm bereits durch die nächste Messung mit Werten im grünen Bereich gelöscht wurde.
 
-> **Info:**  Wenn Sie einen Alarm löschen, bestätigen Sie damit, dass der Alarm aufgehoben ist. Ein neuer Alarm wird nur erzeugt, wenn das Gerät den Zustand wechselt und den Schwellwert wieder überschreitet.
+> **Info:**  Wenn Sie einen Alarm löschen, bestätigen Sie damit, dass der Alarm aufgehoben ist. Ein neuer Alarm wird nur erzeugt, wenn das Gerät den Zustand wechselt und den Schwellenwert wieder überschreitet.
 
 >**Info:** Unter bestimmten Umständen, etwa wenn der zeitliche Abstand zwischen den Messungen sehr groß ist, kann diese Smart Rule einen falschen Alarmschweregrad hervorrufen. Wird beispielsweise der CEP/Apama-Pod neu gestartet, geht der interne Zustand verloren und es wird erneut ein Alarm ausgegeben, wenn dies nicht der Fall sein sollte, was zu einem falschen Alarmschweregrad führt.
 
 
 <a name="threshold-explicit"></a>
-### Bei explizitem Schwellwert Alarm erzeugen
+### Bei explizitem Schwellenwert Alarm erzeugen
 
 **Funktionalität**
 
@@ -797,7 +797,7 @@ Der Schweregrad des Alarms wird folgendermaßen bestimmt:
 
 * Wenn der Messwert sich in den grünen Bereich bewegt, wird kein Alarm erzeugt.
 
-> **Info:** Die Regel ist ähnlich wie die Regel "Bei Schwellwertüberschreitung Alarm erzeugen". Allerdings wird in dieser Regel hier der rote Schwellwert explizit bereitgestellt, während in der Regel "Bei Schwellwert Alarm erzeugen" der Schwellwert vom Gerät oder aus der Datenpunktbibliothek genommen wird.
+> **Info:** Die Regel ist ähnlich wie die Regel "Bei Schwellenwertüberschreitung Alarm erzeugen". Allerdings wird in dieser Regel hier der rote Schwellenwert explizit bereitgestellt, während in der Regel "Bei Schwellenwert Alarm erzeugen" der Schwellenwert vom Gerät oder aus der Datenpunktbibliothek genommen wird.
 
 **Parameter**
 
@@ -826,7 +826,7 @@ Die Regel verwendet die folgenden Parameter:
 </tr>
 <tr>
 <td align="left">2</td>
-<td align="left">Bei Schwellwert</td>
+<td align="left">Bei Schwellenwert</td>
 <td align="left"><strong>Fragment/Series</strong>: Fragment/Series des Messwerts. Der eingehende Messwert muss exakt die gleichen Fragment/Series-Werte haben. Wenn eine Regel im Daten-Explorer erstellt wird, sind diese Felder bereits ausgefüllt. <br> <strong>Minimum, Maximum</strong>: Wenn sich ein Wert im angegebenen Bereich [minimum; maximum] befindet, wird der konfigurierte Alarm ausgelöst.</td>
 </tr>
 <tr>
@@ -855,7 +855,7 @@ Weitere Informationen zum Aktivieren/Deaktivieren einer Smart Rule finden Sie un
 
 * Prüfen Sie, ob der Alarm bereits durch die nächste Messung mit Werten im grünen Bereich gelöscht wurde.
 
-> **Info:**  Wenn Sie einen Alarm löschen, bestätigen Sie damit, dass der Alarm aufgehoben ist. Ein neuer Alarm wird nur erzeugt, wenn das Gerät den Zustand wechselt und den Schwellwert wieder überschreitet.
+> **Info:**  Wenn Sie einen Alarm löschen, bestätigen Sie damit, dass der Alarm aufgehoben ist. Ein neuer Alarm wird nur erzeugt, wenn das Gerät den Zustand wechselt und den Schwellenwert wieder überschreitet.
 
 >**Info:** Unter bestimmten Umständen, etwa wenn der zeitliche Abstand zwischen den Messungen sehr groß ist, kann diese Smart Rule einen falschen Alarmschweregrad hervorrufen. Wird beispielsweise der CEP/Apama-Pod neu gestartet, geht der interne Zustand verloren und es wird erneut ein Alarm ausgegeben, wenn dies nicht der Fall sein sollte, was zu einem falschen Alarmschweregrad führt.
 
@@ -901,8 +901,8 @@ Sie können diesen Mechanismus verwenden, um etwa Gerätenamen oder Alarmtexte i
 </table>
 
 > **Info:** Bei Verwendung von Apama für Smart Rules (angezeigt durch ein Abonnement von Apama-ctrl in <b>Anwendungen</b> > <b>Abonnierte Anwendungen</b> in der "Administration"-Anwendung) können Variablen für Uhrzeiten eine Zeitzone und ein Zeitformat für die Anzeige der Uhrzeit enthalten.
-So zeigt zum Beispiel die Variable #{time:TZ=America/New_York,FORMAT="HH:mm:ssZ"} die Uhrzeit entsprechend der Zeitzone für New York mit dem Format HH:mm:ssZ an. 
-Siehe auch [Supported time zones]({{< link-apama-webhelp >}}/index.html#page/apama-webhelp%2Fco-DevApaAppInEpl_supported_time_zones.html) 
+So zeigt zum Beispiel die Variable #{time:TZ=America/New_York,FORMAT="HH:mm:ssZ"} die Uhrzeit entsprechend der Zeitzone für New York mit dem Format HH:mm:ssZ an.
+Siehe auch [Supported time zones]({{< link-apama-webhelp >}}/index.html#page/apama-webhelp%2Fco-DevApaAppInEpl_supported_time_zones.html)
 und [Format specification for the TimeFormat functions]({{< link-apama-webhelp >}}/index.html#page/apama-webhelp%2Fco-DevApaAppInEpl_format_specification_for_the_time_format_plug_in_functions.html)
 in der Apama-Dokumentation.
 

--- a/content/benutzerhandbuch/cockpit-de-bundle/smart-rules.md
+++ b/content/benutzerhandbuch/cockpit-de-bundle/smart-rules.md
@@ -13,7 +13,7 @@ Zum einfachen Erstellen von Regeln enthält die Cockpit-Anwendung einen "Smart R
 Smart Rules werden parametrisiert. Es gibt zwei Quellen für Parameter:
 
 * **Regelparameter** werden vom Benutzer beim Erstellen einer Smart Rule aus einem Template bereitgestellt. Beispiele sind E-Mail-Adressen und Alarmtexte.
-* **Objektparameter** werden in der Gruppe oder dem Gerät gespeichert. Diese Parameter können auch nach der Erstellung der Smart Rule bearbeitet werden. Ein Beispiel sind Min- und Max-Werte für Schwellwerte.
+* **Objektparameter** werden in der Gruppe oder dem Gerät gespeichert. Diese Parameter können auch nach der Erstellung der Smart Rule bearbeitet werden. Ein Beispiel sind Min- und Max-Werte für Schwellenwerte.
 
 Es gibt zwei Typen von Smart Rules:
 
@@ -104,7 +104,7 @@ Um eine Regel explizit zu aktivieren bzw. zu deaktivieren, navigieren Sie zur Re
 
 <img src="/images/benutzerhandbuch/cockpit/cockpit-smartrule-active-toggle.png" name="Smart rule in Info tab" />
 
-Ein Anwendungsbeispiel für das Deaktivieren einer Smart Rule für ein einzelnes Objekt könnte sein, dass ein bestimmtes Gerät zu viele Schwellwert-Alarme generiert. Die Regel kann lediglich für dieses Gerät deaktiviert werden, aber immer noch für alle anderen Objekte aktiv sein.
+Ein Anwendungsbeispiel für das Deaktivieren einer Smart Rule für ein einzelnes Objekt könnte sein, dass ein bestimmtes Gerät zu viele Schwellenwert-Alarme generiert. Die Regel kann lediglich für dieses Gerät deaktiviert werden, aber immer noch für alle anderen Objekte aktiv sein.
 
 Im Falle einer Gruppe aktivieren/deaktivieren Sie die Smart Rule mit dem Umschalter allein für die Gruppe. Sie können die Regel dann über das Auswahlfeld unterhalb des Umschalters separat für die Kinder der Gruppe aktivieren/deaktivieren.
 
@@ -112,16 +112,16 @@ Im Falle einer Gruppe aktivieren/deaktivieren Sie die Smart Rule mit dem Umschal
 
 >**Wichtig:** Eine Regel, die für ein bestimmtes Objekt aktiviert ist, funktioniert nur, wenn sie auch global eingeschaltet ist.
 
-### Beispiel: Definieren von exakten Schwellwerten
+### Beispiel: Definieren von exakten Schwellenwerten
 
-Führen Sie folgende Schritte aus, um eine Schwellwertregel zu definieren:
+Führen Sie folgende Schritte aus, um eine Schwellenwertregel zu definieren:
 
-1. Navigieren Sie im Menü Gruppen zu dem Objekt (Gruppe oder Gerät), auf welches Sie den Schwellwert anwenden möchten.
+1. Navigieren Sie im Menü Gruppen zu dem Objekt (Gruppe oder Gerät), auf welches Sie den Schwellenwert anwenden möchten.
 2. Wechseln Sie zur Registerkarte **Daten-Explorer**.
-3. Wenn der Datenpunkt, der den Schwellwert festlegen soll, standardmäßig nicht sichtbar ist, wählen Sie **Datenpunkt hinzufügen** und [fügen Sie einen Datenpunkt hinzu](#add-data-points).
+3. Wenn der Datenpunkt, der den Schwellenwert festlegen soll, standardmäßig nicht sichtbar ist, wählen Sie **Datenpunkt hinzufügen** und [fügen Sie einen Datenpunkt hinzu](#add-data-points).
 4. Öffnen Sie über das Menüsymbol das Kontextmenü für den entsprechenden Datenpunkt und klicken Sie auf **Smart Rule erstellen**. <br><br> <img src="/images/benutzerhandbuch/cockpit/cockpit-smart-rules-data-point.png" name="Data point example"/>
 <br>
-5. Wählen Sie die Smart Rule "Bei Schwellwertüberschreitung Alarm erzeugen".
+5. Wählen Sie die Smart Rule "Bei Schwellenwertüberschreitung Alarm erzeugen".
 6. Geben Sie den minimalen und den maximalen Wert für den roten Bereich ein. Wenn der Messwert den roten Bereich betritt oder verlässt, wird ein KRITISCHER Alarm erzeugt bzw. gelöscht. Weitere Informationen finden Sie in der Beschreibung der Regel "Bei Messbereichsüberschreitung Alarm erzeugen" in der [Smart Rules-Sammlung](/benutzerhandbuch/cockpit-de#smart-rules-collection).
 7. Unter **Alarm erzeugen** können Sie optional den Alarmtyp und Alarmtext definieren.
 8. Unter **Ziel-Assets oder -geräte** können Sie die Objekte auswählen, auf die diese Regel angewendet werden soll.

--- a/content/benutzerhandbuch/enterprise-tenant-de-bundle/ms-data-broker.md
+++ b/content/benutzerhandbuch/enterprise-tenant-de-bundle/ms-data-broker.md
@@ -45,7 +45,7 @@ Der {{< management-tenant-de >}} kann nicht als Data-Broker-Ursprungsmandant ver
 
 #### Data Broker-Verbindungsfehler
 
-Der Data Broker-Agent ist vorkonfiguriert für die Überwachung aller Konnektoren bezüglich der Anzahl der gesendeten Weiterleitungsanfragen. Wenn diese Anzahl einen vorkonfigurierten Schwellwert erreicht, wird beim Mandanten ein KRITISCHER Alarm ausgelöst.
+Der Data Broker-Agent ist vorkonfiguriert für die Überwachung aller Konnektoren bezüglich der Anzahl der gesendeten Weiterleitungsanfragen. Wenn diese Anzahl einen vorkonfigurierten Schwellenwert erreicht, wird beim Mandanten ein KRITISCHER Alarm ausgelöst.
 Geschieht dies, werden die Daten gespeichert, bis die Verbindung wiederhergestellt ist und die Daten wieder weitergeleitet werden können.
 Zu fehlgeschlagenen Anfragen kann es kommen, wenn der den Data Broker abonnierende Mandant nicht mehr erreichbar ist.
 
@@ -55,11 +55,11 @@ Der Data Broker-Agent ist so vorkonfiguriert, dass er die Rate überwacht, mit d
 
 ##### Queue-Backlog
 
-Dieser Alarm wird ausgelöst, wenn die Latenz für die Nachrichtenübermittlung einen festgelegten Schwellwert überschreitet. Dies erfolgt in der Regel dann, wenn es aufgrund verschiedener Faktoren zu einem Rückstand an unzugestellten Ereignissen an den Zielmandanten gekommen ist.
+Dieser Alarm wird ausgelöst, wenn die Latenz für die Nachrichtenübermittlung einen festgelegten Schwellenwert überschreitet. Dies erfolgt in der Regel dann, wenn es aufgrund verschiedener Faktoren zu einem Rückstand an unzugestellten Ereignissen an den Zielmandanten gekommen ist.
 
 ##### Durchschnittlich gesendete Bytes pro Sekunde bei Anfragen
 
-Der Data Broker überwacht die Datenrate, mit der Ereignisse weitergeleitet werden. Liegt diese Rate unterhalb eines vorkonfigurierten Schwellwerts, wird ein Alarm wegen langsamer Verarbeitung ausgelöst. Hierzu kann es aufgrund eines langsamen Netzwerks kommen.
+Der Data Broker überwacht die Datenrate, mit der Ereignisse weitergeleitet werden. Liegt diese Rate unterhalb eines vorkonfigurierten Schwellenwerts, wird ein Alarm wegen langsamer Verarbeitung ausgelöst. Hierzu kann es aufgrund eines langsamen Netzwerks kommen.
 
 ![New Data-Broker Alarms](/images/benutzerhandbuch/enterprise-tenant/et-new-data-broker-alarms.png)
 


### PR DESCRIPTION
Fixed spelling of Schwellwert to Schwellenwert in all cases in the German user guide.