### PR TITLE
MTM-49965: reference-notifications: rework of non-persistent subscriptions and tokens 

### DIFF
--- a/content/reference/notifications-bundle/overview.md
+++ b/content/reference/notifications-bundle/overview.md
@@ -111,8 +111,8 @@ even if other consumers of the same non-persistent subscription
 are still receiving older messages that occurred while it was not connected. 
 
 When both a persistent and a non-persistent subscription are created with the same name, that is, with the same `subscription` body parameter value in the request, 
-they will be *separate*, independent subscriptions. Such subscriptions can vary by any other body parameters they choose: they do *not* have to be
-persistent and non-persistent variations of the same notification data, though it is not recommended as it may give rise to confusion.  
+they will be *separate*, independent subscriptions. Such subscriptions can vary by any other body parameters they choose: they do not *have* to be
+persistent and non-persistent variations of the same notification data, although to avoid confusion it is recommended to keep such subscriptions identical except for the `nonPersistent` parameter.  
 
 When a consumer creates a token for either a persistent or non-persistent subscription, 
 it **must** distinguish which type of subscription it is targeting by use of the `non-persistent` body parameter in the token creation request.

--- a/content/reference/notifications-bundle/overview.md
+++ b/content/reference/notifications-bundle/overview.md
@@ -125,7 +125,7 @@ Shared tokens allow parallelization of the consumer client workload for a notifi
 This is useful if the notifications would otherwise arrive at a higher rate than the consuming client application can process them.
 It has no impact on the rate of notification throughput within, and thus their egress from, {{< product-c8y-iot >}} core.
 
-When creating a token, an optional Boolean `shared` body parameter can be added to the request,
+When you create a token, you can add the optional Boolean body parameter `shared` to the request.
 and, if that is set to the value `true`, the created token will be shared.
 If this body parameter is not present or `false`, a token will be exclusive (not shared) by default.
 

--- a/content/reference/notifications-bundle/overview.md
+++ b/content/reference/notifications-bundle/overview.md
@@ -95,7 +95,7 @@ and, if that field is set to the value `true`, the created subscription will be 
 If this field is not present or `false`, a subscription will be persistent by default.
 
 Persistent subscriptions ensure consumers never miss a message if their connection is interrupted.
-They use replicated secondary storage to maintain large backlogs (within the constraints of any maximum backlog sizes)
+They use replicated secondary storage to maintain large backlogs (within the constraints of any configured backlog limits)
 and to maintain the consumers' positions in subscription notification streams.
 When a consumer of a persistent subscription has their connection interrupted,
 whether that is due to network issues or deliberate actions by the consumer,

--- a/content/reference/notifications-bundle/overview.md
+++ b/content/reference/notifications-bundle/overview.md
@@ -111,7 +111,7 @@ even if other consumers of the same non-persistent subscription
 are still receiving older messages that occurred while it was not connected. 
 
 When both a persistent and a non-persistent subscription are created with the same name, that is, with the same `subscription` body parameter value in the request, 
-they will be *separate*, independent subscriptions. Such subscriptions can vary by any other body parameters they choose: they do not *have* to be
+they are *separate*, independent subscriptions. Such subscriptions can vary by any other body parameters you choose. They do not have to be
 persistent and non-persistent variations of the same notification data, although to avoid confusion it is recommended to keep such subscriptions identical except for the `nonPersistent` parameter.  
 
 When a consumer creates a token for either a persistent or non-persistent subscription, 

--- a/content/reference/notifications-bundle/overview.md
+++ b/content/reference/notifications-bundle/overview.md
@@ -115,7 +115,7 @@ they are *separate*, independent subscriptions. Such subscriptions can vary by a
 persistent and non-persistent variations of the same notification data. However, we recommend you to keep such subscriptions identical except for the `nonPersistent` parameter to avoid confusion.  
 
 When a consumer creates a token for either a persistent or non-persistent subscription, 
-it **must** distinguish which type of subscription it is targeting by use of the `non-persistent` body parameter in the token creation request.
+it must distinguish which type of subscription it is targeting by using the `non-persistent` body parameter in the token creation request.
 Like for the subscription, this body parameter defaults to `false`, making the token target a persistent subscription. 
 Setting the body parameter to `true` in the token creation request targets a non-persistent subscription.  
 

