### PR TITLE
DM-1416 correcting motion measurement fragment to speed measurement

### DIFF
--- a/content/reference/sensor-library-bundle/environmental-capabilities.md
+++ b/content/reference/sensor-library-bundle/environmental-capabilities.md
@@ -36,7 +36,7 @@ In a managed object, a motion sensor is modeled as a simple empty fragment:
 "c8y_MotionSensor" : {}
 ```
 
-### c8y\_MotionMeasurement
+### c8y\_SpeedMeasurement
 
 |Measurement|Units|Description|
 |:----------|:----|:----------|
@@ -44,7 +44,7 @@ In a managed object, a motion sensor is modeled as a simple empty fragment:
 |speed|km/h|Measured speed towards (+ve) or away (-ve) from the sensor.|
 
 ```json
-"c8y_MotionMeasurement": {
+"c8y_SpeedMeasurement": {
   "motionDetected": { "value": 1.0, "unit": "", "type": "BOOLEAN" },
   "speed": { "value": -63.2, "unit": "km/h" }
 }


### PR DESCRIPTION
There was no MotionMeasurement class but instead there is SpeedMeasurement https://github.com/SoftwareAG/cumulocity-clients-java/blob/develop/device-capability-model/src/main/java/c8y/SpeedMeasurement.java 
Therefore, I corrected the name in the sensor library documentation.


### I'll create a task for the below things I noticed:
In the source code the MoistureSensor fragment contains a moisture measurement fragment https://github.com/SoftwareAG/cumulocity-clients-java/blob/develop/device-capability-model/src/main/java/c8y/MoistureSensor.java but it is not consistent with other Sensor models in device-capability-model library and in the documentation it was not mentioned. There is also MoistureMeasurement measurement exists. In the task it can be decided to remove from source code or adding to the documentation.

Mssing things in the device-capability-model lib related to the sensor lib documentation that can be added:
c8y_Barometer
c8y_BarometerMeasurement

c8y_PowerSensor
c8y_PowerMeasurement

c8y_PushButton