### PR TITLE
Esper-to-Apama migration: null values for measurements are no longer supported

### DIFF
--- a/content/apama/overview-analytics-bundle/migrate-from-esper.md
+++ b/content/apama/overview-analytics-bundle/migrate-from-esper.md
@@ -68,6 +68,7 @@ Migrating from custom rules written in CEL to Apama EPL requires rewriting and r
 2. Make available a new tenant on which Apama has been enabled.
 3. Manually convert all old custom rules from the existing tenant into equivalent Apama EPL apps on the new tenant. Refer to the rest of this guide, in particular [Best practices and guidelines](/apama/best-practices/). This includes smart rules where the CEL has been modified.
 4. Test the behavior of the new EPL apps by sending, for example, measurements or events into the new tenant and verifying that the new EPL apps respond appropriately.
+    > **Important:** CEL allowed measurements with null values. This is no longer supported. Therefore, you must make sure that all of your measurements send numeric values. 
 5. When all new EPL apps have been developed and tested, move your production tenant from CEP to Apama, that is: subscribe the new tenant to the Apama-ctrl microservice (and unsubscribe it from CEP). 
 	* Any unmodified smart rules will migrate automatically. 
 	* Delete any smart rules where the CEL version had been modified and a new EPL app has been implemented. 


### PR DESCRIPTION
Please also cherry-pick this into all supported previous versions.