### PR TITLE
Shortcodes: Update PAM and PAB links for 10.16

### DIFF
--- a/themes/c8ydocs/layouts/shortcodes/link-analytics-builder.html
+++ b/themes/c8ydocs/layouts/shortcodes/link-analytics-builder.html
@@ -1,1 +1,1 @@
-{{- "https://documentation.softwareag.com/pab/10.15.0/en/webhelp/pab-webhelp/" -}}
+{{- "https://documentation.softwareag.com/pab/10.16.0/en/webhelp/pab-webhelp/" -}}

--- a/themes/c8ydocs/layouts/shortcodes/link-apama-webhelp.html
+++ b/themes/c8ydocs/layouts/shortcodes/link-apama-webhelp.html
@@ -1,1 +1,1 @@
-{{- "https://documentation.softwareag.com/pam/10.15.0/en/webhelp/pam-webhelp/" -}}
+{{- "https://documentation.softwareag.com/pam/10.15.1/en/webhelp/pam-webhelp/" -}}

--- a/themes/c8ydocs/layouts/shortcodes/link-apamadoc-api.html
+++ b/themes/c8ydocs/layouts/shortcodes/link-apamadoc-api.html
@@ -1,1 +1,1 @@
-{{- "https://documentation.softwareag.com/pam/10.15.0/en/webhelp/related/ApamaDoc/" -}}
+{{- "https://documentation.softwareag.com/pam/10.15.1/en/webhelp/related/ApamaDoc/" -}}


### PR DESCRIPTION
Changed the PAB and PAM version numbers in the URLs to the doc website: 10.16 for PAB and 10.15.1 for PAM.

@BeateRixen , do we already have a branch for 10.16? If yes, then please merge this into develop and also into the 10.16 branch. Thanks!