### PR TITLE
PAQ release note updates for 10.13

### DIFF
--- a/content/release-10-13-0/streaming-analytics-10-13-0-bundle/10_13_0.md
+++ b/content/release-10-13-0/streaming-analytics-10-13-0-bundle/10_13_0.md
@@ -6,8 +6,8 @@ layout: redirect
 
 ### Apama correlator version
 
-This release of Cumulocity IoT Streaming Analytics includes the Apama version 10.11.1 correlator.
-See also [What's New In Apama 10.11.1](https://documentation.softwareag.com/apama/v10-11/apama10-11/apama-webhelp/index.html#page/apama-webhelp%2Fco-WhaNewInApa_10111_top.html)
+This release of Cumulocity IoT Streaming Analytics includes the Apama version 10.11.2 correlator.
+See also [What's New In Apama 10.11.2](https://documentation.softwareag.com/apama/v10-11/apama10-11/apama-webhelp/index.html#page/apama-webhelp%2Fco-WhaNewInApa_10112_top.html)
 in the Apama documentation.
 
 ### Improvements for time zone support
@@ -33,18 +33,18 @@ See also [Developing apps with the Streaming Analytics application](https://cumu
 
 ### Improvements in Analytics Builder
 
-The documentation for [Analytics Builder](https://documentation.softwareag.com/apama/Analytics_Builder/pab10-12-0/apama-pab-webhelp/index.html), including release notes,
+The documentation for [Analytics Builder](https://documentation.softwareag.com/apama/Analytics_Builder/pab10-13-0/apama-pab-webhelp/index.html), including release notes,
 is available separately. For your convenience, the release notes from the above documentation are also given below:
 
-- The [Send Email](https://documentation.softwareag.com/apama/Analytics_Builder/pab10-12-0/apama-pab-webhelp/index.html#page/apamaanalyticsbuilder-webhelp%2Fre_AnaBui_block_reference_Output_Send_Email.html)
-  and [Send SMS](https://documentation.softwareag.com/apama/Analytics_Builder/pab10-12-0/apama-pab-webhelp/index.html#page/apamaanalyticsbuilder-webhelp%2Fre_AnaBui_block_reference_Output_Send_SMS.html)
+- The [Send Email](https://documentation.softwareag.com/apama/Analytics_Builder/pab10-13-0/apama-pab-webhelp/index.html#page/apamaanalyticsbuilder-webhelp%2Fre_AnaBui_block_reference_Output_Send_Email.html)
+  and [Send SMS](https://documentation.softwareag.com/apama/Analytics_Builder/pab10-13-0/apama-pab-webhelp/index.html#page/apamaanalyticsbuilder-webhelp%2Fre_AnaBui_block_reference_Output_Send_SMS.html)
   blocks can now be used in simulation and test mode.
   When running in these modes, these blocks log the output instead of sending an email or SMS.
 
   In previous versions, when using these blocks in simulation or test mode, the activation of the model failed with the following error message:
   `Model produces output for device '' not declared by any block. Make sure that device parameters of all blocks are properly tagged`.
 
-- The [Text Substitution](https://documentation.softwareag.com/apama/Analytics_Builder/pab10-12-0/apama-pab-webhelp/index.html#page/apamaanalyticsbuilder-webhelp%2Fre_AnaBui_block_reference_Utilities_TextSubstitution.html)
+- The [Text Substitution](https://documentation.softwareag.com/apama/Analytics_Builder/pab10-13-0/apama-pab-webhelp/index.html#page/apamaanalyticsbuilder-webhelp%2Fre_AnaBui_block_reference_Utilities_TextSubstitution.html)
   block now supports the new `FORMAT` parameter for specifying a different time format.
   For example, `#{time:TZ="America/New_York",FORMAT="HH:mm:ssZ"}` specifies the time zone for New York and the format to be `HH:mm:ssZ`.
   For a list of valid time format strings, see [Format specification for the TimeFormat functions](https://documentation.softwareag.com/apama/v10-11/apama10-11/apama-webhelp/index.html#page/apama-webhelp%2Fco-DevApaAppInEpl_format_specification_for_the_time_format_plug_in_functions.html) in the Apama documentation.


### PR DESCRIPTION
Changed the version number for the Apama correlator to 10.11.2 and changed the URLs to the Analytics Builder doc to 10.13.