### PR TITLE
feature/MTM-50214/MTM-53144-documentation-improvements

### DIFF
--- a/content/users-guide/administration-bundle/managing-permissions.md
+++ b/content/users-guide/administration-bundle/managing-permissions.md
@@ -94,11 +94,11 @@ Furthermore, the following pre-configured roles are initially provided.
 </tr>
 <tr>
 <td align="left">Global Manager</td>
-<td align="left">Can read and write all devices.</td>
+<td align="left">Can read and write all data from all devices.</td>
 </tr>
 <tr>
 <td align="left">Global Reader</td>
-<td align="left">Can read all devices.</td>
+<td align="left">Can read all data from all devices.</td>
 </tr>
 <tr>
 <td align="left">Global User Manager</td>

--- a/content/users-guide/administration-bundle/managing-users.md
+++ b/content/users-guide/administration-bundle/managing-users.md
@@ -56,7 +56,7 @@ Users which are using single sign-on cannot change the password of users which a
 
 ### To view users
 
-To view all users in your tenant, click **Users** in the **Account** menu in the navigator.
+To view all users in your tenant, click **Users** in the **Accounts** menu in the navigator.
 
 ![Expanded view](/images/users-guide/Administration/admin-users-list.png)
 
@@ -81,63 +81,67 @@ Initially, the **User** page only shows the top-level users. To see all users in
 If single sign-on is enabled for your tenant, a message will show up which reminds you that you are about to create a local user which will not be able to login via single sign-on. Create new users in **My Cloud** instead, accessible through the application switcher in the upper right corner, to enable them using the single sign-on feature.
   {{< /c8y-admon-info >}}
 
-2. At the left of the **New user** window, provide the following information to identify the user:
+   2. At the left of the **New user** window, provide the following information to identify the user:
 
-	<table>
-	<thead>
-	<colgroup>
-	<col style="width: 20%;">
-	<col style="width: 80%;">
-	</colgroup>
-	<tr>
-	<th align="left">Field</th>
-	<th align="left">Description</th>
-	</tr>
-	</thead>
-	<tbody>
-	<tr>
-	<td align="left">Username</td>
-	<td align="left">Serves as a unique user ID to identify the user at the system. Note that the username cannot be changed once the user has been created. This field is mandatory.</td>
-	</tr>
-	<tr>
-	<td align="left">Login alias</td>
-	<td align="left">In addition to the username, an optional alias can be provided to be used to log on. In contrast to username, this alias may be changed if required. User alias is not supported for devices.</td>
-	</tr>
-	<tr>
-	<td align="left">Status</td>
-	<td align="left">Enable/disable the user account here. If the user account is disabled the user cannot login.</td>
-	</tr>
-	<tr>
-	<td align="left">Email</td>
-	<td align="left">A valid email address. This field is mandatory.</td>
-	</tr>
-	<tr>
-	<td align="left">First name</td>
-	<td align="left">First name of the user. When the user is logged in, this name appears at the right of the top bar on the <strong>User</strong> button.</td>
-	</tr>
-	<tr>
-	<td align="left">Last name</td>
-	<td align="left">Last name of the user.</td>
-	</tr>
-	<tr>
-	<td align="left">Telephone</td>
-	<td align="left">A valid phone number. The phone number is required if the user is configured to use two-factor authentication.</td>
-	</tr>
-	<tr>
-	<td align="left">Owner</td>
-	<td align="left">Another user that manages ("owns") the new user. Select a user from the dropdown list and click <strong>Done</strong> to confirm. Refer to <a href="../../users-guide/enterprise-tenant#user-hierarchies">Managing user hierarchies</a> for details on user hierarchies.</td>
-	</tr>
-	<tr>
-	<td align="left">Delegated by</td>
-	<td align="left">Can be activated to delegate user hierarchies and permissions to the user. Refer to <a href="../../users-guide/enterprise-tenant#user-hierarchies">Managing user hierarchies</a> for details on delegation.</td>
-	</tr>
-	</tbody>
-	</table>
+       <table>
+           <thead>
+               <colgroup>
+                   <col style="width: 20%;">
+                   <col style="width: 80%;">
+               </colgroup>
+               <tr>
+                   <th align="left">Field</th>
+                   <th align="left">Description</th>
+               </tr>
+           </thead>
+           <tbody>
+               <tr>
+                   <td align="left">Username</td>
+                   <td align="left">Serves as a unique user ID to identify the user at the system. Note that the username cannot be changed once the user has been created. This field is mandatory.</td>
+               </tr>
+               <tr>
+                   <td align="left">Login alias</td>
+                   <td align="left">In addition to the username, an optional alias can be provided to be used to log on. In contrast to username, this alias may be changed if required. User alias is not supported for devices.
+	  					{{<c8y-admon-info>}} Login alias can not be same as username {{</c8y-admon-info>}}
+                   </td>
+               </tr>
+               <tr>
+                   <td align="left">Status</td>
+                   <td align="left">Enable/disable the user account here. If the user account is disabled the user cannot login.</td>
+               </tr>
+               <tr>
+                   <td align="left">Email</td>
+                   <td align="left">A valid email address. This field is mandatory.</td>
+               </tr>
+               <tr>
+                   <td align="left">First name</td>
+                   <td align="left">First name of the user.</td>
+               </tr>
+               <tr>
+                   <td align="left">Last name</td>
+                   <td align="left">Last name of the user.</td>
+               </tr>
+               <tr>
+                   <td align="left">Telephone</td>
+                   <td align="left">A valid phone number. The phone number is required if the user is configured to use two-factor authentication.</td>
+               </tr>
+               <tr>
+                   <td align="left">Owner</td>
+                   <td align="left">Another user that manages ("owns") the new user. Select a user from the dropdown list and click <strong>Done</strong> to confirm. Refer to <a href="../../users-guide/enterprise-tenant#user-hierarchies">Managing user hierarchies</a> for details on user hierarchies.</td>
+               </tr>
+               <tr>
+                   <td align="left">Delegated by</td>
+                   <td align="left">Can be activated to delegate user hierarchies and permissions to the user. Refer to <a href="../../users-guide/enterprise-tenant#user-hierarchies">Managing user hierarchies</a> for details on delegation.</td>
+               </tr>
+           </tbody>
+       </table>
 
