### PR TITLE
[MTM-45518] Device availability added missing description:

### DIFF
--- a/content/reference/device-management-library-bundle/device-availability.md
+++ b/content/reference/device-management-library-bundle/device-availability.md
@@ -55,35 +55,34 @@ The static template 117 is provided to set the required availability for SmartRE
 
 The response interval set in the ```c8y_RequiredAvailability``` fragment is used as interval in which the platform expects to receive data from the device. If no data is received in this interval the device will be marked as offline and an alarm of type ```c8y_UnavailabilityAlarm``` will be raised automatically. This alarm will also be cleared automatically when the device sends data again. No further action from the device is necessary.
 
-The availability information computed by {{< product-c8y-iot >}} is stored in the fragments "c8y\_Availability" and "c8y\_Connection" of the device.
+The availability information computed by {{< product-c8y-iot >}} is stored in the fragments `c8y_Availability` and `c8y_Connection` of the device.
 
     "c8y_Availability": { "lastMessage": "2022-05-21...", "status": "AVAILABLE" },
     "c8y_Connection": {"status":"CONNECTED"}
 
 |Name|Type|Description|
 |:---|:---|:----------|
-|lastMessage|Date|The time when the device sent the last message to {{< product-c8y-iot >}}.|
+|lastMessage|Date|The date and time when the device sent the last message to {{< product-c8y-iot >}}.|
 |status|String|The current status, one of AVAILABLE, UNAVAILABLE, MAINTENANCE.|
 
 
-The following requests are considered a device's heartbeat and will mark the device as available and update the last message timestamp of a device ,
-as long as the `X-Cumulocity-Application-Key` header is not set:
- * Creation an event, measurement or alarm (for given device as source)
- * Updates the device itself (with given id) sending empty PUT request or request with id only, ie. {} or {“id”:…}
+The following requests are considered a device's heartbeat and will mark the device as available and update the last message timestamp of a device,as long as the `X-Cumulocity-Application-Key` header is not set:
 
-> **Info:** Keep in mind that after updating the last message it may take some minutes until the new status has been saved in a database.
+ * Creation of an event, measurement or alarm (for given device as source)
+ * Updates to the device itself (with a given ID), in the form of empty PUT requests or requests with an ID only, that is `{}` or `{"id": ... }`
+
+>**Info:** Keep in mind that after updating the last message it may take some minutes until the new status has been saved in a database.
 
 ### Connection monitoring
 
 {{< product-c8y-iot >}} also provides connection monitoring for devices. When the device establishes a connection where it is able to receive operations the platform considers this device as connected. This applies to HTTP longpolling connection or a MQTT session equally.
 
-A monitored device has one of the following statuses for c8y_Connection:
+A monitored device has one of the following statuses for `c8y_Connection`:
 
 |Name| Description                                                                            |
 |:---|:---------------------------------------------------------------------------------------|
 |CONNECTED| A device push connection is established.                                               |
-|DISCONNECTED| "responseInterval" is larger than 0 and the device is neither AVAILABLE nor CONNECTED. |
-|MAINTENANCE| "responseInterval" is smaller or equal to 0; the device is under maintenance.          |
+|DISCONNECTED| `responseInterval` is larger than 0 and the device is neither AVAILABLE nor CONNECTED. |
+|MAINTENANCE| `responseInterval` is smaller or equal to 0; the device is under maintenance.          |
 
->**Info:** If a device is not connected via device push, but a message was sent within the required response interval, c8y_Availability can still have the status AVAILABLE, even if c8y_Connection does not have the status CONNECTED.
-
+>**Info:** If a device is not connected via device push, but a message was sent within the required response interval, `c8y_Availability` can still have the status AVAILABLE, even if `c8y_Connection` does not have the status CONNECTED.

--- a/content/reference/device-management-library-bundle/device-availability.md
+++ b/content/reference/device-management-library-bundle/device-availability.md
@@ -55,10 +55,35 @@ The static template 117 is provided to set the required availability for SmartRE
 
 The response interval set in the ```c8y_RequiredAvailability``` fragment is used as interval in which the platform expects to receive data from the device. If no data is received in this interval the device will be marked as offline and an alarm of type ```c8y_UnavailabilityAlarm``` will be raised automatically. This alarm will also be cleared automatically when the device sends data again. No further action from the device is necessary.
 
-The following requests are considered a device's heartbeat and will mark the device as available:
- * Creation of measurements, events, and alarms as long as the `X-Cumulocity-Application-Key` header is not set.
- * Empty managed object updates.
+The availability information computed by {{< product-c8y-iot >}} is stored in the fragments "c8y\_Availability" and "c8y\_Connection" of the device.
+
+    "c8y_Availability": { "lastMessage": "2022-05-21...", "status": "AVAILABLE" },
+    "c8y_Connection": {"status":"CONNECTED"}
+
+|Name|Type|Description|
+|:---|:---|:----------|
+|lastMessage|Date|The time when the device sent the last message to {{< product-c8y-iot >}}.|
+|status|String|The current status, one of AVAILABLE, UNAVAILABLE, MAINTENANCE.|
+
+
+The following requests are considered a device's heartbeat and will mark the device as available and update the last message timestamp of a device ,
+as long as the `X-Cumulocity-Application-Key` header is not set:
+ * Creation an event, measurement or alarm (for given device as source)
+ * Updates the device itself (with given id) sending empty PUT request or request with id only, ie. {} or {“id”:…}
+
+> **Info:** Keep in mind that after updating the last message it may take some minutes until the new status has been saved in a database.
 
 ### Connection monitoring
 
 {{< product-c8y-iot >}} also provides connection monitoring for devices. When the device establishes a connection where it is able to receive operations the platform considers this device as connected. This applies to HTTP longpolling connection or a MQTT session equally.
+
+A monitored device has one of the following statuses for c8y_Connection:
+
+|Name| Description                                                                            |
+|:---|:---------------------------------------------------------------------------------------|
+|CONNECTED| A device push connection is established.                                               |
+|DISCONNECTED| "responseInterval" is larger than 0 and the device is neither AVAILABLE nor CONNECTED. |
+|MAINTENANCE| "responseInterval" is smaller or equal to 0; the device is under maintenance.          |
+
+>**Info:** If a device is not connected via device push, but a message was sent within the required response interval, c8y_Availability can still have the status AVAILABLE, even if c8y_Connection does not have the status CONNECTED.
+


### PR DESCRIPTION
- ping request with application header will not update lastMessage
- added missing(removed before) how c8y store availability
- added missing(removed before) information that updating last message in database is done with delay
- added missing(removed before) list available Connection status
- added missing(removed before) information that device can be disconnected even sending within required interval