### PR TITLE
MTM-44931 add information about constraint, that tenant options…

### DIFF
--- a/content/users-guide/enterprise-tenant-bundle/managing-tenants.md
+++ b/content/users-guide/enterprise-tenant-bundle/managing-tenants.md
@@ -279,6 +279,8 @@ Creating a tenant policy with a specific set of options and rules saves time whe
 
 >**Info:** The options and rules are copied into the tenant. Editing the policy has no effect on tenants that have already been created.
 
+>**Info:** Tenant options specified in tenant policy are **not encrypted**. You should not specify or overwrite here tenant options with "credentials." prefix, since system expects those options to be encrypted with data that will appear after the tenant is created.
+
 #### To view tenant policies
 
 Click **Tenant policies** in the **Tenants** menu to view all available tenant policies.

--- a/content/users-guide/enterprise-tenant-bundle/managing-tenants.md
+++ b/content/users-guide/enterprise-tenant-bundle/managing-tenants.md
@@ -279,7 +279,7 @@ Creating a tenant policy with a specific set of options and rules saves time whe
 
 >**Info:** The options and rules are copied into the tenant. Editing the policy has no effect on tenants that have already been created.
 
->**Info:** Tenant options specified in tenant policy are **not encrypted**. You should not specify or overwrite here tenant options with "credentials." prefix, since system expects those options to be encrypted with data that will appear after the tenant is created.
+>**Important:** Tenant options specified in a tenant policy are **not encrypted**. You should not specify or overwrite tenant options here with a "credentials." prefix, since the platform expects those options to be encrypted with data that will appear after the tenant has been created.
 
 #### To view tenant policies
 


### PR DESCRIPTION
… created via policies are not encrypted, even "credentials" options

This PR may be backported as far as we support documentation, since described feature was always working like this.