--- a/content/reference/notifications-bundle/overview.md
+++ b/content/reference/notifications-bundle/overview.md
@@ -110,7 +110,7 @@ This will be the case for such temporarily disconnected consumers,
 even if other consumers of the same non-persistent subscription 
 are still receiving older messages that occurred while it was not connected. 
 
-When both a persistent and a non-persistent subscriptions are created with the same name (`subscription` field value in the request body) 
+When both a persistent and a non-persistent subscription are created with the same name, that is, with the same `subscription` field value in the request body, 
 they will be *separate*, independent subscriptions. Such subscriptions can vary by any other fields they choose: they do *not* have to be
 persistent and non-persistent variations of the same notification data, though using such similar subscriptions in notably different ways 
 may be surprising to others, so it may not be wise to do this unless they are otherwise the same. 

--- a/content/reference/notifications-bundle/overview.md
+++ b/content/reference/notifications-bundle/overview.md
@@ -139,7 +139,8 @@ each consumer receives a non-overlapping subset (share) of the notifications fro
 The collective ensemble of consumers sharing a token can be thought of as one logical consumer.
 Collectively, the ensemble will receive all notifications for the subscription. 
 
-The notification load is divided into shares dictated by a hash of the id of the source that generated the notification (typically a device id).
+The notification load is spread across the shared consumers according to the id of the source that generated the notification, typically a device id.
+All notifications for a given id will be delivered to the same consumer, and each consumer may be receiving notifications for many different ids.
 This means there is no benefit using shared tokens unless the notifications feeding the subscription are coming from multiple sources.
 Note that, as the shares are divided by a hash of the ids, it can result in an asymmetric balance of notification load across the shares if there are few source ids involved. This should even out for higher numbers of source ids.
 

--- a/content/reference/notifications-bundle/overview.md
+++ b/content/reference/notifications-bundle/overview.md
@@ -123,7 +123,7 @@ Setting the body parameter to `true` in the token creation request targets a non
 
 Shared tokens allow parallelization of the consumer client workload for a notification subscription.
 This is useful if the notifications would otherwise arrive at a higher rate than the consuming client application can process them.
-It has no impact on the rate of notification throughput within, and thus their egress from, Cumulocity core.
+It has no impact on the rate of notification throughput within, and thus their egress from, {{< product-c8y-iot >}} core.
 
 When creating a token, an optional Boolean `shared` body parameter can be added to the request,
 and, if that is set to the value `true`, the created token will be shared.

--- a/content/reference/notifications-bundle/overview.md
+++ b/content/reference/notifications-bundle/overview.md
@@ -147,7 +147,8 @@ The load should generally become more evenly distributed as the number of source
 
 In order to help keep the messages from a given set of source IDs stick to shared consumers in the face of connection interruptions, the consumer clients can provide an 
 optional `consumer` parameter in their connection URL string, in addition to their usual `token` parameter. 
-For example: two consumers identifying themselves as *instance1* and *instance2* would connect using URL paths
+
+For example: two consumers identifying themselves as *instance1* and *instance2* connect using URL paths
 `notification2/consumer?token=xyz&consumer=instance1` and `notification2/consumer?token=xyz&consumer=instance2`.
 
 Subscriptions are always unaware of the nature and number of their consumers: any number of shared and exclusive tokens can be created for the same subscription and they all operate independently, each receiving their own copy of the notifications. This means you can have multiple shared tokens for the same subscription and their load will only be divided up within the scope of each shared token.

--- a/content/reference/notifications-bundle/overview.md
+++ b/content/reference/notifications-bundle/overview.md
@@ -150,7 +150,7 @@ optional `consumer` parameter in their connection URL string, in addition to the
 For example: two consumers identifying themselves as *instance1* and *instance2* would connect using URL paths
 `notification2/consumer?token=xyz&consumer=instance1` and `notification2/consumer?token=xyz&consumer=instance2`.
 
