### PR TITLE
feature/MTM-50214/MTM-53145-documentation-improvements

### DIFF
--- a/content/users-guide/administration-bundle/managing-permissions.md
+++ b/content/users-guide/administration-bundle/managing-permissions.md
@@ -370,7 +370,7 @@ Inventory roles are assigned to a user and a group of devices.
 
 To assign inventory roles, click **Users** in the **Accounts** menu, select a user in the user list and switch to its **Inventory roles** tab.
 
-In the **Inventory roles** tab you will see a tree of device groups. To assign an inventory role, click on the arrow right from a group. Select the relevant roles and click **Apply**. For detailed `description` on the roles hover over the info icon next to it or refer to [Inventory roles](#inventory).
+In the **Inventory roles** tab you will see a tree of device groups. To assign an inventory role, click on the arrow right from a group. Select the relevant roles and click **Apply**. For a detailed description of a role hover over the info icon next to it or refer to [Inventory roles](#inventory).
 
 {{< c8y-admon-important >}}
 If a user already has a global role containing inventory permissions, the user will be

--- a/content/users-guide/administration-bundle/managing-permissions.md
+++ b/content/users-guide/administration-bundle/managing-permissions.md
@@ -275,7 +275,7 @@ When new features with new permissions are added to {{< product-c8y-iot >}}, the
 <a name="attach-global"></a>
 #### Assigning global roles
 
-You can assign global roles to users either directly in the user list, or by opening the page for a particular user and adding them there.
+You can assign global roles to users either directly in the user list, or by opening the details page for a particular user and adding them there.
 
 {{< c8y-admon-important >}}
 By default it is not possible to change roles of SSO users (created automatically during SSO login) as those would be overridden by dynamic access mapping. However this behaviour can be changed. For more information refer to [Administration > Configuration settings](/users-guide/administration/#custom-template) in the *User guide*.
@@ -370,7 +370,7 @@ Inventory roles are assigned to a user and a group of devices.
 
 To assign inventory roles, click **Users** in the **Accounts** menu, select a user in the user list and switch to its **Inventory roles** tab.
 
-In the **Inventory roles** tab you will see a tree of device groups. To assign an inventory role, click on the arrow right from a group. Select the relevant roles and click **Apply**. For details on the roles hover over the info icon next to it or refer to [Inventory roles](#inventory).
+In the **Inventory roles** tab you will see a tree of device groups. To assign an inventory role, click on the arrow right from a group. Select the relevant roles and click **Apply**. For detailed `description` on the roles hover over the info icon next to it or refer to [Inventory roles](#inventory).
 
 {{< c8y-admon-important >}}
 If a user already has a global role containing inventory permissions, the user will be

--- a/content/users-guide/administration-bundle/managing-permissions.md
+++ b/content/users-guide/administration-bundle/managing-permissions.md
@@ -370,7 +370,7 @@ Inventory roles are assigned to a user and a group of devices.
 
 To assign inventory roles, click **Users** in the **Accounts** menu, select a user in the user list and switch to its **Inventory roles** tab.
 
-In the **Inventory roles** tab you will see a tree of device groups. To assign an inventory role, click on the arrow right from a group. Select the relevant roles and click **Apply**. For a detailed description of a role hover over the info icon next to it or refer to [Inventory roles](#inventory).
+In the **Inventory roles** tab you will see a tree of device groups. To assign an inventory role, open the dropdown on the right side of the group row. Select the relevant roles and click **Apply**. For a detailed description of a role click the info icon next to it or refer to [Inventory roles](#inventory).
 
 {{< c8y-admon-important >}}
 If a user already has a global role containing inventory permissions, the user will be


### PR DESCRIPTION
* more precise description for user details page reference
* more precise description for inventory role information in inventory role assignment screen

Details: 
[-]	in https://staging-resources.cumulocity.com/guides/10.16.0/users-guide/administration/#to-add-an-inventory-role part
there is a text: ... there is no way an exclamation mark will be shown for adding a new inventory role, probably this information should be moved to the part when the inventory role is assigned to the user, or just be removed

> There is a way, documentation is correct. Inventory roles can be overriden by full access pemission. Tupical scenario: assign full access read and assing inventory read, in result inventory read is overriden by full access read and warning is being shown.

[x]	in https://staging-resources.cumulocity.com/guides/10.16.0/users-guide/administration/#assigning-global-roles
`You can assign global roles to users either directly in the user list, or by opening the page for a particular user and adding them there.` => `You can assign global roles to users either directly in the user list, or by opening the details page for a particular user and adding them there.`

[x]	https://staging-resources.cumulocity.com/guides/10.16.0/users-guide/administration/#assigning-inventory-roles-to-users
is written `For details on the roles hover over the info icon next to it or refer to Inventory roles.` , can be also added that details about inventory role are actually its description and also can be viewed /roles/inventory_roles (so admin knows what kind of info is displayed under info icon) 

> Slightly improved description