### PR TITLE
Karin should be able to give CODEOWNER approval to apama documentation

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,3 +7,5 @@
 * @BeateRixen marlene.windel@softwareag.com @rssag
 
 /content/users-guide/device-management-bundle/ @Oezge-Akin
+
+/content/apama/ @kailol-sag 


### PR DESCRIPTION
She was given Admin access to the whole repo so that we can shortcut the need to have Beate or Richard approve, but CODEOWNER access seems more 'legitimate'