### PR TITLE
PAQ: Move block reference up in ToC

### DIFF
--- a/content/streaming-analytics/block-reference.md
+++ b/content/streaming-analytics/block-reference.md
@@ -1,6 +1,5 @@
 ---
-weight: 60
+weight: 30
 title: Analytics Builder block reference
 layout: bundle
 ---
-

--- a/content/streaming-analytics/customization.md
+++ b/content/streaming-analytics/customization.md
@@ -1,5 +1,5 @@
 ---
-weight: 40
+weight: 50
 title: Customization and permissions
 layout: bundle
 aliases:

--- a/content/streaming-analytics/epl-apps.md
+++ b/content/streaming-analytics/epl-apps.md
@@ -1,5 +1,5 @@
 ---
-weight: 30
+weight: 40
 title: EPL Apps
 layout: bundle
 aliases:

--- a/content/streaming-analytics/troubleshooting.md
+++ b/content/streaming-analytics/troubleshooting.md
@@ -1,5 +1,5 @@
 ---
-weight: 50
+weight: 60
 title: Troubleshooting and diagnostics
 layout: bundle
 aliases:


### PR DESCRIPTION
Rob wants to see the block reference directly below the Analytics Builder entry. 