### PR TITLE
MTM-50640/MTM-53152-documentation-improvements

### DIFF
--- a/content/users-guide/administration-bundle/managing-microservices.md
+++ b/content/users-guide/administration-bundle/managing-microservices.md
@@ -203,7 +203,7 @@ The following information is provided on the **Status** tab:
 * Subscriptions - number of active, unhealthy and desired microservice instances for all subtenants subscribed to the microservice.
 * Alarms - alarms for given application, provided in realtime.
 * Events - events for given application, provided in realtime.
-* Smart rules - list of applicable smartrules.
+* Smart rules - list of applicable smart rules.
 
 ##### Alarms and events
 
@@ -224,7 +224,7 @@ In the **On alarm matching** section, use `c8y_Application_Down` as an alarm typ
 
 #### Log files
 
-{{< product-c8y-iot >}} offers viewing logs which provide more details on the status of owned by tenant microservices.
+{{< product-c8y-iot >}} offers viewing logs which provide more details on the status of microservices owned by the tenant.
 
 To view logs, open the **Logs** tab of the respective microservice.
 


### PR DESCRIPTION
* Fixed part of URI which was not rendered correctly and removed the prefix dots
* Fixed description for smartrules
* Removed sentence about subscribed microservices visibility
* changed alarm severity from minor to major in description
* added condition on which log tab displayed

Details: 
feature/MTM-50640/MTM-53152-documentation-improvements

[x]	in part https://cumulocity.com/guides/10.16.0/users-guide/administration/#microservice-properties ...instead of Automatically created as .../service/ should be Automatically created as /service/... or `Automatically created as .../service/…`
> Fixed part of URI which was not rendered correctly and removed the prefix dots.

[x]	In part https://cumulocity.com/guides/10.16.0/users-guide/administration/#status-information is written that in Status tab next info is provided: `Smart rules - alarms for the given application.` → and it makes almost no difference in comparison with `Alarms - alarms for given application, provided in realtime.` So would be better to update the description a bit, because by smart rules can be created not only alarms
> Fixed description. List of smartrules displays a list of smartrules which might be applicable for given microservice representation. In other words all global smartrules and those of private which are attached to respective MO.

[x]	in the https://cumulocity.com/guides/10.16.0/users-guide/administration/#status-information part of the documentation is written: The status information is available for subscribed applications as well as for own applications. Information on subscribed subtenants is only visible for the application owner. => better to change word applications to microservices because applications doesn’t have such view even on management:
> Removed completely. Sentence is ambiguous. Besides status information on subscription is available for both - owned and subscribed.

[x]	https://cumulocity.com/guides/10.16.0/users-guide/administration/#alarms-and-events c8y_Application_Unhealthy is not a minor but a major alarm

[-]	https://cumulocity.com/guides/10.16.0/users-guide/administration/#alarms-and-events if the text: In the On alarm matching section, use c8y_Application_Down as an alarm type. As a target asset select the microservice which you would like to monitor, for example “echo-agent-server”. is connected to smart rules, then it should be in the same paragraph and not the new one, otherwise is not fully clear what it is about
> it's good here, this is an example we provide for this use case, but actual reference is to cockpit smartrules mentioned before

[x]	can be added info in which conditions Logs tab for MS appears
> added information that logs are available for owned microservices

[-]	https://cumulocity.com/guides/10.16.0/users-guide/administration/#alarms-and-events c8y_Application_Unhealthy - minor alarm which is created when there is at least one microservice instance working properly, but not all of them are fully operating. alarm severity should be changed to major in the text
> duplicate of above, done.