### PR TITLE
MTM-45799 add generic information about inventory roles improvements for 10.14

### DIFF
--- a/content/users-guide/administration-bundle/managing-permissions.md
+++ b/content/users-guide/administration-bundle/managing-permissions.md
@@ -403,7 +403,7 @@ The following UI pages have an improved performance after updating to version {{
 * Pages with aggregated alarm views from multiple devices, if the number of alarms in the system is low, for example, [Cockpit > Home dashboard](/users-guide/cockpit/#home-dashboard), Cockpit > Alarms and Device Management > Home.
 * Pages with aggregated events from multiple devices, if the number of events is low, for example, [Device Management > Overviews > Events](/users-guide/device-management/#to-view-events).
 
-New approach is disabled by default and needs to be switched on the tenant level using tenant option (see the Release notes for details).
+The improvements are disabled by default in version {{< c8y-current-version >}}. Activate them on tenant level by using the tenant option. See the relevant [10.13.0 release notes entry](https://cumulocity.com/releasenotes/release-10-13-0/whatsnew-10-13-0/#inventory-roles-performance-improvement) for details.
 
 <a name="app-access"></a>
 ### Granting application access

--- a/content/users-guide/administration-bundle/managing-permissions.md
+++ b/content/users-guide/administration-bundle/managing-permissions.md
@@ -393,6 +393,18 @@ If you try to perform actions without sufficient permissions, an error message w
 
 To help troubleshooting permissions, click the **User** button (showing the current user name) at the right of the top bar. From the context menu, select **Access denied requests**. In the resulting window details on the denied accesses are provided. An administrator user or the [product support](/welcome/contacting-support/) can help in fixing the permissions.
 
+### Performance improvements
+
+Starting with version 10.13 of the {{< product-c8y-iot >}} platform, several improvements have been implemented for users with inventory roles access.
+In earlier versions responses were slow for tenants with large inventory hierarchies.
+The following UI pages have an improved performance after updating to version {{< c8y-current-version >}}:
+* In the [device details view](/users-guide/device-management/#device-details), the tabs **Info**, **Measurements**, **Alarms**, **Events**.
+* Pages displaying lists of inventory objects, such as [All devices](/users-guide/device-management/#viewing-devices).
+* Pages with aggregated alarm views from multiple devices, if the number of alarms in the system is low, for example, [Cockpit > Home dashboard](/users-guide/cockpit/#home-dashboard), Cockpit > Alarms and Device Management > Home.
+* Pages with aggregated events from multiple devices, if the number of events is low, for example, [Device Management > Overviews > Events](/users-guide/device-management/#to-view-events).
+
+New approach is disabled by default and needs to be switched on the tenant level using tenant option (see the Release notes for details).
+
 <a name="app-access"></a>
 ### Granting application access
 

--- a/content/users-guide/administration-bundle/managing-permissions.md
+++ b/content/users-guide/administration-bundle/managing-permissions.md
@@ -401,7 +401,7 @@ This performance feature can be enabled:
 - on platform level via the configuration file (only available for platform administrators, see the *{{< product-c8y-iot >}} - Operations guide* for details).
 - on tenant level via a tenant option. The tenant option has 2 possible values: LEGACY/OPTIMIZED, where LEGACY is the global default.
 
-The option looks like the following in the REST API (see also the [{{< openapi >}}](https://cumulocity.com/api/10.13.0/#operation/postOptionCollectionResource)):
+The option looks like the following in the REST API (see also the [{{< openapi >}}](https://cumulocity.com/api/10.14.0/#operation/postOptionCollectionResource)):
 
 `{"category": "configuration", "key": "acl.algorithm-version", "value": "OPTIMIZED"}`
 

--- a/content/users-guide/administration-bundle/managing-permissions.md
+++ b/content/users-guide/administration-bundle/managing-permissions.md
@@ -393,17 +393,27 @@ If you try to perform actions without sufficient permissions, an error message w
 
 To help troubleshooting permissions, click the **User** button (showing the current user name) at the right of the top bar. From the context menu, select **Access denied requests**. In the resulting window details on the denied accesses are provided. An administrator user or the [product support](/welcome/contacting-support/) can help in fixing the permissions.
 
-### Performance improvements
+### Improving the performance
 
-Starting with version 10.13 of the {{< product-c8y-iot >}} platform, several improvements have been implemented for users with inventory roles access.
-In earlier versions responses were slow for tenants with large inventory hierarchies.
-The following UI pages have an improved performance after updating to version {{< c8y-current-version >}}:
+As an administrator, you can optimize the UI performance for users with inventory roles access and particularly speed up requests for tenants with large inventory hierarchies.
+
+This performance feature can be enabled:
+- on platform level via the configuration file (only available for platform administrators, see the *{{< product-c8y-iot >}} - Operations guide* for details).
+- on tenant level via a tenant option. The tenant option has 2 possible values: LEGACY/OPTIMIZED, where LEGACY is the global default.
+
+The option looks like the following in the REST API (see also the [{{< openapi >}}](https://cumulocity.com/api/10.13.0/#operation/postOptionCollectionResource)):
+
+`{"category": "configuration", "key": "acl.algorithm-version", "value": "OPTIMIZED"}`
+
+The setting on tenant level has priority over the setting on platform level.
+
+The performance of the following UI pages will be improved when this option is enabled:
 * In the [device details view](/users-guide/device-management/#device-details), the tabs **Info**, **Measurements**, **Alarms**, **Events**.
 * Pages displaying lists of inventory objects, such as [All devices](/users-guide/device-management/#viewing-devices).
 * Pages with aggregated alarm views from multiple devices, if the number of alarms in the system is low, for example, [Cockpit > Home dashboard](/users-guide/cockpit/#home-dashboard), Cockpit > Alarms and Device Management > Home.
 * Pages with aggregated events from multiple devices, if the number of events is low, for example, [Device Management > Overviews > Events](/users-guide/device-management/#to-view-events).
 
-The improvements are disabled by default in version {{< c8y-current-version >}}. Activate them on tenant level by using the tenant option. See the relevant [10.13.0 release notes entry](https://cumulocity.com/releasenotes/release-10-13-0/whatsnew-10-13-0/#inventory-roles-performance-improvement) for details.
+By default, this option is disabled.
 
 <a name="app-access"></a>
 ### Granting application access


### PR DESCRIPTION
PR based on https://github.com/SoftwareAG/c8y-docs/pull/628, but with scope of information what is done till 10.14 (and 10.15 since there were no changes between those)

Preview from local hugo:

![image](https://user-images.githubusercontent.com/92089923/195903005-154fcdae-ec20-42c2-a82a-e0d513221e66.png)
