### PR TITLE
[MTM-51784] Fixed missing sections in `index.json`s

### DIFF
--- a/content/users-guide/administration-bundle/managing-applications.md
+++ b/content/users-guide/administration-bundle/managing-applications.md
@@ -26,10 +26,10 @@ helpcontent:
 
 
     Click on an application to view the application details. To add an application, click **Add application** and follow the instructions in the wizard, see also the *User guide*."
-    label: packages
+  - label: packages
     title: Packages
     content: "On the **Packages** tab, you will find a list of all packages available in your tenant. Packages are combinations of plugins and blueprints which can be packed together into a single file and deployed to the platform. To add a new package, click **Add package** at the top right."
-    label: features
+  - label: features
     title: Features
     content: "On the **Features** tab, you will find a list of all features subscribed to your tenant. Features are applications which are built-in and not represented by an explicit artifact (like microservices or web applications)."
 

--- a/content/users-guide/device-management-bundle/monitoring-and-controlling-devices.md
+++ b/content/users-guide/device-management-bundle/monitoring-and-controlling-devices.md
@@ -21,13 +21,13 @@ helpcontent:
 
 
   By clicking one of the buttons at the top, the corresponding section will be hidden. Click it once more to make the section visible again. Within each section, the alarms are sorted by their occurrence, displaying the most recent alarm first."
-  label: single-operations
+- label: single-operations
   title: Single operations
   content: "Using operations, you can control devices remotely. **Single operations** show all operations executed on a single device.
 
 
   Single operations can have one of the following four statuses: PENDING, EXECUTED, SUCCESSFUL, FAILED. For each operation, the name, status, and device is provided. Clicking the device leads you to the detailed view of the particular device."
-  -label: bulk-operations
+- label: bulk-operations
   title: Bulk operations
   content: "**Bulk operations** are single operations executed on a set of devices.
 

--- a/content/users-guide/enterprise-tenant-bundle/data-broker.md
+++ b/content/users-guide/enterprise-tenant-bundle/data-broker.md
@@ -8,10 +8,10 @@ helpcontent:
   - label: data-broker
     title: Data broker
     content: "Data broker lets you share data selectively with other tenants such as devices (and more generically, managed objects), events, alarms, measurements, or operations."
-    label: data-connector
+  - label: data-connector
     title: Data connector
     content: "The **Data connectors** page shows a list of all currently defined data connectors with their status. A data connector describes the subset of the data that you would like to send to a destination tenant as well as the URL of that destination tenant. To add a data connector, click **Add data connector** at the top right."
-    label: data-subscriptions
+  - label: data-subscriptions
     title: Data subscriptions
     content: "The **Data subscriptions** page shows a list of all currently defined data forwarded to your tenant. For each subscription, the name, target tenant and status (enabled or disabled) are provided on a card. Use the toggle to temporarily stop forwarding data to your tenant."
 ---

--- a/content/users-guide/enterprise-tenant-bundle/managing-tenants.md
+++ b/content/users-guide/enterprise-tenant-bundle/managing-tenants.md
@@ -11,7 +11,7 @@ helpcontent:
 
 
     To create a subtenant click **Create tenant** at the top right."
-    label: tenant-policies
+  - label: tenant-policies
     title: Tenant policies
     content: "During tenant creation, tenant options and retention rules may be specified. This can easily be done by using a tenant policy, which defines a set of tenant options and retention rules. Creating a tenant policy with a specific set of options and rules saves time when creating multiple tenants with the same settings.
 


### PR DESCRIPTION
Incorrect list markup caused some sections to be missing from `index.json` files.

Before:
![2023-02-27_14-28](https://user-images.githubusercontent.com/92171763/221580770-24edafad-30f7-4e0b-b7e4-8f3e197b1ca1.png)

After:
![2023-02-27_14-49](https://user-images.githubusercontent.com/92171763/221580738-a37a281b-a7cf-4f9b-8add-64c73e71a90f.png)

Should be grafted to earlier releases, too.