### PR TITLE
PAB-3255: New topic "Optimizing requests with concurrent connections" 

### DIFF
--- a/content/apama/advanced-bundle/control-access.md
+++ b/content/apama/advanced-bundle/control-access.md
@@ -1,5 +1,5 @@
 ---
-weight: 70
+weight: 80
 title: Controlling access to the Streaming Analytics application
 layout: redirect
 ---

--- a/content/apama/advanced-bundle/customize-home-screen.md
+++ b/content/apama/advanced-bundle/customize-home-screen.md
@@ -1,5 +1,5 @@
 ---
-weight: 80
+weight: 90
 title: Customizing the home screen of the Streaming Analytics application
 layout: redirect
 ---

--- a/content/apama/advanced-bundle/microservice-permissions.md
+++ b/content/apama/advanced-bundle/microservice-permissions.md
@@ -1,5 +1,5 @@
 ---
-weight: 90
+weight: 100
 title: Modifying microservice permissions and resource usage
 layout: redirect
 ---

--- a/content/apama/advanced-bundle/optimize-requests.md
+++ b/content/apama/advanced-bundle/optimize-requests.md
@@ -1,0 +1,28 @@
+---
+weight: 70
+title: Optimizing requests with concurrent connections
+layout: redirect
+---
+
+In order to provide better performance in requests to the {{< product-c8y-iot >}} platform, you can configure the transport to use multiple client connections to perform requests concurrently. 
+This can provide improved performance, but may also change the ordering in which requests are executed and responses are returned. 
+By default, the {{< product-c8y-iot >}} transport tries to use multiple connections and restricts ordering to avoid races that may affect your EPL application.
+
+An attempt is made to ensure order is maintained when required. For example, all updates to a single managed object are performed serially in the order they were sent to the transport. 
+For more details see [Optimizing requests to Cumulocity IoT with concurrent connections]({{< link-apama-webhelp >}}index.html#page/apama-webhelp%2Fco-ConApaAppToExtCom_cumulocity_optimizing_requests_to_cumulocity_iot_with_concurrent_connections.html) in the Apama documentation.
+
+You can configure the number of client connections with the `client.numClients` tenant option in the `streaminganalytics` category. For example:
+
+```
+{
+   "category": "streaminganalytics", 
+   "key": "client.numClients", 
+   "value": "5" 
+}
+```
+If you require a fully serial transport, set the value of `client.numClients` to 1. 
+
+{{< c8y-admon-info >}}
+This does not apply to the Apama-ctrl-smartrules microservices. They have a fixed value for this option, which is not configurable.
+{{< /c8y-admon-info >}}
+

--- a/themes/c8ydocs/layouts/shortcodes/link-analytics-builder.html
+++ b/themes/c8ydocs/layouts/shortcodes/link-analytics-builder.html
@@ -1,1 +1,1 @@
-{{- "https://documentation.softwareag.com/apama/Analytics_Builder/pab10-14-0/apama-pab-webhelp/" -}}
+{{- "https://documentation.softwareag.com/apama/Analytics_Builder/pab10-15-0/apama-pab-webhelp/" -}}

--- a/themes/c8ydocs/layouts/shortcodes/link-apama-webhelp.html
+++ b/themes/c8ydocs/layouts/shortcodes/link-apama-webhelp.html
@@ -1,1 +1,1 @@
-{{- "https://documentation.softwareag.com/apama/v10-11/apama10-11/apama-webhelp/" -}}
+{{- "https://documentation.softwareag.com/apama/v10-15/apama10-15/apama-webhelp/" -}}

--- a/themes/c8ydocs/layouts/shortcodes/link-apamadoc-api.html
+++ b/themes/c8ydocs/layouts/shortcodes/link-apamadoc-api.html
@@ -1,1 +1,1 @@
-{{- "https://documentation.softwareag.com/apama/v10-11/apama10-11/ApamaDoc/" -}}
+{{- "https://documentation.softwareag.com/apama/v10-15/apama10-15/ApamaDoc/" -}}


### PR DESCRIPTION
Inserted the new topic after "Spawning monitor instances and contexts"; therefore had to update the weight in the subsequent topics. 

Also updated the shortcodes for the documentation links so that they now point to the - still unpublished - PAM 10.15 doc. Keep in mind that the link in the new topic refers to a new topic in the PAM doc which has only been included with 10.15. And as the 10.15 PAM doc is not yet live, this link will not work yet.