### PR TITLE
PAB-3268: Rename Starter and more

### DIFF
--- a/content/apama/advanced-bundle/control-access.md
+++ b/content/apama/advanced-bundle/control-access.md
@@ -12,9 +12,9 @@ Which pages are available also depends on the variant of the Apama-ctrl microser
 
 - If the microservice is not running, an error message is shown indicating that the microservice cannot be accessed,
 and only a card with information about smart rules is shown.
-- If the Apama Starter microservice is running, the EPL Apps card is not shown (and cannot be enabled)
-as the EPL apps functionality is not available in Apama Starter.
-- If the Apama Smart Rules-only microservice is running, neither the EPL Apps card nor the Analytics Builder card is shown (and cannot be enabled).
+- If the Apama-ctrl-starter microservice is running, the EPL Apps card is not shown (and cannot be enabled)
+as the EPL apps functionality is not available in Apama-ctrl-starter.
+- If the Apama-ctrl-smartrules microservice is running, neither the EPL Apps card nor the Analytics Builder card is shown (and cannot be enabled).
 In this case, only the card with information about the smart rules is shown.
 - For other variants of the Apama-ctrl microservice, both the Analytics Builder and EPL Apps cards are shown by default.
 

--- a/content/apama/advanced-bundle/control-access.md
+++ b/content/apama/advanced-bundle/control-access.md
@@ -4,7 +4,7 @@ title: Controlling access to the Streaming Analytics application
 layout: redirect
 ---
 