-Subscriptions are always unaware of the nature and number of their consumers: any number of shared and exclusive tokens can created for the same subscription and they all operate independently, each receiving their own copy of the notifications. This means you can have multiple shared tokens for the same subscription and their load will only be divided up within the scope of each shared token.
+Subscriptions are always unaware of the nature and number of their consumers: any number of shared and exclusive tokens can be created for the same subscription and they all operate independently, each receiving their own copy of the notifications. This means you can have multiple shared tokens for the same subscription and their load will only be divided up within the scope of each shared token.
 
 ### Deleting subscriptions and unsubscribing a subscriber
 

--- a/content/reference/notifications-bundle/overview.md
+++ b/content/reference/notifications-bundle/overview.md
@@ -143,7 +143,7 @@ The notification load is spread across the shared consumers according to the id 
 All notifications for a given id will be delivered to the same consumer, and each consumer may be receiving notifications for many different ids.
 This means there is no benefit using shared tokens unless the notifications feeding the subscription are coming from multiple sources.
 Note that the load spreading algorithm may result in an asymmetric balance of notification load across the shares when there are few source IDs in the subscription.
-Load should generally become more evenly distributed as the number of sources increases.
+The load should generally become more evenly distributed as the number of sources increases.
 
 In order to help keep the messages from a given set of source ids "sticky" to shared consumers in the face of connection interruptions, the consumer clients can provide an 
 optional `consumer` parameter in their connection URL string, in addition to their usual `token` parameter. 

--- a/content/reference/notifications-bundle/overview.md
+++ b/content/reference/notifications-bundle/overview.md
@@ -142,7 +142,8 @@ Collectively, the ensemble will receive all notifications for the subscription.
 The notification load is spread across the shared consumers according to the id of the source that generated the notification, typically a device id.
 All notifications for a given id will be delivered to the same consumer, and each consumer may be receiving notifications for many different ids.
 This means there is no benefit using shared tokens unless the notifications feeding the subscription are coming from multiple sources.
-Note that, as the shares are divided by a hash of the ids, it can result in an asymmetric balance of notification load across the shares if there are few source ids involved. This should even out for higher numbers of source ids.
+Note that the load spreading algorithm may result in an asymmetric balance of notification load across the shares when there are few source ids in the subscription.
+Load should generally become more evenly distributed as the number of sources increases.
 
 In order to help keep the messages from a given set of source ids "sticky" to shared consumers in the face of connection interruptions, the consumer clients can provide an 
 optional `consumer` parameter in their connection URL string, in addition to their usual `token` parameter. 

--- a/content/reference/notifications-bundle/overview.md
+++ b/content/reference/notifications-bundle/overview.md
@@ -143,7 +143,7 @@ The notification load is divided into shares dictated by a hash of the id of the
 This means there is no benefit using shared tokens unless the notifications feeding the subscription are coming from multiple sources.
 Note that, as the shares are divided by a hash of the ids, it can result in an asymmetric balance of notification load across the shares if there are few source ids involved. This should even out for higher numbers of source ids.
 
-In order to help keep the messages from a given set of source ids sticky to consumer client shares in the face of consumer client connection interruptions, the consumer clients can provide an 
+In order to help keep the messages from a given set of source ids "sticky" to shared consumers in the face of connection interruptions, the consumer clients can provide an 
 optional `consumer` parameter in their connection URL string, in addition to their usual `token` parameter. 
 For example: two consumers identifying themselves as *instance1* and *instance2* would connect using URL paths
 `notification2/consumer?token=xyz&consumer=instance1` and `notification2/consumer?token=xyz&consumer=instance2`.

--- a/content/reference/notifications-bundle/overview.md
+++ b/content/reference/notifications-bundle/overview.md
@@ -95,13 +95,14 @@ and, if that field is set to the value `true`, the created subscription will be 
 If this field is not present or `false`, a subscription will be persistent by default.
 
 Persistent subscriptions ensure consumers never miss a message if their connection is interrupted.
-They use replicated secondary storage maintain larger backlogs (within the constraints of any maximum backlog sizes).
+They use replicated secondary storage to maintain large backlogs (within the constraints of any maximum backlog sizes)
+and to maintain the consumers' positions in subscription notification streams.
 When a consumer of a persistent subscription has their connection interrupted,
 whether that is due to network issues or deliberate actions by the consumer,
 upon reconnection they will continue to receive notifications from position they were at before the outage 
 (specifically, from the message after the last one they acknowledged successfully before the outage). 
 
