### PR TITLE
Feature/MTM-38615 Microservice SDK guide update

### DIFF
--- a/content/microservice-sdk/concept-bundle/manifest.md
+++ b/content/microservice-sdk/concept-bundle/manifest.md
@@ -82,7 +82,7 @@ See below for detailed information about available settings.
 <tr>
 <td style="text-align:left">apiVersion</td>
 <td style="text-align:left">String</td>
-<td style="text-align:left">Document type format discriminator. The accepted values are positive integer numbers proceeded by a "v", such as "v2".</td>
+<td style="text-align:left">Document type format discriminator. The accepted values are positive integer numbers proceeded by a "v", such as "v2". Values which do not conform to this convention are automatically considered as "v1".</td>
 <td style="text-align:left">Yes</td>
 </tr>
 <tr>

--- a/content/microservice-sdk/concept-bundle/manifest.md
+++ b/content/microservice-sdk/concept-bundle/manifest.md
@@ -82,7 +82,7 @@ See below for detailed information about available settings.
 <tr>
 <td style="text-align:left">apiVersion</td>
 <td style="text-align:left">String</td>
-<td style="text-align:left">Document type format discriminator. The accepted values are positive integer numbers proceeded by a "v", such as "v2". Values which do not conform to this convention are automatically considered as "v1".</td>
+<td style="text-align:left">Document type format discriminator. The accepted values are positive integer numbers proceeded by an optional "v", such as "v2" and "2". Values which do not conform to this convention are automatically considered as "v1".</td>
 <td style="text-align:left">Yes</td>
 </tr>
 <tr>

--- a/content/microservice-sdk/concept-bundle/manifest.md
+++ b/content/microservice-sdk/concept-bundle/manifest.md
@@ -82,7 +82,7 @@ See below for detailed information about available settings.
 <tr>
 <td style="text-align:left">apiVersion</td>
 <td style="text-align:left">String</td>
-<td style="text-align:left">Document type format discriminator. The accepted values are positive integer numbers proceeded by an optional "v", such as "v2" and "2". Values which do not conform to this convention are automatically considered as "v1".</td>
+<td style="text-align:left">Document type format discriminator. The accepted values are positive integer numbers proceeded by an optional "v", such as "v2" and "2". Values which do not conform to this convention are considered "v1".</td>
 <td style="text-align:left">Yes</td>
 </tr>
 <tr>

--- a/content/microservice-sdk/concept-bundle/manifest.md
+++ b/content/microservice-sdk/concept-bundle/manifest.md
@@ -11,7 +11,7 @@ Here is an example manifest:
 
 ```json
 {
-    "apiVersion": "v1",
+    "apiVersion": "v2",
     "name": "my-microservice",
     "version": "1.0.0",
     "provider": {
@@ -82,7 +82,7 @@ See below for detailed information about available settings.
 <tr>
 <td style="text-align:left">apiVersion</td>
 <td style="text-align:left">String</td>
-<td style="text-align:left">Document type format discriminator, for future changes in format.</td>
+<td style="text-align:left">Document type format discriminator. The accepted values are positive integer numbers proceeded by a "v", such as "v2".</td>
 <td style="text-align:left">Yes</td>
 </tr>
 <tr>

--- a/content/microservice-sdk/concept-bundle/microservice-runtime.md
+++ b/content/microservice-sdk/concept-bundle/microservice-runtime.md
@@ -42,7 +42,7 @@ $ docker images
 Run the Docker container for the microservice providing the environment variables:
 
 ```shell
-$ docker run -e C8Y_BASEURL=<URL> -e C8Y_BOOTSTRAP_TENANT=<BOOTSTRAP_TENANT> -e C8Y_BOOTSTRAP_USER=<BOOTSTRAP_USERNAME> -e C8Y_BOOTSTRAP_PASSWORD=<BOOTSTRAP_USER_PASSWORD> -e C8Y_MICROSERVICE_ISOLATION=MULTI_TENANT -i -t <DOCKER_REPOSITORY_IMAGE>:<TAG>
+$ docker run –cap-drop=all –cap-add=net_bind_service -e C8Y_BASEURL=<URL> -e C8Y_BOOTSTRAP_TENANT=<BOOTSTRAP_TENANT> -e C8Y_BOOTSTRAP_USER=<BOOTSTRAP_USERNAME> -e C8Y_BOOTSTRAP_PASSWORD=<BOOTSTRAP_USER_PASSWORD> -e C8Y_MICROSERVICE_ISOLATION=MULTI_TENANT -i -t <DOCKER_REPOSITORY_IMAGE>:<TAG>
 ```
 
 Use a backslash (\\) before special characters such as `&, !, ;, \`.

--- a/content/microservice-sdk/concept-bundle/microservice-runtime.md
+++ b/content/microservice-sdk/concept-bundle/microservice-runtime.md
@@ -42,7 +42,12 @@ $ docker images
 Run the Docker container for the microservice providing the environment variables:
 
 ```shell
