### PR TITLE
MTM-50640/MTM-53153-documentation-improvements

### DIFF
--- a/content/users-guide/administration-bundle/changing-settings.md
+++ b/content/users-guide/administration-bundle/changing-settings.md
@@ -203,8 +203,8 @@ Select the checkbox **Allow two-factor authentication** if you want to allow TFA
 You may select one of the following options:
 
 * **SMS-based**, supporting the following settings:
-	- **Limit token validity for** - lifetime of each session in minutes. When the session expires or a user logs out, the user must enter a new verification code.
-  - **Limit verification code validity for** - here you can set the lifetime of each verification code sent via SMS. When the verification code expires, the user must request a new verification code in order to login.
+  - **Token validity limit** - lifetime of each session in minutes. When the session expires or a user logs out, the user must enter a new verification code.
+  - **Verification code validity limit** - here you can set the lifetime of each verification code sent via SMS. When the verification code expires, the user must request a new verification code in order to login.
 
 
 	{{< c8y-admon-info >}}

--- a/content/users-guide/administration-bundle/configuring-single-sign-on.md
+++ b/content/users-guide/administration-bundle/configuring-single-sign-on.md
@@ -146,7 +146,7 @@ On user login, user data like first name, last name, email and phone number can 
 
 Mapping for alias is not available because it is not used in the context of SSO login.
 
-Each access token is signed by a signing certificate. There are following options to configure the signing certificates.
+Each access token is signed by a signing certificate. The following options are available to configure the signing certificates.
 
 1. By specifying the Azure AD certificate discovery address.
 

--- a/content/users-guide/administration-bundle/configuring-single-sign-on.md
+++ b/content/users-guide/administration-bundle/configuring-single-sign-on.md
@@ -93,7 +93,7 @@ If no access mapping matches the user access token, the user will get an "access
 
 New rules can be added by clicking **Add access mapping** or **Add inventory roles** at the bottom. An access mapping statement can consist of multiple checks like in the image below. You can add a rule to an existing statement by clicking **and**. Click the Minus button to remove a rule.
 
-New roles are added to the user from every matching access mapping. If one access mapping statement assigns the role "admin" and a second one assigns the role "business" and both meet the defined conditions, then the user will be granted access to the global roles "business" and "admin"."
+New roles are added to the user from every matching access mapping. If one access mapping statement assigns the role "admin" and a second one assigns the role "business" and both meet the defined conditions, then the user will be granted access to the global roles "business" and "admin".
 
 When using "=" as operator you may use wildcards in the **Value** field. The supported wildcard is asterisk (\*) and it matches zero or more characters. For example, if you enter "cur\*" this matches "cur", "curiosity", "cursor" and anything that starts with "cur". "f\*n" matches "fn", "fission", "falcon", and anything that begins with an "f" and ends with an "n".
 
@@ -146,7 +146,7 @@ On user login, user data like first name, last name, email and phone number can 
 
 Mapping for alias is not available because it is not used in the context of SSO login.
 
-Each access token is signed by a signing certificate. Currently there are three options to configure the signing certificates.
+Each access token is signed by a signing certificate. There are following options to configure the signing certificates.
 
 1. By specifying the Azure AD certificate discovery address.
 

--- a/content/users-guide/administration-bundle/tfa.md
+++ b/content/users-guide/administration-bundle/tfa.md
@@ -23,10 +23,10 @@ When adding a user and TFA is enabled, a mobile phone number must be specified. 
 {{< /c8y-admon-req >}}
 
 
-#### How to enable a specific user
+#### How to enable for a specific user
 
 1. In the Administration application, navigate to **Accounts** > **Users** and select a user in the **Users** page.
-2. Select the checkbox next to **Enable two-factor authentication**.
+2. Select the checkbox next to **Two-factor authentication**.
 3. Click **Save**.
 
 ![Enable TFA](/images/users-guide/Administration/admin-user-enable-tfa-1.png)

--- a/content/users-guide/administration-bundle/tfa.md
+++ b/content/users-guide/administration-bundle/tfa.md
@@ -23,7 +23,7 @@ When adding a user and TFA is enabled, a mobile phone number must be specified. 
 {{< /c8y-admon-req >}}
 
 
-#### How to enable for a specific user
+#### How to enable TFA for a specific user
 
 1. In the Administration application, navigate to **Accounts** > **Users** and select a user in the **Users** page.
 2. Select the checkbox next to **Two-factor authentication**.


### PR DESCRIPTION
* Fixed typos
* Updated properties names

Details: 
MTM-50640/MTM-53153-documentation-improvements

[x]	https://cumulocity.com/guides/10.16.0/users-guide/administration/#tfa-settings SMS-based settings naming should be changed from.. to..

[-]	in https://cumulocity.com/guides/10.16.0/users-guide/administration/#managing-the-connectivity-settings are specified only: Actility LoRa, Sigfox, SIM. why to Impact and Loriot as well?
> Should check for input from Data in Control

[x]	https://cumulocity.com/guides/10.16.0/users-guide/administration/#how-to-enable-a-specific-user name of the paragraph is How to enable a specific user - would be better to change to How to enable for a specific user

[x]	in https://cumulocity.com/guides/10.16.0/users-guide/administration/#how-to-enable-a-specific-user for 2 point: `Select the checkbox next to Enable two-factor authentication.` better to rename to Two-factor authentication as is on design

[x]	in https://cumulocity.com/guides/10.16.0/users-guide/administration/#custom-template in New roles are added to the user from every matching access mapping. If one access mapping statement assigns the role “admin” and a second one assigns the role “business” and both meet the defined conditions, then the user will be granted access to the global roles “business” and “admin”." remove quotes at the end of the sentence

[x]	in https://cumulocity.com/guides/10.16.0/users-guide/administration/#custom-template Each access token is signed by a signing certificate. Currently there are three options to configure the signing certificates. on the page are described 4 options for signing certificates not 3

[-]	In part https://cumulocity.com/guides/10.16.0/users-guide/administration/#passwords in Password validity limit (days) - the number of days a password may be valid before it must be reset; minimum value is “0”, maximum value is “999999”. Leave empty to use the value from the tenant options configured in the Management tenant, see Cumulocity IoT Core - Operations guide. there is no link for Cumulocity IoT Core - Operations guide.
> it is so because operations guide is usually a pdf document available in knowledge center, for example: https://documentation.softwareag.com/cumulocity_iot_platform/iot10-15-0/index.htm 