-Non-persistent subscriptions are only buffered in memory.
+Non-persistent subscriptions are only buffered in memory and their consumers' positions are not persisted (not durable).
 When a consumer of a non-persistent subscription has their connection interrupted,
 upon reconnection they will start receiving notifications from the most recent message of the subscription,
 missing all other notifications that occurred during the connection outage. 

--- a/content/reference/notifications-bundle/overview.md
+++ b/content/reference/notifications-bundle/overview.md
@@ -120,9 +120,9 @@ Like for the subscription, this body parameter defaults to `false`, making the t
 Setting the body parameter to `true` in the token creation request targets a non-persistent one.  
 
 ### Shared tokens
-Shared tokens allow parallelization of the consumer client workload.
+Shared tokens allow parallelization of the consumer client workload for a notification subscription.
 This is useful if the notifications would otherwise arrive at a higher rate than the consuming client application can process them.
-It has no impact on the rate of notification throughput within, and thus their egress from, Cumulocity.
+It has no impact on the rate of notification throughput within, and thus their egress from, Cumulocity core.
 
 When creating a token, an optional Boolean `shared` body parameter can be added to the request,
 and, if that is set to the value `true`, the created token will be shared.

--- a/content/reference/notifications-bundle/overview.md
+++ b/content/reference/notifications-bundle/overview.md
@@ -99,7 +99,7 @@ They use replicated secondary storage to maintain large backlogs (within the con
 and to maintain the consumers' positions in subscription notification streams.
 When a consumer of a persistent subscription has their connection interrupted,
 whether that is due to network issues or deliberate actions by the consumer,
-upon reconnection they will continue to receive notifications from position they were at before the outage 
+upon reconnection they will continue to receive notifications from the position they were at before the outage 
 (specifically, from the message after the last one they acknowledged successfully before the outage). 
 
 Non-persistent subscriptions are only buffered in memory and their consumers' positions are not persisted (not durable).

--- a/content/reference/notifications-bundle/overview.md
+++ b/content/reference/notifications-bundle/overview.md
@@ -110,7 +110,7 @@ This will be the case for such temporarily disconnected consumers,
 even if other consumers of the same non-persistent subscription 
 are still receiving older messages that occurred while it was not connected. 
 
-When both a persistent and a non-persistent subscription are created with the same name, that is, with the same `subscription` body parameter value in the request, 
+If you create both a persistent and a non-persistent subscription with the same name, that is, with the same `subscription` body parameter value in the request, 
 they are *separate*, independent subscriptions. Such subscriptions can vary by any other body parameters you choose. They do not have to be
 persistent and non-persistent variations of the same notification data. However, we recommend you to keep such subscriptions identical except for the `nonPersistent` parameter to avoid confusion.  
 

--- a/content/reference/notifications-bundle/overview.md
+++ b/content/reference/notifications-bundle/overview.md
@@ -126,23 +126,23 @@ This is useful if the notifications would otherwise arrive at a higher rate than
 It has no impact on the rate of notification throughput within, and thus their egress from, {{< product-c8y-iot >}} core.
 
 When you create a token, you can add the optional Boolean body parameter `shared` to the request.
-and, if that is set to the value `true`, the created token will be shared.
-If this body parameter is not present or `false`, a token will be exclusive (not shared) by default.
+If it is set to `true`, the created token is shared.
+If it is not present or `false`, the token is exclusive (not shared).
 
-If a consumer's token is *not* shared, the consumer is an **exclusive** consumer.
-Only one consumer client can connect using an exclusive token: attempts to connect further consumers with the same exclusive token will result in error.
-An exclusive consumer will receive a copy of all notifications from the subscription its token is for.
+If a consumer's token is not shared, the consumer is an *exclusive* consumer.
+Only one consumer client can connect using an exclusive token. An attempt to connect further consumers with the same exclusive token results in an error.
+An exclusive consumer receives a copy of all notifications from the subscription its token is for.
 
-If a consumer's token is shared, the consumer is a **shared** consumer. Additional consumer clients can connect using the same token.
-When only one shared consumer is connected, it receives a copy of all notifications from subscription.
+If a consumer's token is shared, the consumer is a *shared consumer*. Additional consumer clients can connect using the same token.
+If only one shared consumer is connected, it receives a copy of all notifications from the subscription.
 As additional consumer clients connect using the same token, the consumers' notification load is rebalanced so that 
 each consumer receives a non-overlapping subset (share) of the notifications from the subscription. 
-The collective ensemble of consumers sharing a token can be thought of as one logical consumer.
-Collectively, the ensemble will receive all notifications for the subscription. 
+The set of consumers sharing a token can be thought of as a single logical consumer.
+Collectively, the set receives all notifications for the subscription. 
 
-The notification load is spread across the shared consumers according to the id of the source that generated the notification, typically a device id.
-All notifications for a given id will be delivered to the same consumer, and each consumer may be receiving notifications for many different ids.
-This means there is no benefit using shared tokens unless the notifications feeding the subscription are coming from multiple sources.
+The notification load is spread across the shared consumers according to the ID of the source that generated the notification, typically a device ID.
+All notifications for a given ID will be delivered to the same consumer. Each consumer may receive notifications for many different IDs.
+This means that there is no benefit using shared tokens unless the notifications feeding the subscription are coming from multiple sources.
 Note that the load spreading algorithm may result in an asymmetric balance of notification load across the shares when there are few source IDs in the subscription.
 The load should generally become more evenly distributed as the number of sources increases.
 

--- a/content/reference/notifications-bundle/overview.md
+++ b/content/reference/notifications-bundle/overview.md
@@ -102,7 +102,7 @@ whether that is due to network issues or deliberate actions by the consumer,
 upon reconnection they will continue to receive notifications from the position they were at before the outage 
 (specifically, from the message after the last one they acknowledged successfully before the outage). 
 
-Non-persistent subscriptions are only buffered in memory and their consumers' positions are not persisted (not durable).
+Non-persistent subscriptions are only buffered in memory and their consumers' positions are not persisted across disconnections of the consumer.
 When a consumer of a non-persistent subscription has their connection interrupted,
 upon reconnection they will start receiving notifications from the most recent message of the subscription,
 missing all other notifications that occurred during the connection outage. 

--- a/content/reference/notifications-bundle/overview.md
+++ b/content/reference/notifications-bundle/overview.md
@@ -92,7 +92,7 @@ The {{< product-c8y-iot >}} microservice Java SDK [TokenApi](https://github.com/
 
 When you create a subscription, you can add the optional Boolean body parameter `nonPersistent` to the request.
 If it is set to `true`, the created subscription is non-persistent. 
-If this body parameter is not present or `false`, the subscription will be persistent by default.
+If it is not present or `false`, the subscription will be persistent.
 
 Persistent subscriptions ensure consumers never miss a message if their connection is interrupted.
 They use replicated secondary storage to maintain large backlogs (within the constraints of any configured backlog limits)

--- a/content/reference/notifications-bundle/overview.md
+++ b/content/reference/notifications-bundle/overview.md
@@ -120,6 +120,7 @@ For the subscription, this body parameter defaults to `false`, making the token 
 Setting the body parameter to `true` in the token creation request targets a non-persistent subscription.  
 
 ### Shared tokens
+
 Shared tokens allow parallelization of the consumer client workload for a notification subscription.
 This is useful if the notifications would otherwise arrive at a higher rate than the consuming client application can process them.
 It has no impact on the rate of notification throughput within, and thus their egress from, Cumulocity core.

--- a/content/reference/notifications-bundle/overview.md
+++ b/content/reference/notifications-bundle/overview.md
@@ -116,7 +116,7 @@ persistent and non-persistent variations of the same notification data. However,
 
 When a consumer creates a token for either a persistent or non-persistent subscription, 
 it must distinguish which type of subscription it is targeting by using the `non-persistent` body parameter in the token creation request.
-Like for the subscription, this body parameter defaults to `false`, making the token target a persistent subscription. 
+For the subscription, this body parameter defaults to `false`, making the token target a persistent subscription. 
 Setting the body parameter to `true` in the token creation request targets a non-persistent subscription.  
 
 ### Shared tokens

--- a/content/reference/notifications-bundle/overview.md
+++ b/content/reference/notifications-bundle/overview.md
@@ -112,7 +112,7 @@ are still receiving older messages that occurred while it was not connected.
 
 When both a persistent and a non-persistent subscription are created with the same name, that is, with the same `subscription` body parameter value in the request, 
 they are *separate*, independent subscriptions. Such subscriptions can vary by any other body parameters you choose. They do not have to be
-persistent and non-persistent variations of the same notification data, although to avoid confusion it is recommended to keep such subscriptions identical except for the `nonPersistent` parameter.  
+persistent and non-persistent variations of the same notification data. However, we recommend you to keep such subscriptions identical except for the `nonPersistent` parameter to avoid confusion.  
 
 When a consumer creates a token for either a persistent or non-persistent subscription, 
 it **must** distinguish which type of subscription it is targeting by use of the `non-persistent` body parameter in the token creation request.

--- a/content/reference/notifications-bundle/overview.md
+++ b/content/reference/notifications-bundle/overview.md
@@ -151,7 +151,7 @@ optional `consumer` parameter in their connection URL string, in addition to the
 For example: two consumers identifying themselves as *instance1* and *instance2* connect using URL paths
 `notification2/consumer?token=xyz&consumer=instance1` and `notification2/consumer?token=xyz&consumer=instance2`.
 
-Subscriptions are always unaware of the nature and number of their consumers: any number of shared and exclusive tokens can be created for the same subscription and they all operate independently, each receiving their own copy of the notifications. This means you can have multiple shared tokens for the same subscription and their load will only be divided up within the scope of each shared token.
+Subscriptions are always unaware of the nature and number of their consumers: any number of shared and exclusive tokens can be created for the same subscription and they all operate independently, each receiving their own copy of the notifications. This means you can have multiple shared tokens for the same subscription and their load is only divided within the scope of each shared token.
 
 ### Deleting subscriptions and unsubscribing a subscriber
 

--- a/content/reference/notifications-bundle/overview.md
+++ b/content/reference/notifications-bundle/overview.md
@@ -142,7 +142,7 @@ Collectively, the ensemble will receive all notifications for the subscription.
 The notification load is spread across the shared consumers according to the id of the source that generated the notification, typically a device id.
 All notifications for a given id will be delivered to the same consumer, and each consumer may be receiving notifications for many different ids.
 This means there is no benefit using shared tokens unless the notifications feeding the subscription are coming from multiple sources.
-Note that the load spreading algorithm may result in an asymmetric balance of notification load across the shares when there are few source ids in the subscription.
+Note that the load spreading algorithm may result in an asymmetric balance of notification load across the shares when there are few source IDs in the subscription.
 Load should generally become more evenly distributed as the number of sources increases.
 
 In order to help keep the messages from a given set of source ids "sticky" to shared consumers in the face of connection interruptions, the consumer clients can provide an 

--- a/content/reference/notifications-bundle/overview.md
+++ b/content/reference/notifications-bundle/overview.md
@@ -90,9 +90,9 @@ The {{< product-c8y-iot >}} microservice Java SDK [TokenApi](https://github.com/
 
 ### Non-persistent subscriptions and their tokens
 
-When creating a subscription, an optional Boolean `nonPersistent` field can be added to the request body, 
-and, if that field is set to the value `true`, the created subscription will be non-persistent. 
-If this field is not present or `false`, a subscription will be persistent by default.
+When creating a subscription, an optional Boolean `nonPersistent` body parameter can be added to the request, 
+and, if that is set to the value `true`, the created subscription will be non-persistent. 
+If this body parameter is not present or `false`, a subscription will be persistent by default.
 
 Persistent subscriptions ensure consumers never miss a message if their connection is interrupted.
 They use replicated secondary storage to maintain large backlogs (within the constraints of any configured backlog limits)
@@ -110,24 +110,23 @@ This will be the case for such temporarily disconnected consumers,
 even if other consumers of the same non-persistent subscription 
 are still receiving older messages that occurred while it was not connected. 
 
-When both a persistent and a non-persistent subscription are created with the same name, that is, with the same `subscription` field value in the request body, 
-they will be *separate*, independent subscriptions. Such subscriptions can vary by any other fields they choose: they do *not* have to be
-persistent and non-persistent variations of the same notification data, though using such similar subscriptions in notably different ways 
-may be surprising to others, so it may not be wise to do this unless they are otherwise the same. 
+When both a persistent and a non-persistent subscription are created with the same name, that is, with the same `subscription` body parameter value in the request, 
+they will be *separate*, independent subscriptions. Such subscriptions can vary by any other body parameters they choose: they do *not* have to be
+persistent and non-persistent variations of the same notification data, though it is not recommended as it may give rise to confusion.  
 
-When a consumer creates a token for either of these, 
-it can distinguish which subscription it is targeting by use of the `non-persistent` field in the token creation request.
-Like for the subscription, this field defaults to `false`, making the token target the persistent subscription. 
-Setting this field to `true` in the token creation request targets the non-persistent one.  
+When a consumer creates a token for either a persistent or non-persistent subscription, 
+it **must** distinguish which type of subscription it is targeting by use of the `non-persistent` body parameter in the token creation request.
+Like for the subscription, this body parameter defaults to `false`, making the token target a persistent subscription. 
+Setting the body parameter to `true` in the token creation request targets a non-persistent one.  
 
 ### Shared tokens
 Shared tokens allow parallelization of the consumer client workload.
 This is useful if the notifications would otherwise arrive at a higher rate than the consuming client application can process them.
 It has no impact on the rate of notification throughput within, and thus their egress from, Cumulocity.
 
-When creating a token, an optional Boolean `shared` field can be added to the request body,
-and, if that field is set to the value `true`, the created token will be shared.
-If this field is not present or `false`, a token will be exclusive (not shared) by default.
+When creating a token, an optional Boolean `shared` body parameter can be added to the request,
+and, if that is set to the value `true`, the created token will be shared.
+If this body parameter is not present or `false`, a token will be exclusive (not shared) by default.
 
 If a consumer's token is *not* shared, the consumer is an **exclusive** consumer.
 Only one consumer client can connect using an exclusive token: attempts to connect further consumers with the same exclusive token will result in error.

--- a/content/reference/notifications-bundle/overview.md
+++ b/content/reference/notifications-bundle/overview.md
@@ -117,7 +117,7 @@ persistent and non-persistent variations of the same notification data, though i
 When a consumer creates a token for either a persistent or non-persistent subscription, 
 it **must** distinguish which type of subscription it is targeting by use of the `non-persistent` body parameter in the token creation request.
 Like for the subscription, this body parameter defaults to `false`, making the token target a persistent subscription. 
-Setting the body parameter to `true` in the token creation request targets a non-persistent one.  
+Setting the body parameter to `true` in the token creation request targets a non-persistent subscription.  
 
 ### Shared tokens
 Shared tokens allow parallelization of the consumer client workload for a notification subscription.

--- a/content/reference/notifications-bundle/overview.md
+++ b/content/reference/notifications-bundle/overview.md
@@ -90,8 +90,8 @@ The {{< product-c8y-iot >}} microservice Java SDK [TokenApi](https://github.com/
 
 ### Non-persistent subscriptions and their tokens
 
-When creating a subscription, an optional Boolean `nonPersistent` body parameter can be added to the request, 
-and, if that is set to the value `true`, the created subscription will be non-persistent. 
+When you create a subscription, you can add the optional Boolean body parameter `nonPersistent` to the request.
+If it is set to `true`, the created subscription is non-persistent. 
 If this body parameter is not present or `false`, the subscription will be persistent by default.
 
 Persistent subscriptions ensure consumers never miss a message if their connection is interrupted.

--- a/content/reference/notifications-bundle/overview.md
+++ b/content/reference/notifications-bundle/overview.md
@@ -94,7 +94,7 @@ When you create a subscription, you can add the optional Boolean body parameter 
 If it is set to `true`, the created subscription is non-persistent. 
 If it is not present or `false`, the subscription will be persistent.
 
-Persistent subscriptions ensure consumers never miss a message if their connection is interrupted.
+Persistent subscriptions ensure that consumers never miss a message if their connection is interrupted.
 They use replicated secondary storage to maintain large backlogs (within the constraints of any configured backlog limits)
 and to maintain the consumers' positions in subscription notification streams.
 When a consumer of a persistent subscription has their connection interrupted,

--- a/content/reference/notifications-bundle/overview.md
+++ b/content/reference/notifications-bundle/overview.md
@@ -92,7 +92,7 @@ The {{< product-c8y-iot >}} microservice Java SDK [TokenApi](https://github.com/
 
 When creating a subscription, an optional Boolean `nonPersistent` body parameter can be added to the request, 
 and, if that is set to the value `true`, the created subscription will be non-persistent. 
-If this body parameter is not present or `false`, a subscription will be persistent by default.
+If this body parameter is not present or `false`, the subscription will be persistent by default.
 
 Persistent subscriptions ensure consumers never miss a message if their connection is interrupted.
 They use replicated secondary storage to maintain large backlogs (within the constraints of any configured backlog limits)
@@ -130,10 +130,10 @@ If this body parameter is not present or `false`, a token will be exclusive (not
 
 If a consumer's token is *not* shared, the consumer is an **exclusive** consumer.
 Only one consumer client can connect using an exclusive token: attempts to connect further consumers with the same exclusive token will result in error.
-An exclusive consumer will receive all notifications from the subscription its token is for.
+An exclusive consumer will receive a copy of all notifications from the subscription its token is for.
 
 If a consumer's token is shared, the consumer is a **shared** consumer. Additional consumer clients can connect using the same token.
-When only one shared consumer is connected, it receives all notifications from subscription.
+When only one shared consumer is connected, it receives a copy of all notifications from subscription.
 As additional consumer clients connect using the same token, the consumers' notification load is rebalanced so that 
 each consumer receives a non-overlapping subset (share) of the notifications from the subscription. 
 The collective ensemble of consumers sharing a token can be thought of as one logical consumer.
@@ -143,12 +143,12 @@ The notification load is divided into shares dictated by a hash of the id of the
 This means there is no benefit using shared tokens unless the notifications feeding the subscription are coming from multiple sources.
 Note that, as the shares are divided by a hash of the ids, it can result in an asymmetric balance of notification load across the shares if there are few source ids involved. This should even out for higher numbers of source ids.
 
-In order to help keep the messages from a given set of source ids sticky to consumer client shares in the face of client connection interruptions, the consumers can provide an 
-optional `consumer` parameter to their connection URL string, in addition to their usual `token` parameter. 
+In order to help keep the messages from a given set of source ids sticky to consumer client shares in the face of consumer client connection interruptions, the consumer clients can provide an 
+optional `consumer` parameter in their connection URL string, in addition to their usual `token` parameter. 
 For example: two consumers identifying themselves as *instance1* and *instance2* would connect using URL paths
 `notification2/consumer?token=xyz&consumer=instance1` and `notification2/consumer?token=xyz&consumer=instance2`.
 
-Subscriptions are always unaware of the nature of their consumers: any number of shared and exlusive tokens can created for the same subscription and they all operate independently, each recieving their own copy of the notificaitons. This means you can have multiple shared tokens for the same subscription and their load will only be divided up within the scope of each shared token.
+Subscriptions are always unaware of the nature and number of their consumers: any number of shared and exclusive tokens can created for the same subscription and they all operate independently, each receiving their own copy of the notifications. This means you can have multiple shared tokens for the same subscription and their load will only be divided up within the scope of each shared token.
 
 ### Deleting subscriptions and unsubscribing a subscriber
 

--- a/content/reference/notifications-bundle/overview.md
+++ b/content/reference/notifications-bundle/overview.md
@@ -145,7 +145,7 @@ This means there is no benefit using shared tokens unless the notifications feed
 Note that the load spreading algorithm may result in an asymmetric balance of notification load across the shares when there are few source IDs in the subscription.
 The load should generally become more evenly distributed as the number of sources increases.
 
-In order to help keep the messages from a given set of source ids "sticky" to shared consumers in the face of connection interruptions, the consumer clients can provide an 
+In order to help keep the messages from a given set of source IDs stick to shared consumers in the face of connection interruptions, the consumer clients can provide an 
 optional `consumer` parameter in their connection URL string, in addition to their usual `token` parameter. 
 For example: two consumers identifying themselves as *instance1* and *instance2* would connect using URL paths
 `notification2/consumer?token=xyz&consumer=instance1` and `notification2/consumer?token=xyz&consumer=instance2`.


### PR DESCRIPTION
Near complete rewrite of the (new to 1016) Shared and Non-persistent Notifications2 section in the reference manual.

Needs to be merged to pending 1016 release branch quickly