### PR TITLE
MTM-43738 info about how OPC UA datavalue stored in events when exceeds the long range

### DIFF
--- a/content/protocol-integration/opcua-bundle/device-protocols.md
+++ b/content/protocol-integration/opcua-bundle/device-protocols.md
@@ -92,7 +92,7 @@ The value will also be populated as a fragment of the created event, under a sta
 }
 ```
 
-The node value under this static fragment that are numeric and exceed the Java Long ranges for Long.Max_VALUE(9,223,372,036,854,775,807) or Long.MIN_VALUE(-9,223,372,036,854,775,807) are converted internal to Double values with scientific notation (for example 9.223372036854778e+24) to ensure the storage in the database. This may result in a less precise rounded value. However, the node value that is populated for the value placeholder in the event text will have the actual value even it exceeds the Long range.
+The node values under this static fragment that are numeric and exceed the Java long ranges for Long.Max_VALUE(9,223,372,036,854,775,807) or Long.MIN_VALUE(-9,223,372,036,854,775,807) are converted internally to double values with scientific notation (for example 9.223372036854778e+24) to ensure the storage in the database. This may result in a less precise rounded value. However, the node value that is populated for the value placeholder in the event text will have the actual value even if it exceeds the long range.
 
 
 > **Info:** The measurements, events and alarms are added to a queue by the gateway, and they are flushed at once to create the respective elements. If the server is deleted, but there are still some items to be flushed, then the request is failed with a response code 403.

--- a/content/protocol-integration/opcua-bundle/device-protocols.md
+++ b/content/protocol-integration/opcua-bundle/device-protocols.md
@@ -91,6 +91,10 @@ The value will also be populated as a fragment of the created event, under a sta
  }
 }
 ```
+
+The node value under this static fragment that are numeric and exceed the Java Long ranges for Long.Max_VALUE(9,223,372,036,854,775,807) or Long.MIN_VALUE(-9,223,372,036,854,775,807) are converted internal to Double values with scientific notation (for example 9.223372036854778e+24) to ensure the storage in the database. This may result in a less precise rounded value. However, the node value that is populated for the value placeholder in the event text will have the actual value even it exceeds the Long range.
+
+
 > **Info:** The measurements, events and alarms are added to a queue by the gateway, and they are flushed at once to create the respective elements. If the server is deleted, but there are still some items to be flushed, then the request is failed with a response code 403.
 Thereafter, the exception is handled by validating the existence of the source. If the source is missing then the elements will be removed from the queue.
 


### PR DESCRIPTION
Added info about how OPC UA datavalue stored in events when exceeds the long range.
The info for the measurements was already there.