### PR TITLE
Revert "DM-2000: Skip nodes without defined namespace"

### DIFF
--- a/content/protocol-integration/opcua-bundle/authentication.md
+++ b/content/protocol-integration/opcua-bundle/authentication.md
@@ -54,9 +54,6 @@ When you navigate to the child device of the gateway, the **Address space** tab 
 
 The address space is automatically scanned when a connection between the gateway and the server is established. The duration of the scan depends on the size of the address space. The address space information is stored locally once it is scanned and then used by this applying process. If the address space information is not yet available, for example, the address space has not been scanned, another scan will be triggered without synchronizing data into {{< product-c8y-iot >}}. Performing another address space operation will update the address space information.
 
-In case a node is found with a non-existing namespace entry the scan process skips this node and continues.
-An error entry will be written to the log file to provide information (more information available in debug level).
-
 ![Gateway events tab](/images/device-protocols/opcua/opcua-address.png)
 
 ### Monitoring measurements


### PR DESCRIPTION
Reverts SoftwareAG/c8y-docs#808

@torsSAG  We need to revert it because your change is not in 10.17. Please graft the reversal back to 10.17. We remerge the change to develop once done.