### PR TITLE
feature/MTM-46136/MTM-46140-Add-requirements-for-managing-applications-and-microservices

### DIFF
--- a/content/users-guide/administration-bundle/managing-applications.md
+++ b/content/users-guide/administration-bundle/managing-applications.md
@@ -19,15 +19,15 @@ helpcontent:
 {{< c8y-admon-req >}}
 ROLES & PERMISSIONS:
 
-* To view applications and microservices: READ permission for the "Application management" permission type
-* To manage applications and microservices (create, update, copy): ADMIN permission for the "Application management" permission type
+* To view applications and microservices: assign READ permission for the "Application management" permission type
+* To manage applications and microservices (create, update, copy, delete): assign ADMIN permission for the "Application management" permission type
 
 On tenant creation there are default roles available that can be used as sample configuration for the above mentioned permissions:
 * Tenant Manager - Can manage tenant wide configurations like applications, tenant options and retention rules.
 
 Note that for complete application management some additional permission types with different permission levels might be required per feature, for example:
-* [Default subscriptions](/users-guide/enterprise-tenant/#default-subscriptions) for the Enterprise tenant additionally require READ and ADMIN permission for the "Option management" permission type.
-* [Managing subscriptions](/users-guide/enterprise-tenant/#applications) for the Enterprise tenant additionally requires READ and ADMIN permission for the "Tenant management" permission type.
+* [Default subscriptions](/users-guide/enterprise-tenant/#default-subscriptions) for the Enterprise tenant additionally requires READ and ADMIN permissions for the "Option management" permission type.
+* [Managing subscriptions](/users-guide/enterprise-tenant/#applications) for the Enterprise tenant additionally requires READ and ADMIN permissions for the "Tenant management" permission type.
 
 {{< /c8y-admon-req >}}
 

--- a/content/users-guide/administration-bundle/managing-applications.md
+++ b/content/users-guide/administration-bundle/managing-applications.md
@@ -16,6 +16,22 @@ helpcontent:
     Click on an application to view the application properties. To add an application, click **Add application** and follow the instructions in the wizard, see also the *User guide*."
 ---
 
+{{< c8y-admon-req >}}
+ROLES & PERMISSIONS:
+
+"Application management" permission:
+* READ - allows to view applications and microservices.
+* ADMIN - allows to manage applications and microservices (create, update, copy).
+
+By default on tenant creation there are default roles available that can be used as example of configuration for above mentioned permissions:
+* Tenant Manager - can manage tenant wide configurations like applications, tenant options and retention rules.
+
+Please note that for complete application management some additional permissions in different permission scopes might be required per feature, for example:
+* [Default subscriptions](/users-guide/enterprise-tenant/#default-subscriptions) of enterprise tenant will require additionally "Option management" permission with READ and ADMIN access.
+* [Managing subscriptions](http://localhost:1313/guides/users-guide/enterprise-tenant/#applications) of enterprise tenant will require additionally "Tenant management" permission with READ and ADMIN access.
+
+{{< /c8y-admon-req >}}
+
 The {{< product-c8y-iot >}} platform distinguishes between applications and microservices, see also [Developing applications](/concepts/applications) in the *Concepts guide*.
 
 * [Applications](#applications) -  all web applications either subscribed to the tenant or owned by the tenant.

--- a/content/users-guide/administration-bundle/managing-applications.md
+++ b/content/users-guide/administration-bundle/managing-applications.md
@@ -19,8 +19,8 @@ helpcontent:
 {{< c8y-admon-req >}}
 ROLES & PERMISSIONS:
 
-* To view applications and microservices: assign READ permission for the "Application management" permission type
-* To manage applications and microservices (create, update, copy, delete): assign ADMIN permission for the "Application management" permission type
+* To view applications and microservices: READ permission for the "Application management" permission type
+* To manage applications and microservices (create, update, copy, delete): ADMIN permission for the "Application management" permission type
 
 On tenant creation there are default roles available that can be used as sample configuration for the above mentioned permissions:
 * Tenant Manager - Can manage tenant wide configurations like applications, tenant options and retention rules.

--- a/content/users-guide/administration-bundle/managing-applications.md
+++ b/content/users-guide/administration-bundle/managing-applications.md
@@ -19,16 +19,15 @@ helpcontent:
 {{< c8y-admon-req >}}
 ROLES & PERMISSIONS:
 
-"Application management" permission:
-* READ - allows to view applications and microservices.
-* ADMIN - allows to manage applications and microservices (create, update, copy).
+* To view applications and microservices: READ permission for the "Application management" permission type
+* To manage applications and microservices (create, update, copy): ADMIN permission for the "Application management" permission type
 
-By default on tenant creation there are default roles available that can be used as example of configuration for above mentioned permissions:
-* Tenant Manager - can manage tenant wide configurations like applications, tenant options and retention rules.
+On tenant creation there are default roles available that can be used as sample configuration for the above mentioned permissions:
+* Tenant Manager - Can manage tenant wide configurations like applications, tenant options and retention rules.
 
-Please note that for complete application management some additional permissions in different permission scopes might be required per feature, for example:
-* [Default subscriptions](/users-guide/enterprise-tenant/#default-subscriptions) of enterprise tenant will require additionally "Option management" permission with READ and ADMIN access.
-* [Managing subscriptions](http://localhost:1313/guides/users-guide/enterprise-tenant/#applications) of enterprise tenant will require additionally "Tenant management" permission with READ and ADMIN access.
+Note that for complete application management some additional permission types with different permission levels might be required per feature, for example:
+* [Default subscriptions](/users-guide/enterprise-tenant/#default-subscriptions) for the Enterprise tenant additionally require READ and ADMIN permission for the "Option management" permission type.
+* [Managing subscriptions](/users-guide/enterprise-tenant/#applications) for the Enterprise tenant additionally requires READ and ADMIN permission for the "Tenant management" permission type.
 
 {{< /c8y-admon-req >}}
 


### PR DESCRIPTION
* added required permissions for application management


Tasks:
* [x] To view applications and microservices: READ permission for the "Application management" permission type is required ( jakby brakuję jeszcze czasownika, czy może być is needed)
-> added `assign` before READ

* [x] To manage applications and microservices (create, update, copy): ADMIN permission for the "Application management" permission type => To manage applications and microservices (create, update, copy, delete):....
-> added `delete`

* [x]  `for the Enterprise tenant additionally require READ and ADMIN permission for the "Option management" permission type.`  =>  for the Enterprise tenant additionally require READ and ADMIN permission`S` for the "Option management" permission type.
-> applied fixes proposed

* [x] `requires READ and ADMIN permission for the "Tenant management" permission type.`  => requires READ and ADMIN permission`S` for the "Tenant management" permission type.  (z `s` na koncu permission)
-> applied fixes proposed