### PR TITLE
MTM-46599 Clarify that feature-broker is required (#487)

### DIFF
--- a/content/users-guide/enterprise-tenant-bundle/ms-data-broker.md
+++ b/content/users-guide/enterprise-tenant-bundle/ms-data-broker.md
@@ -16,7 +16,9 @@ At this time the {{< product-c8y-iot >}} Messaging Service and the microservice-
 ###  To enable the microservice-based data broker
 
 1. In the {{< management-tenant >}}, navigate to **Administration** > **Tenants** > **Subtenants**, and select the tenant that will serve as the source of the data connector.
-2. In the **Applications** tab, subscribe the tenant to the data broker agent (databroker-agent-server).
+2. In the **Applications** tab:
+    * Subscribe the tenant to the data broker feature (`feature-broker` application), if it is not already subscribed.
+    * Subscribe the tenant to the data broker agent (`databroker-agent-server` application).
 
 ![Databroker-Agent-Server](/images/users-guide/enterprise-tenant/et-new-data-broker-agent.png)
 


### PR DESCRIPTION
Make it very clear that both `feature-broker` and `databroker-agent-server` are required on any tenant that will use the microservice-based data broker.  This is a graft of #487.

Note that I only included the reviewers who approved the first PR.