-$ docker run –cap-drop=all –cap-add=net_bind_service -e C8Y_BASEURL=<URL> -e C8Y_BOOTSTRAP_TENANT=<BOOTSTRAP_TENANT> -e C8Y_BOOTSTRAP_USER=<BOOTSTRAP_USERNAME> -e C8Y_BOOTSTRAP_PASSWORD=<BOOTSTRAP_USER_PASSWORD> -e C8Y_MICROSERVICE_ISOLATION=MULTI_TENANT -i -t <DOCKER_REPOSITORY_IMAGE>:<TAG>
+$ docker run -–cap-drop=ALL -–cap-add=NET_BIND_SERVICE \ 
+   -e C8Y_BOOTSTRAP_TENANT=<BOOTSTRAP_TENANT> \
+   -e C8Y_BOOTSTRAP_USER=<BOOTSTRAP_USERNAME> \
+   -e C8Y_BOOTSTRAP_PASSWORD=<BOOTSTRAP_USER_PASSWORD> \
+   -e C8Y_MICROSERVICE_ISOLATION=MULTI_TENANT \
+   -e C8Y_BASEURL=<URL> -i -t <DOCKER_REPOSITORY_IMAGE>:<TAG>
 ```
 
 Use a backslash (\\) before special characters such as `&, !, ;, \`.

--- a/content/microservice-sdk/concept-bundle/migration.md
+++ b/content/microservice-sdk/concept-bundle/migration.md
@@ -21,25 +21,22 @@ With the apiVersion change, the microservice is granted the capability NET_BIND_
 
 Please perform the following steps to migrate your microservice to the new apiVersion. 
 
-1. Change the apiVersion to v2 in the microservice manifest. See <a href="#manifest">Microservice manifest</a>.   
+1. Change the apiVersion to 2 in the microservice manifest. See <a href="#manifest">Microservice manifest</a>.   
 
 2. Deploy your microservice to the test environment. 
 
 3. Test the functionality of your microservice and analyse possible errors.
  
-In the simplest case it is sufficient to set the apiVersion to v2 in your microservice manifest.  
+In the simplest case it is sufficient to set the apiVersion to 2 in your microservice manifest.  
 
 However, for microservices which currently make use of specific privileges of the Linux Kernel API, not granted anymore,
 you additionally need to refactor the source code so that the service doesn't require the invocation of these privileges.  
 
-For details refer to section "Microservice migration" 
-in the Microservice SDK user guide.
-
 #### How to check whether your microservice is impacted?
 
-Set the apiVersion field in the microservice manifest to "v2" and 
+Set the apiVersion field in the microservice manifest to 2 and 
 deploy this service to your Cumulocity IoT test environment. 
-This environment must be in version 10.14. 
+This environment must be in version 10.14 or higher. 
 Verify that the functionality provided by the miroservice still works as expected.
 
 #### What happens if your Cumulocity IoT microservice is still using one of these user privileges after the upgrade of the environment to the 10.15 release? 

--- a/content/microservice-sdk/concept-bundle/migration.md
+++ b/content/microservice-sdk/concept-bundle/migration.md
@@ -1,23 +1,17 @@
 ---
 weight: 50
-title: Microservice migration
+title: Microservice migration to apiVersion 2
 layout: redirect
 ---
 
-### Cumulocity IoT microservice user privilege deprecation
-
-#### Microservice apiVersion 2
-
-To comply with new security requirements, {{< company-sag >}} is announcing the availability of the microservice apiVersion 2 and is deprecating apiVersion 1.  
-
-**With release 10.14**, {{< company-sag >}} announces the availability of microservice apiVersion 2 and the deprecation of apiVersion 1.  
+**With release 10.14**, {{< company-sag >}} announces the availability of microservice apiVersion 2 and the deprecation of apiVersion 1 to comply with new security requirements.  
 Microservice apiVersion 2 provides an improved microservice container security context restricting the invocation of privileged Linux Kernel APIs.
 In details this means that with microservice apiVersion 2 the microservice container is granted only specific capabilities.
 
 Refer to the [Linux man page](https://man7.org/linux/man-pages/man7/capabilities.7.html) for more information on Kernel capabilities.
 With the apiVersion change, the microservice is granted the capability NET_BIND_SERVICE.
 
-#### Microservice migration in release 10.15
+#### Microservice migration from release 10.15
 
 Perform the following steps to migrate your microservice to the new apiVersion.
 

--- a/content/microservice-sdk/concept-bundle/migration.md
+++ b/content/microservice-sdk/concept-bundle/migration.md
@@ -1,16 +1,18 @@
 ---
-weight: 60
-title: Migration 
+weight: 50
+title: Microservice migration to API v2
 layout: redirect
 ---
 
-### Cumulocity IoT microservice user privilege deprecation 
+### Cumulocity IoT microservice user privilege deprecation
 
 #### What's happening:
 
-To comply with new security requirements Software AG is announcing the availability of the Microservice API version 2 and is deprecating the usage of version 1.
+To comply with new security requirements Software AG is announcing the availability of the Microservice API version 2 and is deprecating the usage of version 1.  
 
-#### With release 10.14, Software AG announces the availability of Microservice API version 2 and the deprecation of version 1. Microservice API version 2 provides an improved microservice container security context restricting the invocation of privileged Linux Kernel APIs. In details this means that the Microservice API version 2 does not grant the microservice container user the following privileges. 
+**With release 10.14**, Software AG announces the availability of Microservice API version 2 and the deprecation of version 1.  
+Microservice API version 2 provides an improved microservice container security context restricting the invocation of privileged Linux Kernel APIs.   
+In details this means that the Microservice API version 2 does not grant the microservice container user the following privileges.
 
 * CAP_AUDIT_CONTROL
 * CAP_AUDIT_READ
@@ -53,22 +55,31 @@ To comply with new security requirements Software AG is announcing the availabil
 * CAP_SYSLOG
 * CAP_WAKE_ALARM
 
+Please refer to the   
+[Linux man page](https://man7.org/linux/man-pages/ma7/capabilities.7.html) 
+for more information.
 
-Please refer to the [Linux man page](https://man7.org/linux/man-pages/ma7/capabilities.7.html) for more information.
+#### What you need to do by XX.YY.ZZ?
 
-#### What you need to do by XX.YY.ZZZZ:
+Migrate your microservice to the new API version 2.  
 
-Migrate your microservice to the new API version 2.
+In the simplest case it is sufficient to set the API version 2 in your microservice manifest.  
 
-In the simplest case it is sufficient to set the API version 2 in your microservice manifest. 
+However, for microservices which currently make use of Linux Kernel API which requires one of the above-mentioned user privileges   
+you additionally need to refactor the source code so that the service doesn't require the invocation of these privileged Linux Kernel APIs anymore.  
 
-However, for microservices which currently make use of Linux Kernel API which requires one of the above-mentioned user privileges you additionally need to refactor the source code so that the service doesn't require the invocation of these privileged Linux Kernel APIs anymore.
-
-For details refer to section "Migration of Microservices to API version 2" in the Microservice SDK user guide.
+For details refer to section "Migration of Microservices to API version 2" 
+in the Microservice SDK user guide.
 
 #### How to check whether your microservice is impacted?
 
-Set the API version field in the microservice manifest to "2" and deploy this service to your Cumulocity IoT test environment. This environment must be in version 10.14. Verify that the functionality provided by the miroservice still works as expected. 
+Set the API version field in the microservice manifest to "2" and 
+deploy this service to your Cumulocity IoT test environment. 
+This environment must be in version 10.14. 
+Verify that the functionality provided by the miroservice still works as expected.
 
-#### What happens if your Cumulocity IoT microservice is still using one of these user privileges after the upgrade of the environment to the 10.15 release:
-If your microservice is using the deprecated API version 1 and is deployed to a Cumulocity IoT environment in version 10.15 or higher it might, depending on the configuration of this environment, no longer work. 
+#### What happens if your Cumulocity IoT microservice is still using one of these user privileges after the upgrade of the environment to the 10.15 release? 
+
+If your microservice is using the deprecated API version 1 and 
+is deployed to a Cumulocity IoT environment in version 10.15 or higher it might, 
+depending on the configuration of this environment, no longer work.

--- a/content/microservice-sdk/concept-bundle/migration.md
+++ b/content/microservice-sdk/concept-bundle/migration.md
@@ -1,0 +1,74 @@
+---
+weight: 60
+title: Migration 
+layout: redirect
+---
+
+### Cumulocity IoT microservice user privilege deprecation 
+
+#### What's happening:
+
+To comply with new security requirements Software AG is announcing the availability of the Microservice API version 2 and is deprecating the usage of version 1.
+
+#### With release 10.14, Software AG announces the availability of Microservice API version 2 and the deprecation of version 1. Microservice API version 2 provides an improved microservice container security context restricting the invocation of privileged Linux Kernel APIs. In details this means that the Microservice API version 2 does not grant the microservice container user the following privileges. 
+
+* CAP_AUDIT_CONTROL
+* CAP_AUDIT_READ
+* CAP_AUDIT_WRITE
+* CAP_BLOCK_SUSPEND
+* CAP_BPF
+* CAP_CHECKPOINT_RESTORE
+* CAP_CHOWN
+* CAP_DAC_OVERRIDE
+* CAP_DAC_READ_SEARCH
+* CAP_FOWNER
+* CAP_FSETID
+* CAP_IPC_LOCK
+* CAP_IPC_OWNER
+* CAP_KILL
+* CAP_LEASE
+* CAP_LINUX_IMMUTABLE
+* CAP_MAC_ADMIN
+* CAP_MAC_OVERRIDE
+* CAP_MKNOD
+* CAP_NET_ADMIN
+* CAP_NET_BROADCAST
+* CAP_NET_RAW
+* CAP_PERFMON
+* CAP_SETGID
+* CAP_SETFCAP
+* CAP_SETPCAP
+* CAP_SETUID
+* CAP_SYS_ADMIN
+* CAP_SYS_BOOT
+* CAP_SYS_CHROOT
+* CAP_SYS_MODULE
+* CAP_SYS_NICE
+* CAP_SYS_PACCT
+* CAP_SYS_PTRACE
+* CAP_SYS_RAWIO
+* CAP_SYS_RESOURCE
+* CAP_SYS_TIME
+* CAP_SYS_TTY_CONFIG
+* CAP_SYSLOG
+* CAP_WAKE_ALARM
+
+
+Please refer to the [Linux man page](https://man7.org/linux/man-pages/ma7/capabilities.7.html) for more information.
+
+#### What you need to do by XX.YY.ZZZZ:
+
+Migrate your microservice to the new API version 2.
+
+In the simplest case it is sufficient to set the API version 2 in your microservice manifest. 
+
+However, for microservices which currently make use of Linux Kernel API which requires one of the above-mentioned user privileges you additionally need to refactor the source code so that the service doesn't require the invocation of these privileged Linux Kernel APIs anymore.
+
+For details refer to section "Migration of Microservices to API version 2" in the Microservice SDK user guide.
+
+#### How to check whether your microservice is impacted?
+
+Set the API version field in the microservice manifest to "2" and deploy this service to your Cumulocity IoT test environment. This environment must be in version 10.14. Verify that the functionality provided by the miroservice still works as expected. 
+
+#### What happens if your Cumulocity IoT microservice is still using one of these user privileges after the upgrade of the environment to the 10.15 release:
+If your microservice is using the deprecated API version 1 and is deployed to a Cumulocity IoT environment in version 10.15 or higher it might, depending on the configuration of this environment, no longer work. 

--- a/content/microservice-sdk/concept-bundle/migration.md
+++ b/content/microservice-sdk/concept-bundle/migration.md
@@ -87,4 +87,5 @@ Verify that the functionality provided by the miroservice still works as expecte
 
 If your microservice is using the deprecated apiVersion 1 and 
 is deployed to a Cumulocity IoT environment in version 10.15 or higher, it might, 
-depending on the configuration of this environment, no longer work.
+depending on the configuration of this environment, be affected by the change. 
+In such a case, you will not be able to upload or subscribe the microservice.

--- a/content/microservice-sdk/concept-bundle/migration.md
+++ b/content/microservice-sdk/concept-bundle/migration.md
@@ -29,8 +29,8 @@ Please perform the following steps to migrate your microservice to the new apiVe
  
 In the simplest case it is sufficient to set the apiVersion to v2 in your microservice manifest.  
 
-However, for microservices which currently make use of Linux Kernel API which requires one of the above-mentioned user privileges,   
-you additionally need to refactor the source code so that the service doesn't require the invocation of these privileged Linux Kernel APIs anymore.  
+However, for microservices which currently make use of specific privileges of the Linux Kernel API, which are not granted anymore,
+you additionally need to refactor the source code so that the service doesn't require the invocation of these privileges.  
 
 For details refer to section "Microservice migration" 
 in the Microservice SDK user guide.

--- a/content/microservice-sdk/concept-bundle/migration.md
+++ b/content/microservice-sdk/concept-bundle/migration.md
@@ -6,42 +6,39 @@ layout: redirect
 
 ### Cumulocity IoT microservice user privilege deprecation
 
-#### What's happening:
+#### Microservice apiVersion 2
 
-To comply with new security requirements, Software AG is announcing the availability of the Microservice apiVersion 2 and is deprecating apiVersion 1.  
+To comply with new security requirements, {{< company-sag >}} is announcing the availability of the microservice apiVersion 2 and is deprecating apiVersion 1.  
 
-**With release 10.14**, Software AG announces the availability of Microservice apiVersion 2 and the deprecation of apiVersion 1.  
+**With release 10.14**, {{< company-sag >}} announces the availability of microservice apiVersion 2 and the deprecation of apiVersion 1.  
 Microservice apiVersion 2 provides an improved microservice container security context restricting the invocation of privileged Linux Kernel APIs.
-In details this means that with microservice apiVersion 2 the microservice container is granted only specific capabilities. 
+In details this means that with microservice apiVersion 2 the microservice container is granted only specific capabilities.
 
 Refer to the [Linux man page](https://man7.org/linux/man-pages/man7/capabilities.7.html) for more information on Kernel capabilities.
 With the apiVersion change, the microservice is granted the capability NET_BIND_SERVICE.
 
-#### What you need to do by release 10.15:
+#### Microservice migration in release 10.15
 
-Perform the following steps to migrate your microservice to the new apiVersion. 
+Perform the following steps to migrate your microservice to the new apiVersion.
 
-1. Change the apiVersion to 2 in the microservice manifest. See <a href="#manifest">Microservice manifest</a>.   
+1. Change the apiVersion to 2 in the microservice manifest. See [Microservice manifest](#manifest).   
 
-2. Deploy your microservice to the test environment. 
+2. Deploy your microservice to the test environment.
 
-3. Test the functionality of your microservice and analyse possible errors.
- 
+3. Test the functionality of your microservice and analyze possible errors.
+
 In the simplest case it is sufficient to set the apiVersion to 2 in your microservice manifest.  
 
-However, for microservices which currently make use of specific privileges of the Linux Kernel API, not granted anymore,
-you additionally need to refactor the source code so that the service doesn't require the invocation of these privileges.  
+However, for microservices which currently make use of specific privileges of the Linux Kernel API that are not granted anymore, you additionally need to refactor the source code so that the service doesn't require the invocation of these privileges.  
 
-#### How to check whether your microservice is impacted?
+#### Affected microservices
 
-Set the apiVersion field in the microservice manifest to 2 and 
-deploy this service to your Cumulocity IoT test environment. 
-This environment must be in version 10.14 or higher. 
+Set the apiVersion field in the microservice manifest to 2 and deploy this service to your {{< company-c8y >}} test environment.
+This environment must be in version 10.14 or higher.
 Verify that the functionality provided by the miroservice still works as expected.
 
-#### What happens if your Cumulocity IoT microservice is still using one of these user privileges after the upgrade of the environment to the 10.15 release? 
+#### Microservices still using old user privileges after the environment upgrade
 
-If your microservice is using the deprecated apiVersion 1 and 
-is deployed to a Cumulocity IoT environment in version 10.15 or higher, it might, 
-depending on the configuration of this environment, be affected by the change. 
-In such a case, you will not be able to upload or subscribe the microservice.
+If your microservice is using the deprecated apiVersion 1 and
+is deployed to a {{< company-c8y >}} environment in version 10.15 or higher, it may be affected by the change, depending on the configuration of this environment.
+In this case, you will not be able to upload or subscribe the microservice.

--- a/content/microservice-sdk/concept-bundle/migration.md
+++ b/content/microservice-sdk/concept-bundle/migration.md
@@ -29,7 +29,7 @@ Please perform the following steps to migrate your microservice to the new apiVe
  
 In the simplest case it is sufficient to set the apiVersion to v2 in your microservice manifest.  
 
-However, for microservices which currently make use of specific privileges of the Linux Kernel API, which are not granted anymore,
+However, for microservices which currently make use of specific privileges of the Linux Kernel API, not granted anymore,
 you additionally need to refactor the source code so that the service doesn't require the invocation of these privileges.  
 
 For details refer to section "Microservice migration" 

--- a/content/microservice-sdk/concept-bundle/migration.md
+++ b/content/microservice-sdk/concept-bundle/migration.md
@@ -1,6 +1,6 @@
 ---
 weight: 50
-title: Microservice migration to API v2
+title: Microservice migration
 layout: redirect
 ---
 
@@ -8,11 +8,11 @@ layout: redirect
 
 #### What's happening:
 
-To comply with new security requirements Software AG is announcing the availability of the Microservice API version 2 and is deprecating the usage of version 1.  
+To comply with new security requirements, Software AG is announcing the availability of the Microservice apiVersion 2 and is deprecating apiVersion 1.  
 
-**With release 10.14**, Software AG announces the availability of Microservice API version 2 and the deprecation of version 1.  
-Microservice API version 2 provides an improved microservice container security context restricting the invocation of privileged Linux Kernel APIs.   
-In details this means that the Microservice API version 2 does not grant the microservice container user the following privileges.
+**With release 10.14**, Software AG announces the availability of Microservice apiVersion 2 and the deprecation of apiVersion 1.  
+Microservice apiVersion 2 provides an improved microservice container security context restricting the invocation of privileged Linux Kernel APIs.
+In details this means that the Microservice apiVersion 2 does not grant the microservice container user the following privileges.
 
 * CAP_AUDIT_CONTROL
 * CAP_AUDIT_READ
@@ -55,31 +55,36 @@ In details this means that the Microservice API version 2 does not grant the mic
 * CAP_SYSLOG
 * CAP_WAKE_ALARM
 
-Please refer to the   
-[Linux man page](https://man7.org/linux/man-pages/ma7/capabilities.7.html) 
+Please refer to the [Linux man page](https://man7.org/linux/man-pages/man7/capabilities.7.html) 
 for more information.
 
-#### What you need to do by XX.YY.ZZ?
+#### What you need to do by 25.10.2022:
 
-Migrate your microservice to the new API version 2.  
+Please perform the following steps to migrate your microservice to the new apiVersion. 
 
-In the simplest case it is sufficient to set the API version 2 in your microservice manifest.  
+1. Change the apiVersion to v2 in the microservice manifest. See <a href="#manifest">Microservice manifest</a>.   
 
-However, for microservices which currently make use of Linux Kernel API which requires one of the above-mentioned user privileges   
+2. Deploy your microservice to the test environment. 
+
+3. Test the functionality of your microservice and analyse possible errors.
+ 
+In the simplest case it is sufficient to set the apiVersion to v2 in your microservice manifest.  
+
+However, for microservices which currently make use of Linux Kernel API which requires one of the above-mentioned user privileges,   
 you additionally need to refactor the source code so that the service doesn't require the invocation of these privileged Linux Kernel APIs anymore.  
 
-For details refer to section "Migration of Microservices to API version 2" 
+For details refer to section "Microservice migration" 
 in the Microservice SDK user guide.
 
 #### How to check whether your microservice is impacted?
 
-Set the API version field in the microservice manifest to "2" and 
+Set the apiVersion field in the microservice manifest to "v2" and 
 deploy this service to your Cumulocity IoT test environment. 
 This environment must be in version 10.14. 
 Verify that the functionality provided by the miroservice still works as expected.
 
 #### What happens if your Cumulocity IoT microservice is still using one of these user privileges after the upgrade of the environment to the 10.15 release? 
 
-If your microservice is using the deprecated API version 1 and 
-is deployed to a Cumulocity IoT environment in version 10.15 or higher it might, 
+If your microservice is using the deprecated apiVersion 1 and 
+is deployed to a Cumulocity IoT environment in version 10.15 or higher, it might, 
 depending on the configuration of this environment, no longer work.

--- a/content/microservice-sdk/concept-bundle/migration.md
+++ b/content/microservice-sdk/concept-bundle/migration.md
@@ -12,53 +12,12 @@ To comply with new security requirements, Software AG is announcing the availabi
 
 **With release 10.14**, Software AG announces the availability of Microservice apiVersion 2 and the deprecation of apiVersion 1.  
 Microservice apiVersion 2 provides an improved microservice container security context restricting the invocation of privileged Linux Kernel APIs.
-In details this means that the Microservice apiVersion 2 does not grant the microservice container user the following privileges.
+In details this means that with microservice apiVersion 2 the microservice container is granted only specific capabilities. 
 
-* CAP_AUDIT_CONTROL
-* CAP_AUDIT_READ
-* CAP_AUDIT_WRITE
-* CAP_BLOCK_SUSPEND
-* CAP_BPF
-* CAP_CHECKPOINT_RESTORE
-* CAP_CHOWN
-* CAP_DAC_OVERRIDE
-* CAP_DAC_READ_SEARCH
-* CAP_FOWNER
-* CAP_FSETID
-* CAP_IPC_LOCK
-* CAP_IPC_OWNER
-* CAP_KILL
-* CAP_LEASE
-* CAP_LINUX_IMMUTABLE
-* CAP_MAC_ADMIN
-* CAP_MAC_OVERRIDE
-* CAP_MKNOD
-* CAP_NET_ADMIN
-* CAP_NET_BROADCAST
-* CAP_NET_RAW
-* CAP_PERFMON
-* CAP_SETGID
-* CAP_SETFCAP
-* CAP_SETPCAP
-* CAP_SETUID
-* CAP_SYS_ADMIN
-* CAP_SYS_BOOT
-* CAP_SYS_CHROOT
-* CAP_SYS_MODULE
-* CAP_SYS_NICE
-* CAP_SYS_PACCT
-* CAP_SYS_PTRACE
-* CAP_SYS_RAWIO
-* CAP_SYS_RESOURCE
-* CAP_SYS_TIME
-* CAP_SYS_TTY_CONFIG
-* CAP_SYSLOG
-* CAP_WAKE_ALARM
+Please refer to the [Linux man page](https://man7.org/linux/man-pages/man7/capabilities.7.html) for more information on Kernel capabilities.
+With the apiVersion change, the microservice is granted the capability NET_BIND_SERVICE.
 
-Please refer to the [Linux man page](https://man7.org/linux/man-pages/man7/capabilities.7.html) 
-for more information.
-
-#### What you need to do by 25.10.2022:
+#### What you need to do by release 10.15:
 
 Please perform the following steps to migrate your microservice to the new apiVersion. 
 

--- a/content/microservice-sdk/concept-bundle/migration.md
+++ b/content/microservice-sdk/concept-bundle/migration.md
@@ -1,38 +1,38 @@
 ---
 weight: 50
-title: Microservice migration to apiVersion 2
+title: Microservice migration to API Version 2
 layout: redirect
 ---
 
-**With release 10.14**, {{< company-sag >}} announces the availability of microservice apiVersion 2 and the deprecation of apiVersion 1 to comply with new security requirements.  
-Microservice apiVersion 2 provides an improved microservice container security context restricting the invocation of privileged Linux Kernel APIs.
-In details this means that with microservice apiVersion 2 the microservice container is granted only specific capabilities.
+**With release 10.14**, {{< company-sag >}} announces the availability of microservice API Version 2 and the deprecation of API Version 1 to comply with new security requirements.  
+Microservice API Version 2 provides an improved microservice container security context restricting the invocation of privileged Linux Kernel APIs.
+In details this means that with microservice API Version 2 the microservice container is granted only specific capabilities.
 
 Refer to the [Linux man page](https://man7.org/linux/man-pages/man7/capabilities.7.html) for more information on Kernel capabilities.
-With the apiVersion change, the microservice is granted the capability NET_BIND_SERVICE.
+With the API Version change, the microservice is granted the capability NET_BIND_SERVICE.
 
 #### Microservice migration from release 10.15
 
-Perform the following steps to migrate your microservice to the new apiVersion.
+Perform the following steps to migrate your microservice to the new API Version.
 
-1. Change the apiVersion to 2 in the microservice manifest. See [Microservice manifest](#manifest).   
+1. Change the API Version to 2 in the microservice manifest. See [Microservice manifest](#manifest).   
 
 2. Deploy your microservice to the test environment.
 
 3. Test the functionality of your microservice and analyze possible errors.
 
-In the simplest case it is sufficient to set the apiVersion to 2 in your microservice manifest.  
+In the simplest case it is sufficient to set the API Version to 2 in your microservice manifest.  
 
 However, for microservices which currently make use of specific privileges of the Linux Kernel API that are not granted anymore, you additionally need to refactor the source code so that the service doesn't require the invocation of these privileges.  
 
 #### Affected microservices
 
-Set the apiVersion field in the microservice manifest to 2 and deploy this service to your {{< company-c8y >}} test environment.
+Set the API Version field in the microservice manifest to 2 and deploy this service to your {{< company-c8y >}} test environment.
 This environment must be in version 10.14 or higher.
 Verify that the functionality provided by the miroservice still works as expected.
 
 #### Microservices still using old user privileges after the environment upgrade
 
-If your microservice is using the deprecated apiVersion 1 and
+If your microservice is using the deprecated API Version 1 and
 is deployed to a {{< company-c8y >}} environment in version 10.15 or higher, it may be affected by the change, depending on the configuration of this environment.
 In this case, you will not be able to upload or subscribe the microservice.

--- a/content/microservice-sdk/concept-bundle/migration.md
+++ b/content/microservice-sdk/concept-bundle/migration.md
@@ -14,12 +14,12 @@ To comply with new security requirements, Software AG is announcing the availabi
 Microservice apiVersion 2 provides an improved microservice container security context restricting the invocation of privileged Linux Kernel APIs.
 In details this means that with microservice apiVersion 2 the microservice container is granted only specific capabilities. 
 
-Please refer to the [Linux man page](https://man7.org/linux/man-pages/man7/capabilities.7.html) for more information on Kernel capabilities.
+Refer to the [Linux man page](https://man7.org/linux/man-pages/man7/capabilities.7.html) for more information on Kernel capabilities.
 With the apiVersion change, the microservice is granted the capability NET_BIND_SERVICE.
 
 #### What you need to do by release 10.15:
 
-Please perform the following steps to migrate your microservice to the new apiVersion. 
+Perform the following steps to migrate your microservice to the new apiVersion. 
 
 1. Change the apiVersion to 2 in the microservice manifest. See <a href="#manifest">Microservice manifest</a>.   
 

--- a/content/microservice-sdk/concept-bundle/migration.md
+++ b/content/microservice-sdk/concept-bundle/migration.md
@@ -8,7 +8,7 @@ layout: redirect
 Microservice API Version 2 provides an improved microservice container security context restricting the invocation of privileged Linux Kernel APIs.
 In details this means that with microservice API Version 2 the microservice container is granted only specific capabilities.
 
-Refer to the [Linux man page](https://man7.org/linux/man-pages/man7/capabilities.7.html) for more information on Kernel capabilities.
+Refer to the [Linux manual page](https://man7.org/linux/man-pages/man7/capabilities.7.html) for more information on Kernel capabilities.
 With the API Version change, the microservice is granted the capability NET_BIND_SERVICE.
 
 #### Microservice migration from release 10.15


### PR DESCRIPTION
This pull request adds a subsection to the documentation on the microservice migration from apiVersion 1 to apiVersion 2 which is required to restricting the granted microservice privileges.  
For more information, please refer to https://cumulocity.atlassian.net/browse/MTM-38615

Announcement task: https://cumulocity.atlassian.net/browse/MTM-42449