+       {{<c8y-admon-related>}} For additional information see  [User options and settings](/users-guide/getting-started/#user-settings). 
+       {{</c8y-admon-related>}}
 3. Select the login options for the user.
 	* 	**Two-factor authentication (SMS)** - if selected, the user will receive a verification code via SMS which is required to complete the authentication. The SMS will be sent to the phone number configured above. For details refer to [Two-factor authentication](/users-guide/administration/#tfa).
-	* **User must reset password on next login** - if selected, you must provide a password which the user must reset on the next login. Enter a password and confirm it. While entering the password, the strength of the password will be checked. See [To change your password](/users-guide/getting-started/#change-password) for further information on password reset and strenth.  
-	* **Send password reset link as email** - if selected, the user will receive an email message with a link to set a password. The email will be sent to the email address configured above.
+	* **User must reset password on next login** - if selected, you must provide a password which the user must reset on the next login. Enter a password and confirm it. While entering the password, the strength of the password will be checked. See [To change your password](/users-guide/getting-started/#change-password) for further information on password reset and strength.  
+	* **Send password reset link as email** - if selected, the user will receive an email message with a link to set a password. The email will be sent to the email address configured above. This option only available during user creation.
 
 4. On the right of the page, select the global roles for the user. Details on global roles are described in [Managing permissions](/users-guide/administration#managing-permissions).
 5. Click **Save** to save your settings.

--- a/content/users-guide/administration-bundle/managing-users.md
+++ b/content/users-guide/administration-bundle/managing-users.md
@@ -101,8 +101,7 @@ If single sign-on is enabled for your tenant, a message will show up which remin
                </tr>
                <tr>
                    <td align="left">Login alias</td>
-                   <td align="left">In addition to the username, an optional alias can be provided to be used to log on. In contrast to username, this alias may be changed if required. User alias is not supported for devices.
-	  					{{<c8y-admon-info>}} Login alias can not be same as username {{</c8y-admon-info>}}
+                   <td align="left">In addition to the username, an optional alias can be provided to be used to log on. In contrast to the username, this alias may be changed if required. The login alias cannot be the same as the username. Note that the login alias is not supported for devices.
                    </td>
                </tr>
                <tr>
@@ -141,7 +140,7 @@ If single sign-on is enabled for your tenant, a message will show up which remin
 3. Select the login options for the user.
 	* 	**Two-factor authentication (SMS)** - if selected, the user will receive a verification code via SMS which is required to complete the authentication. The SMS will be sent to the phone number configured above. For details refer to [Two-factor authentication](/users-guide/administration/#tfa).
 	* **User must reset password on next login** - if selected, you must provide a password which the user must reset on the next login. Enter a password and confirm it. While entering the password, the strength of the password will be checked. See [To change your password](/users-guide/getting-started/#change-password) for further information on password reset and strength.  
-	* **Send password reset link as email** - if selected, the user will receive an email message with a link to set a password. The email will be sent to the email address configured above. This option only available during user creation.
+	* **Send password reset link as email** - if selected, the user will receive an email message with a link to set a password. The email will be sent to the email address configured above. This option is only available during user creation.
 
 4. On the right of the page, select the global roles for the user. Details on global roles are described in [Managing permissions](/users-guide/administration#managing-permissions).
 5. Click **Save** to save your settings.


### PR DESCRIPTION
* fixed: Account -> Accounts
* Added info that alias can't be same as user name
* Removed info about "Send password change visibility" from edit user description. Added a sentence to create user section instad.
* Added admon related referencing own user settings
* Updated description for Global Manager and Global Reader roles


Details: 
feature/MTM-50214/MTM-53144-documentation-improvements

[x]	https://staging-resources.cumulocity.com/guides/10.16.0/users-guide/administration/#viewing-users {{ To view all users in your tenant, click Users in the Account menu in the navigator.}} => should be {{in the Accounts menu }}

[x]	https://staging-resources.cumulocity.com/guides/10.16.0/users-guide/administration/#to-add-a-user add info, that alias can not be the same as username

[x]	In section https://staging-resources.cumulocity.com/guides/10.16.0/users-guide/administration/#to-edit-a-user
is written ```Click the menu icon at the right of the respective row and then click Edit. All fields except Username and Send password reset link as email can be changed. For details on the fields, see To add a user.``` whereby the fact during user edition ``` Send password reset link as email ``` is not visible, so this part should be updated

[-]	increase padding above filter input 
>> removed on latest

[x]	in the section https://staging-resources.cumulocity.com/guides/10.16.0/users-guide/administration/#to-add-a-user
in point 2, with user fields and description written: .. but real behaviour is that either visible user name or the first letter of the name and the surname -> removed that part of description, addded admon-related

[x]	Typo error in section 3 for https://staging-resources.cumulocity.com/guides/10.16.0/users-guide/administration/#to-add-a-user
instead of ```See To change your password for further information on password reset and strenth.``` should be 
```See To change your password for further information on password reset and strength.```

[-]	in https://staging-resources.cumulocity.com/guides/10.16.0/users-guide/administration/#to-add-a-user
in the info section is written that the manually created user by default has “Own_User_Management” permission, it's not actually true, because the permissions could be given only by assigning a global/inventory role, hence better to say, that by default the "business" role is assigned to the user and it provides one with the “Own_User_Management” permission.
Because if there won't be given role then won't be also any permission given to the user 
```INFO
By default, manually created users always have the “Own_User_Management” permissions set to active.
```

>> Documentation correct, own user management assigned by default by backend and UI has no control whatsoever. Stated already in admon-req section for the chapter.


[x]	update the description for `Global Manager` global role from ```Can read and write all devices.``` to ```Can read and write all data from all devices``` (the same description as is visible on global roles page) and for `Global Reader` from ```Can read all devices.``` to ```Can read all data from all devices```