-By default, the Streaming Analytics application gives you access to the Analytics Builder and EPL Apps pages.
+By default, the Streaming Analytics application gives you access to the **Analytics Builder** and **EPL Apps** pages.
 Administrators may wish to control which of these are shown on different tenants or for different users,
 or modify the wording of the cards on the home screen (see also [Customizing the home screen of the Streaming Analytics application](/apama/advanced/#customize-home-screen)).
 

--- a/content/apama/analytics-introduction-bundle/deploying-apps.md
+++ b/content/apama/analytics-introduction-bundle/deploying-apps.md
@@ -16,10 +16,6 @@ In the Streaming Analytics application, the term "activate" is used for deployin
 <a name="single-mon-file"></a>
 ### Deploying EPL apps as single \*.mon files with the Streaming Analytics application
 
-{{< c8y-admon-info >}}
-To be able to deploy single \*.mon files with the Streaming Analytics application, your tenant must be subscribed to both the Apama-ctrl microservice and the Streaming Analytics application provided in {{< product-c8y-iot >}}. If you have the Apama Starter microservice or the Apama Smart Rules-only microservice, the EPL Apps page is not available in the Streaming Analytics application. If you want to have this capability, contact [product support](/welcome/contacting-support).
-{{< /c8y-admon-info >}}
-
 When an EPL app (that is, a \*.mon file) is activated in {{< product-c8y-iot >}}, the \*.mon file is assigned a unique package name. This prevents conflicts when multiple modules are activated. For this reason, you should not specify a `package` statement in a \*.mon file. If you must share events between different parts of your application, then write the event definitions and monitors that use it in a single \*.mon file.
 
 There is a restricted set of utilities and base events available for your EPL app. At the time of writing, these include the **Time Format** and **HTTP Client > JSON with generic request/response event definitions** bundles.

--- a/content/apama/analytics-introduction-bundle/developing-apps.md
+++ b/content/apama/analytics-introduction-bundle/developing-apps.md
@@ -11,16 +11,18 @@ An EPL app is a monitor (\*.mon) file. You can develop EPL apps in two different
 
 See also [Using the Apama Event Processing Language (EPL)](/concepts/realtime/#using-epl) in the *Concepts guide*.
 
+{{< c8y-admon-info >}}
+To be able to develop and deploy EPL apps with the Streaming Analytics application and/or to import monitor files from {{< sag-designer >}} into {{< product-c8y-iot >}}, 
+your tenant must be subscribed to Apama-ctrl microservice that enables EPL apps. 
+If you do not see the EPL Apps page in the Streaming Analytics application and you wish to use EPL apps, contact [product support](/welcome/contacting-support).
+{{< /c8y-admon-info >}}
+
 <a name="apama-epl-apps"></a>
 ### Developing apps with the Streaming Analytics application
 
 The EPL Apps page of the Streaming Analytics application provides an interface for interactively editing new or existing EPL apps (\*.mon files) as well as importing and activating (deploying) EPL apps.
 
 Any user on the tenant wishing to use the EPL Apps page must be a **CEP Manager**. See [Administration > Managing permissions](/users-guide/administration/#managing-permissions) in the *User guide*.
-
-{{< c8y-admon-info >}}
-To be able to develop EPL apps with the Streaming Analytics application and/or to import monitor files from {{< sag-designer >}} into {{< product-c8y-iot >}}, your tenant must be subscribed to both the Apama-ctrl microservice and the Streaming Analytics application provided in {{< product-c8y-iot >}}. If you have the Apama Starter microservice or the Apama Smart Rules-only microservice, the EPL Apps page is not available in the Streaming Analytics application. If you want to have this capability, contact [product support](/welcome/contacting-support).
-{{< /c8y-admon-info >}}
 
 **Step 1 - Invoke the Streaming Analytics application**
 

--- a/content/apama/analytics-introduction-bundle/developing-apps.md
+++ b/content/apama/analytics-introduction-bundle/developing-apps.md
@@ -14,21 +14,21 @@ See also [Using the Apama Event Processing Language (EPL)](/concepts/realtime/#u
 {{< c8y-admon-info >}}
 To be able to develop and deploy EPL apps with the Streaming Analytics application and/or to import monitor files from {{< sag-designer >}} into {{< product-c8y-iot >}}, 
 your tenant must be subscribed to Apama-ctrl microservice that enables EPL apps. 
-If you do not see the EPL Apps page in the Streaming Analytics application and you wish to use EPL apps, contact [product support](/welcome/contacting-support).
+If you do not see the **EPL Apps** page in the Streaming Analytics application and you wish to use EPL apps, contact [product support](/welcome/contacting-support).
 {{< /c8y-admon-info >}}
 
 <a name="apama-epl-apps"></a>
 ### Developing apps with the Streaming Analytics application
 
-The EPL Apps page of the Streaming Analytics application provides an interface for interactively editing new or existing EPL apps (\*.mon files) as well as importing and activating (deploying) EPL apps.
+The **EPL Apps** page of the Streaming Analytics application provides an interface for interactively editing new or existing EPL apps (\*.mon files) as well as importing and activating (deploying) EPL apps.
 
-Any user on the tenant wishing to use the EPL Apps page must be a **CEP Manager**. See [Administration > Managing permissions](/users-guide/administration/#managing-permissions) in the *User guide*.
+Any user on the tenant wishing to use the **EPL Apps** page must be a **CEP Manager**. See [Administration > Managing permissions](/users-guide/administration/#managing-permissions) in the *User guide*.
 
 **Step 1 - Invoke the Streaming Analytics application**
 
-Open the application switcher and click the icon for the **Streaming Analytics** application. Then navigate to the EPL Apps page.
+Open the application switcher and click the icon for the **Streaming Analytics** application. Then navigate to the **EPL Apps** page.
 
-When you go to the  EPL Apps page, the EPL app manager is shown first, listing any existing EPL apps. Each app is shown as a card. You can add new EPL apps and manage existing EPL apps from here.
+When you go to the **EPL Apps** page, the EPL app manager is shown first, listing any existing EPL apps. Each app is shown as a card. You can add new EPL apps and manage existing EPL apps from here.
 
 ![EPL Apps](/images/apama/apama-epl-apps-cards.png)
 

--- a/content/apama/analytics-introduction-bundle/developing-apps.md
+++ b/content/apama/analytics-introduction-bundle/developing-apps.md
@@ -13,7 +13,7 @@ See also [Using the Apama Event Processing Language (EPL)](/concepts/realtime/#u
 
 {{< c8y-admon-info >}}
 To be able to develop and deploy EPL apps with the Streaming Analytics application and/or to import monitor files from {{< sag-designer >}} into {{< product-c8y-iot >}}, 
-your tenant must be subscribed to Apama-ctrl microservice that enables EPL apps. 
+your tenant must be subscribed to the Apama-ctrl microservice that supports EPL apps. 
 If you do not see the **EPL Apps** page in the Streaming Analytics application and you wish to use EPL apps, contact [product support](/welcome/contacting-support).
 {{< /c8y-admon-info >}}
 

--- a/content/apama/analytics-introduction-bundle/supported-rest-services.md
+++ b/content/apama/analytics-introduction-bundle/supported-rest-services.md
@@ -27,7 +27,7 @@ The following common error response codes can be expected for all requests:
 | Code | Description                                                  |
 | ---- | ------------------------------------------------------------ |
 | 401  | Unauthorized.                                                |
-| 403  | Forbidden. EPL apps are not available with Apama Starter. |
+| 403  | Forbidden. EPL apps are not available with the Apama-ctrl-starter microservice. |
 
 Any other response codes that can be expected from a specific request are given below.
 

--- a/content/apama/microservices-bundle/create-epl-app.md
+++ b/content/apama/microservices-bundle/create-epl-app.md
@@ -4,4 +4,4 @@ title: Creating an EPL app
 layout: redirect
 ---
 
-Click the Streaming Analytics icon in the application switcher. On the resulting home screen, navigate to the EPL Apps page and then click **New EPL app**. You will now see an EPL editor window in which to create the app which interacts with the Zementis microservice.
+Click the Streaming Analytics icon in the application switcher. On the resulting home screen, navigate to the **EPL Apps** page and then click **New EPL app**. You will now see an EPL editor window in which to create the app which interacts with the Zementis microservice.

--- a/content/apama/overview-analytics-bundle/analytics-builder.md
+++ b/content/apama/overview-analytics-bundle/analytics-builder.md
@@ -3,7 +3,7 @@ weight: 20
 title: Analytics Builder
 layout: redirect
 ---
-The Analytics Builder page of the Streaming Analytics application allows you to build analytic models that transform or analyze streaming data in order to generate new data or output events. The models are capable of processing data in real time.
+The **Analytics Builder** page of the Streaming Analytics application allows you to build analytic models that transform or analyze streaming data in order to generate new data or output events. The models are capable of processing data in real time.
 
 You build the models in a graphical environment by combining pre-built *blocks* into *models*. The blocks in a model package up small bits of logic, and have a number of inputs, outputs and parameters. Each block implements a specific piece of functionality, such as receiving data from a sensor, performing a calculation, detecting a condition, or generating an output signal. You define the configuration of the blocks and connect the blocks using *wires*. You can edit the models, simulate deployment with historic data, or run them against live systems.
 

--- a/content/apama/overview-analytics-bundle/apama-epl-apps.md
+++ b/content/apama/overview-analytics-bundle/apama-epl-apps.md
@@ -3,7 +3,7 @@ weight: 30
 title: EPL Apps
 layout: redirect
 ---
-The EPL Apps page of the Streaming Analytics application allows you to develop EPL apps (that is, single \*.mon files) directly within {{< product-c8y-iot >}}, written in Apama EPL. You can also import existing \*.mon files as EPL apps into {{< product-c8y-iot >}}. When you activate an EPL app from the Streaming Analytics application, you deploy it to {{< product-c8y-iot >}}.
+The **EPL Apps** page of the Streaming Analytics application allows you to develop EPL apps (that is, single \*.mon files) directly within {{< product-c8y-iot >}}, written in Apama EPL. You can also import existing \*.mon files as EPL apps into {{< product-c8y-iot >}}. When you activate an EPL app from the Streaming Analytics application, you deploy it to {{< product-c8y-iot >}}.
 
 A quick way to get started is to explore the code of the EPL samples that can be accessed from the EPL editor. See [Developing apps with the Streaming Analytics application](/apama/analytics-introduction/#apama-epl-apps) for information on how to create an EPL app and access the samples. For a start, use one of the simpler samples with temperature measurements, such as "Create an alarm if a measurement exceeds a threshold value". You can immediately see results using this sample. Add your own EPL code to the sample and try out your changes.
 

--- a/content/apama/overview-analytics-bundle/microservice-and-applications.md
+++ b/content/apama/overview-analytics-bundle/microservice-and-applications.md
@@ -17,12 +17,12 @@ See also the following sections in the *User guide*:
 * [Administration > Managing and monitoring microservices > Subscribed microservices](/users-guide/administration/#subscribed-microservices)
 * [Cockpit > Smart rules](/users-guide/cockpit/#smart-rules)
 
-If your tenant is subscribed to the Apama Starter microservice (also called Apama-ctrl-starter), then the following applies:
+If your tenant is subscribed to the Apama-ctrl-starter microservice, then the following applies:
 
 - Limited number of at most 3 active analytic models. Custom blocks written with the Analytics Builder Block SDK cannot be used. 
 - The EPL Apps page is not available in the Streaming Analytics application.
 - Unlimited number of smart rules.
 
-If your tenant is subscribed to the Apama Smart Rules-only microservice (also called Apama-ctrl-smartrules), the Analytics Builder and EPL Apps pages are not available in the Streaming Analytics application.
+If your tenant is subscribed to the Apama-ctrl-smartrules microservice, the Analytics Builder and EPL Apps pages are not available in the Streaming Analytics application.
 
 Contact [product support](/welcome/contacting-support) to discuss adding more capabilities.

--- a/content/apama/overview-analytics-bundle/microservice-and-applications.md
+++ b/content/apama/overview-analytics-bundle/microservice-and-applications.md
@@ -20,9 +20,9 @@ See also the following sections in the *User guide*:
 If your tenant is subscribed to the Apama-ctrl-starter microservice, then the following applies:
 
 - Limited number of at most 3 active analytic models. Custom blocks written with the Analytics Builder Block SDK cannot be used. 
-- The EPL Apps page is not available in the Streaming Analytics application.
+- The **EPL Apps** page is not available in the Streaming Analytics application.
 - Unlimited number of smart rules.
 
-If your tenant is subscribed to the Apama-ctrl-smartrules microservice, the Analytics Builder and EPL Apps pages are not available in the Streaming Analytics application.
+If your tenant is subscribed to the Apama-ctrl-smartrules microservice, the **Analytics Builder** and **EPL Apps** pages are not available in the Streaming Analytics application.
 
 Contact [product support](/welcome/contacting-support) to discuss adding more capabilities.

--- a/content/apama/overview-analytics-bundle/migrate-from-esper.md
+++ b/content/apama/overview-analytics-bundle/migrate-from-esper.md
@@ -62,11 +62,11 @@ The following smart rules are stateless:
 
 ### Migrating from CEL when also using custom rules
 
-Migrating from custom rules written in CEL to Apama EPL requires rewriting and retesting the custom rules. If any of the CEL generated from smart rules has been modified, you must convert that to an Apama EPL app as well, and delete the smart rule when migrating. As with any scripting or programming, you should thoroughly test significant changes before deploying into a production environment. Thus, the recommended approach is to create a separate tenant for hosting Apama EPL apps as they are developed, and replicate any input data required in that tenant. The CEP rules can continue to run in your production tenant while you develop the new Apama EPL apps. To do this, follow these steps:
+Migrating from custom rules written in CEL to Apama EPL requires rewriting and retesting the custom rules. If any of the CEL generated from smart rules has been modified, you must convert that to an EPL app as well, and delete the smart rule when migrating. As with any scripting or programming, you should thoroughly test significant changes before deploying into a production environment. Thus, the recommended approach is to create a separate tenant for hosting EPL apps as they are developed, and replicate any input data required in that tenant. The CEP rules can continue to run in your production tenant while you develop the new EPL apps. To do this, follow these steps:
 
 1. Lock down the CEP custom rules on the existing tenant to prevent change.
 2. Make available a new tenant on which Apama has been enabled.
-3. Manually convert all old custom rules from the existing tenant into equivalent Apama EPL apps on the new tenant. Refer to the rest of this guide, in particular [Best practices and guidelines](/apama/best-practices/). This includes smart rules where the CEL has been modified.
+3. Manually convert all old custom rules from the existing tenant into equivalent EPL apps on the new tenant. Refer to the rest of this guide, in particular [Best practices and guidelines](/apama/best-practices/). This includes smart rules where the CEL has been modified.
 4. Test the behavior of the new EPL apps by sending, for example, measurements or events into the new tenant and verifying that the new EPL apps respond appropriately.
 
     {{< c8y-admon-important >}}
@@ -78,7 +78,7 @@ Migrating from custom rules written in CEL to Apama EPL requires rewriting and r
 	* Activate your newly developed EPL apps in the production tenant.
 
 
-You can also work with {{< company-sag >}} Professional Services to help ensure the migration is as smooth as possible. {{< company-sag >}} Professional Services can help migrate CEL code into Apama EPL code and they can also provide training on using Apama in {{< product-c8y-iot >}}.
+You can also work with {{< company-sag >}} Professional Services to help ensure the migration is as smooth as possible. {{< company-sag >}} Professional Services can help migrate CEL code into EPL code and they can also provide training on using Apama in {{< product-c8y-iot >}}.
 
 ### Handling scheduled exports
 

--- a/content/apama/troubleshooting-bundle/alarms.md
+++ b/content/apama/troubleshooting-bundle/alarms.md
@@ -34,7 +34,7 @@ The following is a list of the alarms. The information further down below explai
 
 - [Change in tenant options and restart of Apama-ctrl](#tenant_option_change)
 - [Safe mode on startup](#apama_safe_mode)
-- [Deactivating models in Apama Starter](#apama_ctrl_starter)
+- [Deactivating models in the Apama-ctrl-starter microservice](#apama_ctrl_starter)
 - [High memory usage](#apama_highmemoryusage)
 - [Warning or higher level logging from an EPL file](#apama_ctrl_fatalcritwarn)
 - [An EPL file throws an uncaught exception](#apama_ctrl_error)
@@ -94,15 +94,15 @@ To diagnose the cause of an unexpected restart, you can try the following:
 In safe mode, all previously active analytic models and EPL apps are deactivated and must be manually re-activated.
 
 <a name="apama_ctrl_starter"></a>
-#### Deactivating models in Apama Starter
+#### Deactivating models in the Apama-ctrl-starter microservice
 
-This alarm is raised when Apama-ctrl switches from the fully capable microservice to Apama Starter with more than 3 active models.
+This alarm is raised when Apama-ctrl switches from the fully capable microservice to the Apama-ctrl-starter microservice with more than 3 active models.
 
 - Alarm type: `apama_ctrl_starter`
-- Alarm text: The following models were de-activated as Apama Starter is restricted to 3 active models: (&lt;models&gt;).
+- Alarm text: The following models were de-activated as Analytics Builder is restricted to 3 active models: (&lt;models&gt;).
 - Alarm severity: MINOR
 
-In Apama Starter, a user can have a maximum of 3 active models. For example, a user is working with the fully capable Apama-ctrl microservice and has 5 active models, and then switches to Apama Starter. Since Apama Starter does not allow more than 3 active models, it deactivates all the active models (5) and raises an alarm to notify the user.
+With the Apama-ctrl-starter microservice, a user can have a maximum of 3 active models. For example, a user is working with the fully capable Apama-ctrl microservice and has 5 active models, and then switches to Apama-ctrl-starter. Since Apama-ctrl-starter does not allow more than 3 active models, it deactivates all the active models (5) and raises an alarm to notify the user.
 
 <a name="apama_highmemoryusage"></a>
 #### High memory usage
@@ -160,7 +160,7 @@ See also [Diagnostic tools for Apama in Cumulocity IoT](https://techcommunity.so
 <a name="apama_ctrl_fatalcritwarn"></a>
 #### Warning or higher level logging from an EPL file
 
-This alarm is raised whenever messages are logged by Apama EPL files with specific log levels (including CRITICAL, FATAL, ERROR and WARNING).
+This alarm is raised whenever messages are logged by EPL files with specific log levels (including CRITICAL, FATAL, ERROR and WARNING).
 
 The Streaming Analytics application allows you to deploy EPL files to the correlator. The Apama-ctrl microservice analyzes logged content in the EPL files and raises an alarm for specific log levels with details such as monitor name, log text and alarm type (either of WARNING or MAJOR), based on the log level.
 

--- a/content/apama/troubleshooting-bundle/alarms.md
+++ b/content/apama/troubleshooting-bundle/alarms.md
@@ -59,10 +59,10 @@ The alarm texts for the alarms below may undergo minor changes in the future.
 This alarm is raised when a tenant option changes in the `analytics.builder` or `streaminganalytics` category. For details on the tenant options, refer to the [Tenant API](https://{{< domain-c8y >}}/api/{{< c8y-current-version >}}/#tag/Tenant-API) in the {{< openapi >}} for more details.
 
 - Alarm type: `tenant_option_change`
-- Alarm text: Apama detected changes in tenant option. Apama will restart in order to use it.
+- Alarm text: Detected changes in tenant option. Apama-ctrl will restart in order to use it.
 - Alarm severity: MAJOR
 
-Analytics Builder allows you to configure its settings by changing the tenant options, using key names such as `numWorkerThreads` or `status_device_name`. For example, if you want to process things in parallel, you can set `numWorkerThreads` to 3 by sending a REST request to {{< product-c8y-iot >}}, which will update the tenant option. Such a change automatically restarts the Apama-ctrl microservice. To notify the users about the restart, Apama-ctrl raises an alarm, saying that Apama has detected a change in a tenant option and will restart in order to use it.
+Analytics Builder allows you to configure its settings by changing the tenant options, using key names such as `numWorkerThreads` or `status_device_name`. For example, if you want to process things in parallel, you can set `numWorkerThreads` to 3 by sending a REST request to {{< product-c8y-iot >}}, which will update the tenant option. Such a change automatically restarts the Apama-ctrl microservice. To notify the users about the restart, Apama-ctrl raises an alarm, saying that changes have been detected in a tenant option and that Apama-ctrl will restart in order to use it.
 
 Once you see this alarm, you can be sure that your change is effective.
 
@@ -72,10 +72,10 @@ Once you see this alarm, you can be sure that your change is effective.
 This alarm is raised whenever the Apama-ctrl microservice switches to safe mode.
 
 - Alarm type: `apama_safe_mode`
-- Alarm text: Apama appears to be repeatedly restarting. As a precaution, user-provided EPL, analytic models and extensions that might have caused this have been disabled. Refer to the audit log for more details. Please check any recent alarms, or contact support or your administrator.
+- Alarm text: Apama-ctrl appears to be repeatedly restarting. As a precaution, user-provided EPL, analytic models and extensions that might have caused this have been disabled. Refer to the audit log for more details. Please check any recent alarms, or contact support or your administrator.
 - Alarm severity: CRITICAL
 
-Apama detects if it has been repeatedly restarting. If it looks like this has been caused by any kind of user asset (EPL, analytic models, extensions), Apama disables them all as a precaution. Potential causes are, for example, an EPL app that consumes more memory than is available or an extension containing bugs.
+Apama-ctrl detects if it has been repeatedly restarting. If it looks like this has been caused by any kind of user asset (EPL, analytic models, extensions), Apama-ctrl disables them all as a precaution. Potential causes are, for example, an EPL app that consumes more memory than is available or an extension containing bugs.
 
 You can check the mode of the microservice (either normal or safe mode) by making a REST request to *service/cep/diagnostics/apamaCtrlStatus* (available as of EPL Apps 10.5.7 and Analytics Builder 10.5.7), which contains a `safe_mode` flag in its response.
 
@@ -99,7 +99,7 @@ In safe mode, all previously active analytic models and EPL apps are deactivated
 This alarm is raised when Apama-ctrl switches from the fully capable microservice to the Apama-ctrl-starter microservice with more than 3 active models.
 
 - Alarm type: `apama_ctrl_starter`
-- Alarm text: The following models were de-activated as Analytics Builder is restricted to 3 active models: (&lt;models&gt;).
+- Alarm text: The following models were de-activated as Analytics Builder is restricted to &lt;activate limit&gt; active models: (&lt;models&gt;).
 - Alarm severity: MINOR
 
 With the Apama-ctrl-starter microservice, a user can have a maximum of 3 active models. For example, a user is working with the fully capable Apama-ctrl microservice and has 5 active models, and then switches to Apama-ctrl-starter. Since Apama-ctrl-starter does not allow more than 3 active models, it deactivates all the active models (5) and raises an alarm to notify the user.
@@ -114,19 +114,19 @@ There are 3 variants of this alarm, depending on the time and count restrictions
 First variant:
 
 - Alarm type: `apama_highmemoryusage`
-- Alarm text: Apama is using 90% of available memory (&lt;totalMemory&gt;). Your apps will be in danger of crashing. Diagnostics file is located at &lt;URL-to-ZIP-file&gt; You can also download the file by navigating to Administration > Management > Files Repository
+- Alarm text: Streaming Analytics is using 90% of available memory (&lt;totalMemory&gt;). Your apps will be in danger of crashing. Diagnostics file is located at &lt;URL-to-ZIP-file&gt; You can also download the file by navigating to Administration > Management > Files Repository
 - Alarm severity: WARNING
 
 Second variant:
 
 - Alarm type: `apama_highmemoryusage`
-- Alarm text: Apama is using 90% of available memory (&lt;totalMemory&gt;). Your apps will be in danger of crashing. Have recently created diagnostics snapshot (within last hour).
+- Alarm text: Streaming Analytics is using 90% of available memory (&lt;totalMemory&gt;). Your apps will be in danger of crashing. Have recently created diagnostics snapshot (within last hour).
 - Alarm severity: WARNING
 
 Third variant:
 
 - Alarm type: `apama_highmemoryusage`
-- Alarm text: Apama is using 90% of available memory (&lt;totalMemory&gt;). Your apps will be in danger of crashing. Have created 5 diagnostics snapshots, not creating any more, refer to past alarms.
+- Alarm text: Streaming Analytics is using 90% of available memory (&lt;totalMemory&gt;). Your apps will be in danger of crashing. Have created 5 diagnostics snapshots, not creating any more, refer to past alarms.
 - Alarm severity: WARNING
 
 Running EPL apps (and to a lesser extent, smart rules and analytic models) consumes memory, the amount will depend a lot on the nature of the app running. The memory usage should be approximately constant for a given set of apps, but it is possible to create a "memory leak", particularly in an EPL file or a custom block. The Apama-ctrl microservice monitors memory and raises an alarm with WARNING severity if the 90% memory limit is reached along with the diagnostics overview ZIP file and saves it to the files repository (as mentioned in the alarm text).

--- a/content/apama/troubleshooting-bundle/diagnostics-download.md
+++ b/content/apama/troubleshooting-bundle/diagnostics-download.md
@@ -5,7 +5,7 @@ layout: redirect
 ---
 
 {{< c8y-admon-info >}}
-Diagnostics are not available for the Apama Smart Rules-only microservice.
+Diagnostics are not available for the Apama-ctrl-smartrules microservice.
 {{< /c8y-admon-info >}}
 
 If a user has READ permission for "CEP management", then two links for downloading diagnostics information are available from the bottom of the Streaming Analytics application: one for downloading basic diagnostics information (the **Diagnostics** link) and another one for downloading enhanced (more resource-intensive) diagnostics information (the **Enhanced** link). These links are shown at the bottom of the home screen and also on the pages that appear when you go to the Analytics Builder and EPL Apps pages (that is, in the EPL app manager and in the model manager).

--- a/content/apama/troubleshooting-bundle/diagnostics-download.md
+++ b/content/apama/troubleshooting-bundle/diagnostics-download.md
@@ -8,7 +8,7 @@ layout: redirect
 Diagnostics are not available for the Apama-ctrl-smartrules microservice.
 {{< /c8y-admon-info >}}
 
-If a user has READ permission for "CEP management", then two links for downloading diagnostics information are available from the bottom of the Streaming Analytics application: one for downloading basic diagnostics information (the **Diagnostics** link) and another one for downloading enhanced (more resource-intensive) diagnostics information (the **Enhanced** link). These links are shown at the bottom of the home screen and also on the pages that appear when you go to the Analytics Builder and EPL Apps pages (that is, in the EPL app manager and in the model manager).
+If a user has READ permission for "CEP management", then two links for downloading diagnostics information are available from the bottom of the Streaming Analytics application: one for downloading basic diagnostics information (the **Diagnostics** link) and another one for downloading enhanced (more resource-intensive) diagnostics information (the **Enhanced** link). These links are shown at the bottom of the home screen and also on the pages that appear when you go to the **Analytics Builder** and **EPL Apps** pages (that is, in the EPL app manager and in the model manager).
 
 It may be useful to capture this diagnostics information when experiencing problems, or for debugging EPL apps. It is also useful to provide to [product support](/welcome/contacting-support) if you are filing a support ticket.
 You can see a version number next to the links.

--- a/content/apama/troubleshooting-bundle/diagnostics-rest.md
+++ b/content/apama/troubleshooting-bundle/diagnostics-rest.md
@@ -5,7 +5,7 @@ layout: redirect
 ---
 
 {{< c8y-admon-info >}}
-These endpoints are not available for the Apama Smart Rules-only microservice.
+These endpoints are not available for the Apama-ctrl-smartrules microservice.
 {{< /c8y-admon-info >}}
 
 The following diagnostics endpoints are available for REST requests. These require authentication as a user with READ permission for "CEP management":

--- a/content/apama/troubleshooting-bundle/monitoring-rest.md
+++ b/content/apama/troubleshooting-bundle/monitoring-rest.md
@@ -13,7 +13,7 @@ The following monitoring endpoints are available for REST requests. These requir
     Also provides correlator and microservice status values. For details about the correlator status values, see "List of correlator status statistics" in the Apama documentation.  
 
     {{< c8y-admon-info >}}
-  For the multi-tenant variant of the Apama Smart Rules-only microservice, only basic microservice status values are provided.
+  For the multi-tenant variant of the Apama-ctrl-smartrules microservice, only basic microservice status values are provided.
     {{< /c8y-admon-info >}}
 - `/service/cep/prometheus`  
     GET only. Plain text format.  

--- a/content/apama/troubleshooting.md
+++ b/content/apama/troubleshooting.md
@@ -5,4 +5,4 @@ layout: bundle
 collection: 'apama/troubleshooting'
 ---
 
-If you have the Apama Smart Rules-only microservice (also called Apama-ctrl-smartrules), most of the functionality described in this topic does not apply.
+If you have the Apama-ctrl-smartrules microservice, most of the functionality described in this topic does not apply.


### PR DESCRIPTION
No longer use "Apama Starter" as this is no longer shown in the UI. Changed that to the real name of the microservice, and also did the same for the smart rules-only microservice.
Moved the Info up to the top of the Develop page, rephrased it as suggested by Rob and removed the second similar Info in the Deploy section..

Still waiting for the developers to look into this and answer some of my questions ....