### PR TITLE
MTM-45799 add generic information about inventory roles improvements

### DIFF
--- a/content/users-guide/administration-bundle/managing-permissions.md
+++ b/content/users-guide/administration-bundle/managing-permissions.md
@@ -395,11 +395,13 @@ To help troubleshooting permissions, click the **User** button (showing the curr
 
 ### Performance improvements
 
-Starting from the version 10.13 of the Cumulocity platform several improvements were implemented for users with inventory roles access. In the past slower responses could have been observed on the tenants with big inventory hierarchies. Currently following UI pages should work smoother after switching to new approach:
-* Device Management > Devices > particular device page > tabs including "Info", "Measurements", "Alarms", "Events", "Control" should load and present the data fast
-* Device Management > Devices > All devices, and all similar screens with search for multiple inventory objects 
-* All screens with aggregated alarm views from many devices, if number of alarms in the system is not big. Example screens: Cockpit > Home, Cockpit > Alarms, Device Management > Home
-* Similar for screens with aggregated events and operations from many devices. Example screens: Device Management > Overviews > Events, Device Management > Overviews > Device control
+Starting with version 10.13 of the {{< product-c8y-iot >}} platform, several improvements have been implemented for users with inventory roles access.
+In earlier versions responses were slow for tenants with large inventory hierarchies.
+The following UI pages have an improved performance after updating to version 10.16:
+* In the [device details view](/users-guide/device-management/#device-details), the tabs **Info**, **Measurements**, **Alarms**, **Events** and **Control**.
+* Pages displaying lists of inventory objects, such as [All devices](/users-guide/device-management/#viewing-devices).
+* Pages with aggregated alarm views from multiple devices, if the number of alarms in the system is low, for example, [Cockpit > Home dashboard](/users-guide/cockpit/#home-dashboard), Cockpit > Alarms and Device Management > Home.
+* Pages with aggregated events and operations from multiple devices, for example, Device Management > Overviews > Events and Device Management > Overviews > Device control.
 
 <a name="app-access"></a>
 ### Granting application access

--- a/content/users-guide/administration-bundle/managing-permissions.md
+++ b/content/users-guide/administration-bundle/managing-permissions.md
@@ -393,6 +393,14 @@ If you try to perform actions without sufficient permissions, an error message w
 
 To help troubleshooting permissions, click the **User** button (showing the current user name) at the right of the top bar. From the context menu, select **Access denied requests**. In the resulting window details on the denied accesses are provided. An administrator user or the [product support](/welcome/contacting-support/) can help in fixing the permissions.
 
+### Performance improvements
+
+Starting from the version 10.13 of the Cumulocity platform several improvements were implemented for users with inventory roles access. In the past slower responses could have been observed on the tenants with big inventory hierarchies. Currently following UI pages should work smoother after switching to new approach:
+* Device Management > Devices > particular device page > tabs including "Info", "Measurements", "Alarms", "Events", "Control" should load and present the data fast
+* Device Management > Devices > All devices, and all similar screens with search for multiple inventory objects 
+* All screens with aggregated alarm views from many devices, if number of alarms in the system is not big. Example screens: Cockpit > Home, Cockpit > Alarms, Device Management > Home
+* Similar for screens with aggregated events and operations from many devices. Example screens: Device Management > Overviews > Events, Device Management > Overviews > Device control
+
 <a name="app-access"></a>
 ### Granting application access
 

--- a/content/users-guide/administration-bundle/managing-permissions.md
+++ b/content/users-guide/administration-bundle/managing-permissions.md
@@ -393,15 +393,27 @@ If you try to perform actions without sufficient permissions, an error message w
 
 To help troubleshooting permissions, click the **User** button (showing the current user name) at the right of the top bar. From the context menu, select **Access denied requests**. In the resulting window details on the denied accesses are provided. An administrator user or the [product support](/welcome/contacting-support/) can help in fixing the permissions.
 
-### Performance improvements
+### Improving the performance
 
-Starting with version 10.13 of the {{< product-c8y-iot >}} platform, several improvements have been implemented for users with inventory roles access.
-In earlier versions responses were slow for tenants with large inventory hierarchies.
-The following UI pages have an improved performance after updating to version {{< c8y-current-version >}}:
+The {{< product-c8y-iot >}} platform now has optimized UI performance for users with inventory roles access. In particular, requests for tenants with large inventory hierarchies are faster.
+
+The performance of the following UI pages is improved:
 * In the [device details view](/users-guide/device-management/#device-details), the tabs **Info**, **Measurements**, **Alarms**, **Events** and **Control**.
-* Pages displaying lists of inventory objects, such as [All devices](/users-guide/device-management/#viewing-devices).
 * Pages with aggregated alarm views from multiple devices, if the number of alarms in the system is low, for example, [Cockpit > Home dashboard](/users-guide/cockpit/#home-dashboard), Cockpit > Alarms and Device Management > Home.
-* Pages with aggregated events and operations from multiple devices, for example, [Device Management > Overviews > Events](/users-guide/device-management/#to-view-events) and [Device Management > Overviews > Device control](/users-guide/device-management/#to-view-single-operations).
+* Pages with aggregated events from multiple devices, if the number of events is low, for example, [Device Management > Overviews > Events](/users-guide/device-management/#to-view-events).
+* Pages with aggregated operations from multiple devices, if the number of operations is low, for example, [Device Management > Overviews > Device control](/users-guide/device-management/#to-view-single-operations).
+
+As an administrator, you can switch back to the previous solution and this improved performance feature will be disabled:
+- on platform level via the configuration file (only available for platform administrators, see the *{{< product-c8y-iot >}} - Operations guide* for details).
+- on tenant level via a tenant option. The tenant option has 2 possible values: LEGACY/OPTIMIZED, where OPTIMIZED is the global default.
+
+The option looks like the following in the REST API (see also the [{{< openapi >}}](https://cumulocity.com/api/10.16.0/#operation/postOptionCollectionResource)):
+
+`{"category": "configuration", "key": "acl.algorithm-version", "value": "LEGACY"}`
+
+The setting on tenant level has priority over the setting on platform level.
+
+By default, this option is enabled.
 
 <a name="app-access"></a>
 ### Granting application access

--- a/content/users-guide/administration-bundle/managing-permissions.md
+++ b/content/users-guide/administration-bundle/managing-permissions.md
@@ -397,7 +397,7 @@ To help troubleshooting permissions, click the **User** button (showing the curr
 
 Starting with version 10.13 of the {{< product-c8y-iot >}} platform, several improvements have been implemented for users with inventory roles access.
 In earlier versions responses were slow for tenants with large inventory hierarchies.
-The following UI pages have an improved performance after updating to version 10.16:
+The following UI pages have an improved performance after updating to version {{< c8y-current-version >}}:
 * In the [device details view](/users-guide/device-management/#device-details), the tabs **Info**, **Measurements**, **Alarms**, **Events** and **Control**.
 * Pages displaying lists of inventory objects, such as [All devices](/users-guide/device-management/#viewing-devices).
 * Pages with aggregated alarm views from multiple devices, if the number of alarms in the system is low, for example, [Cockpit > Home dashboard](/users-guide/cockpit/#home-dashboard), Cockpit > Alarms and Device Management > Home.

--- a/content/users-guide/administration-bundle/managing-permissions.md
+++ b/content/users-guide/administration-bundle/managing-permissions.md
@@ -401,7 +401,7 @@ The following UI pages have an improved performance after updating to version {{
 * In the [device details view](/users-guide/device-management/#device-details), the tabs **Info**, **Measurements**, **Alarms**, **Events** and **Control**.
 * Pages displaying lists of inventory objects, such as [All devices](/users-guide/device-management/#viewing-devices).
 * Pages with aggregated alarm views from multiple devices, if the number of alarms in the system is low, for example, [Cockpit > Home dashboard](/users-guide/cockpit/#home-dashboard), Cockpit > Alarms and Device Management > Home.
-* Pages with aggregated events and operations from multiple devices, for example, Device Management > Overviews > Events and Device Management > Overviews > Device control.
+* Pages with aggregated events and operations from multiple devices, for example, [Device Management > Overviews > Events](/users-guide/device-management/#to-view-events) and [Device Management > Overviews > Device control](/users-guide/device-management/#to-view-single-operations).
 
 <a name="app-access"></a>
 ### Granting application access

--- a/content/users-guide/administration-bundle/managing-permissions.md
+++ b/content/users-guide/administration-bundle/managing-permissions.md
@@ -395,7 +395,7 @@ To help troubleshooting permissions, click the **User** button (showing the curr
 
 ### Improving the performance
 
-The {{< product-c8y-iot >}} platform now has optimized UI performance for users with inventory roles access. In particular, requests for tenants with large inventory hierarchies are faster.
+The {{< product-c8y-iot >}} platform provides optimized UI performance for users with inventory roles access. In particular, requests for tenants with large inventory hierarchies are faster.
 
 The performance of the following UI pages is improved:
 * In the [device details view](/users-guide/device-management/#device-details), the tabs **Info**, **Measurements**, **Alarms**, **Events** and **Control**.
@@ -403,7 +403,7 @@ The performance of the following UI pages is improved:
 * Pages with aggregated events from multiple devices, if the number of events is low, for example, [Device Management > Overviews > Events](/users-guide/device-management/#to-view-events).
 * Pages with aggregated operations from multiple devices, if the number of operations is low, for example, [Device Management > Overviews > Device control](/users-guide/device-management/#to-view-single-operations).
 
-As an administrator, you can switch back to the previous solution and this improved performance feature will be disabled:
+As an administrator, you can disable the performance feature:
 - on platform level via the configuration file (only available for platform administrators, see the *{{< product-c8y-iot >}} - Operations guide* for details).
 - on tenant level via a tenant option. The tenant option has 2 possible values: LEGACY/OPTIMIZED, where OPTIMIZED is the global default.
 


### PR DESCRIPTION
I will create separate PRs to previous releases after this one will be reviewed and language adjusted. 

The reasoning is that part of changes were introduced in 10.13 (MEA), 10.14 (Inventory), and now in 10.16 (Operations, default algorithm changed to new one).