### PR TITLE
Bug/mtm 46743/adding a missing parameter inherit from owner to the documentation

### DIFF
--- a/content/microservice-sdk/concept-bundle/manifest.md
+++ b/content/microservice-sdk/concept-bundle/manifest.md
@@ -231,6 +231,7 @@ The snapshot postfix means that the image build is a snapshot of your applicatio
 |defaultValue|String|Default value|Yes
 |editable|Boolean|Defines if the option can be changed by a subscribed tenant on runtime <br>Default: false |No
 |overwriteOnUpdate|Boolean|Defines if an editable option is reset upon microservice update <br>Default: true |No
+|inheritFromOwner|Boolean|Specifies if an option should be inherited from the owner <br>Default: true |No
 #### Probe
 
 |Name|Type|Description|Required|

--- a/content/microservice-sdk/concept-bundle/manifest.md
+++ b/content/microservice-sdk/concept-bundle/manifest.md
@@ -229,6 +229,7 @@ The snapshot postfix means that the image build is a snapshot of your applicatio
 |:---|:---|:----------|:----------|
 |key|String |Key of the option|Yes
 |defaultValue|String|Default value|Yes
+|overwriteOnUpdate|Boolean|Defines if the option is reset upon microservice update <br>Default: true |No
 |editable|Boolean|Defines if the option can be changed by a subscribed tenant on runtime <br>Default: false |No
 
 #### Probe

--- a/content/microservice-sdk/concept-bundle/manifest.md
+++ b/content/microservice-sdk/concept-bundle/manifest.md
@@ -229,9 +229,8 @@ The snapshot postfix means that the image build is a snapshot of your applicatio
 |:---|:---|:----------|:----------|
 |key|String |Key of the option|Yes
 |defaultValue|String|Default value|Yes
-|overwriteOnUpdate|Boolean|Defines if the option is reset upon microservice update <br>Default: true |No
 |editable|Boolean|Defines if the option can be changed by a subscribed tenant on runtime <br>Default: false |No
-
+|overwriteOnUpdate|Boolean|Defines if an editable option is reset upon microservice update <br>Default: true |No
 #### Probe
 
 |Name|Type|Description|Required|


### PR DESCRIPTION
This pull request addresses https://cumulocity.atlassian.net/browse/MTM-46743
A customer options parameter inheritFromOwner has not been documented, as it was introduced in the core code.