### PR TITLE
MTM-50640/MTM-53150-documentation-improvements

### DIFF
--- a/content/users-guide/administration-bundle/managing-applications.md
+++ b/content/users-guide/administration-bundle/managing-applications.md
@@ -322,8 +322,7 @@ Never change the system application names (such as "Device Management", "Cockpit
 
 ### To delete an application
 
-Click the menu icon at the right of an entry and then click **Delete**.
-Or go to [Edit](editing-and-removing) and click **Delete**.
+Click the menu icon at the right of an entry and then click **Delete**. You can also directly delete an application from the Properties tab in the application details.
 
 If you delete an application that overwrites a subscribed application, the currently subscribed application becomes available to all users. Additionally, the users will then also benefit from future upgrades of the subscribed application.
 

--- a/content/users-guide/administration-bundle/managing-applications.md
+++ b/content/users-guide/administration-bundle/managing-applications.md
@@ -323,6 +323,7 @@ Never change the system application names (such as "Device Management", "Cockpit
 ### To delete an application
 
 Click the menu icon at the right of an entry and then click **Delete**.
+Or go to [Edit](editing-and-removing) and click **Delete**.
 
 If you delete an application that overwrites a subscribed application, the currently subscribed application becomes available to all users. Additionally, the users will then also benefit from future upgrades of the subscribed application.
 

--- a/content/users-guide/administration-bundle/managing-applications.md
+++ b/content/users-guide/administration-bundle/managing-applications.md
@@ -322,7 +322,7 @@ Never change the system application names (such as "Device Management", "Cockpit
 
 ### To delete an application
 
-Click the menu icon at the right of an entry and then click **Delete**. You can also directly delete an application from the Properties tab in the application details.
+Click the menu icon at the right side of an entry and then click **Delete**. You can also delete an application directly from the Properties tab in the application details.
 
 If you delete an application that overwrites a subscribed application, the currently subscribed application becomes available to all users. Additionally, the users will then also benefit from future upgrades of the subscribed application.
 

--- a/content/users-guide/administration-bundle/managing-applications.md
+++ b/content/users-guide/administration-bundle/managing-applications.md
@@ -322,7 +322,7 @@ Never change the system application names (such as "Device Management", "Cockpit
 
 ### To delete an application
 
-Click the menu icon at the right side of an entry and then click **Delete**. You can also delete an application directly from the Properties tab in the application details.
+Click the menu icon at the right of an entry and then click **Delete**. You can also delete an application directly from the **Properties** tab in the application details.
 
 If you delete an application that overwrites a subscribed application, the currently subscribed application becomes available to all users. Additionally, the users will then also benefit from future upgrades of the subscribed application.
 


### PR DESCRIPTION
* added info that application can be deleted from edit view

Details: 
feature/MTM-50640/MTM-53150-documentation-improvements

[-]	in section https://cumulocity.com/guides/10.16.0/users-guide/administration/#applications-subscribed-by-default `Applications subscribed by default` is also should be added Machine Learning and Machine Learning workbench, right?
> Depends on installation. Isn't yet default in owned by core source files

[-]	navigating to section https://cumulocity.com/guides/10.16.0/users-guide/administration/#applications-subscribed-by-default the title of the section is not visible actually same happens for lots of links
> duplicate

[-]	https://cumulocity.com/guides/10.16.0/users-guide/administration/#to-add-a-custom-application in should be also added info about max file size?
> file upload is restricted by system settings and is changable, therefor no need to mention in docs

[-]	section  https://cumulocity.com/guides/10.16.0/users-guide/administration/#to-install-an-application-from-a-blueprint lack information about where the package will be taken, hence how to upload it. f.e. “the package firstly should be uploaded as zip in the packages tab in applications page /apps/administration/index.html#/ecosystem/package-list“
> move to app enablement. For me deploy from package didn't work on latest stage of version: Frontend 1017.201.0 Backend 1018.34.0. Error: "Application for id: 613906 and version: 40506230 does not exist."

[-]	for https://cumulocity.com/guides/10.16.0/users-guide/administration/#to-duplicate-an-application duplicate application modal window does not contain back button, change of screenshot is expected or if back button should be present, then a bug should be raised
> seems ok, there are both, back and cancel buttons. Verified on BACKEND: 1016.0.224, UI: 1016.0.224

[x]	https://cumulocity.com/guides/10.16.0/users-guide/administration/#to-delete-an-application application also can be removed from the app property tab, this info lack in documentation