### PR TITLE
MTM-42115-Treatment-of-Unicode-word-characters-in-passwords

### DIFF
--- a/content/users-guide/getting-started-bundle/user-settings.md
+++ b/content/users-guide/getting-started-bundle/user-settings.md
@@ -121,7 +121,7 @@ By default, the password must meet the following conditions:
   * uppercase letters: `[A-Z]`, for example `ABCDEF`.
   * lowercase letters: `[a-z]`, for example `abcdef`.
   * numbers: `[0-9]`, for example: `123456`.
-  * platform accepts any other symbol as special character: `[^0-9a-zA-Z]`, for example `!@#$%^`.
+  * any other symbol as special character: `[^0-9a-zA-Z]`, for example `!@#$%^`.
 
 {{< c8y-admon-info >}}
 The password rules can be configured by the administrator, that means, your administrator can configure your account to enforce a password policy. You may be required to pick a strong password for example or to change your password regularly.

--- a/content/users-guide/getting-started-bundle/user-settings.md
+++ b/content/users-guide/getting-started-bundle/user-settings.md
@@ -117,7 +117,11 @@ Make sure to select a strong password. To support you in doing so, a password st
 By default, the password must meet the following conditions:
 
 * Consist of at least eight characters (this parameter can be configured by the {{< management-tenant >}}, see [Administration > Platform configuration settings](/users-guide/administration/#platform-configuration-settings).)
-* Include each of the following character types: uppercase letters, lowercase letters, numbers and symbols.
+* Include each of the following character types:
+  * uppercase letters: `[A-Z]`, for example `ABCDEF`.
+  * lowercase letters: `[a-z]`, for example `abcdef`.
+  * numbers: `[0-9]`, for example: `123456`.
+  * platform accepts any other symbol as special character: `[^0-9a-zA-Z]`, for example `!@#$%^`.
 
 {{< c8y-admon-info >}}
 The password rules can be configured by the administrator, that means, your administrator can configure your account to enforce a password policy. You may be required to pick a strong password for example or to change your password regularly.

--- a/content/users-guide/getting-started-bundle/user-settings.md
+++ b/content/users-guide/getting-started-bundle/user-settings.md
@@ -121,7 +121,7 @@ By default, the password must meet the following conditions:
   * uppercase letters: `[A-Z]`, for example `ABCDEF`.
   * lowercase letters: `[a-z]`, for example `abcdef`.
   * numbers: `[0-9]`, for example: `123456`.
-  * any other symbol as special character: `[^0-9a-zA-Z]`, for example `!@#$%^`.
+  * any other symbol as a special character: `[^0-9a-zA-Z]`, for example `!@#$%^`.
 
 {{< c8y-admon-info >}}
 The password rules can be configured by the administrator, that means, your administrator can configure your account to enforce a password policy. You may be required to pick a strong password for example or to change your password regularly.

--- a/content/users-guide/getting-started-bundle/user-settings.md
+++ b/content/users-guide/getting-started-bundle/user-settings.md
@@ -121,7 +121,7 @@ By default, the password must meet the following conditions:
   * uppercase letters: `[A-Z]`, for example `ABCDEF`.
   * lowercase letters: `[a-z]`, for example `abcdef`.
   * numbers: `[0-9]`, for example: `123456`.
-  * any other symbol as a special character: `[^0-9a-zA-Z]`, for example `!@#$%^`.
+  * any other symbol from following list `` `~!@#$%^&*()_|+-=?;:'",.<>{}[]\/`` as a special character, for example `!@#$%^`.
 
 {{< c8y-admon-info >}}
 The password rules can be configured by the administrator, that means, your administrator can configure your account to enforce a password policy. You may be required to pick a strong password for example or to change your password regularly.


### PR DESCRIPTION
* provided more precise description for allowed characters in a password acceptable by the platform

![image](https://user-images.githubusercontent.com/89575984/236285289-32e660b9-cfb3-41a8-8d32-2a4cb4e8762e.png)

