### PR TITLE
Updates microservices.md to replace use of Zementis as the example

### DIFF
--- a/content/streaming-analytics/epl-apps-bundle/microservices.md
+++ b/content/streaming-analytics/epl-apps-bundle/microservices.md
@@ -6,7 +6,7 @@ layout: redirect
 
 ### Overview
 
-Streaming analytics applications using Apama can make use of applications running in other microservices. This section uses the health endpoint of an Apama microservice, but the steps apply to connecting to any other microservice running inside {{< product-c8y-iot >}}. This section is going to show you how to create a connection to the {{< product-c8y-iot >}} platform from within Apama EPL which can be used to invoke other microservices directly. It will then show you how to make a request and decode the result.
+Streaming analytics applications using Apama can make use of applications running in other microservices. This section uses the health endpoint of an apama-ctrl microservice, but the steps apply to connecting to any other microservice running inside {{< product-c8y-iot >}}. This section is going to show you how to create a connection to the {{< product-c8y-iot >}} platform from within Apama EPL which can be used to invoke other microservices directly. It will then show you how to make a request and decode the result.
 
 We will assume that you are developing an EPL app using the EPL editor that is part of the Streaming Analytics application and demonstrate a request to a microservice. The steps in this guide will also work with any other way you could be creating an Apama application and can be used to interact with any microservice.
 
@@ -95,7 +95,7 @@ action sendHealthRequest()
 }
 ```
 
-We use an Apama microservice for this example, which has the context path of "/cep". To modify this for another microservice substitute "/cep" with the context path as defined in the manifest for your microservice.
+We use an apama-ctrl microservice for this example, which has the context path of "/cep". To modify this for another microservice substitute "/cep" with the context path as defined in the manifest for your microservice.
 The "/health" endpoint completes the request path for this example, but could be replaced with any valid endpoint of the microservice.
 
 #### Receiving the response
@@ -119,4 +119,4 @@ action responseHandler(Response healthResponse)
 
 ### Other microservices
 
-This section was demonstrating talking to an Apama microservice. However, you can also access any other microservice through {{< product-c8y-iot >}} as long as it uses standard REST requests with JSON payloads. You must simply construct the appropriate */service* URL using the name of your microservice followed by the path of the request within your microservice.
+This section was demonstrating talking to an apama-ctrl microservice. However, you can also access any other microservice through {{< product-c8y-iot >}} as long as it uses standard REST requests with JSON payloads. You must simply construct the appropriate */service* URL using the name of your microservice followed by the path of the request within your microservice.

--- a/content/streaming-analytics/epl-apps-bundle/microservices.md
+++ b/content/streaming-analytics/epl-apps-bundle/microservices.md
@@ -6,7 +6,7 @@ layout: redirect
 
 ### Overview
 
-Streaming analytics applications using Apama can make use of applications running in other microservices. This section uses the health endpoint of an apama-ctrl microservice, but the steps apply to connecting to any other microservice running inside {{< product-c8y-iot >}}. This section is going to show you how to create a connection to the {{< product-c8y-iot >}} platform from within Apama EPL which can be used to invoke other microservices directly. It will then show you how to make a request and decode the result.
+Streaming analytics applications using Apama can make use of applications running in other microservices. This section uses the `health` endpoint of an Apama-ctrl microservice, but the steps apply to connecting to any other microservice running inside {{< product-c8y-iot >}}. This section is going to show you how to create a connection to the {{< product-c8y-iot >}} platform from within Apama EPL which can be used to invoke other microservices directly. It will then show you how to make a request and decode the result.
 
 We will assume that you are developing an EPL app using the EPL editor that is part of the Streaming Analytics application and demonstrate a request to a microservice. The steps in this guide will also work with any other way you could be creating an Apama application and can be used to interact with any microservice.
 
@@ -61,7 +61,7 @@ The response will also be decoded from JSON and the response payload uses the `A
 
 ### Example request to a microservice endpoint
 
-The following is a very simple application that shows how to query another microservice using the microservices's health endpoint as an example.
+The following is a very simple application that shows how to query another microservice using the microservices's `health` endpoint as an example.
 
 We will start with EPL which connects to {{< product-c8y-iot >}} and calls an action to send the request.
 
@@ -95,14 +95,14 @@ action sendHealthRequest()
 }
 ```
 
-We use an apama-ctrl microservice for this example, which has the context path of "/cep". To modify this for another microservice substitute "/cep" with the context path as defined in the manifest for your microservice.
-The "/health" endpoint completes the request path for this example, but could be replaced with any valid endpoint of the microservice.
+We use an Apama-ctrl microservice for this example, which has the context path of "/cep". To modify this for another microservice substitute "/cep" with the context path as defined in the manifest for your microservice.
+The `/health` endpoint completes the request path for this example, but could be replaced with any valid endpoint of the microservice.
 
 #### Receiving the response
 
 Here is the defined action that we used when sending the request. This action is called on response to the sent request and is provided with the Response object.
 
-For this example we simply log the health of the microservice if it was successful.
+For this example we simply log the `health` of the microservice if it was successful.
 
 ```java
 action responseHandler(Response healthResponse)
@@ -117,4 +117,4 @@ action responseHandler(Response healthResponse)
 
 ### Other microservices
 
-This section was demonstrating talking to an apama-ctrl microservice. However, you can also access any other microservice through {{< product-c8y-iot >}} as long as it uses standard REST requests with JSON payloads. You must simply construct the appropriate */service* URL using the name of your microservice followed by the path of the request within your microservice.
+This section was demonstrating talking to an Apama-ctrl microservice. However, you can also access any other microservice through {{< product-c8y-iot >}} as long as it uses standard REST requests with JSON payloads. You must simply construct the appropriate */service* URL using the name of your microservice followed by the path of the request within your microservice.

--- a/content/streaming-analytics/epl-apps-bundle/microservices.md
+++ b/content/streaming-analytics/epl-apps-bundle/microservices.md
@@ -95,7 +95,7 @@ action sendHealthRequest()
 }
 ```
 
-We use an Apama-ctrl microservice for this example, which has the context path of `/cep`. To modify this for another microservice substitute `/cep` with the context path as defined in the manifest for your microservice.
+We use an Apama-ctrl microservice for this example, which has the context path of `/cep`. To modify this for another microservice, substitute `/cep` with the context path as defined in the manifest for your microservice.
 The `/health` endpoint completes the request path for this example, but could be replaced with any valid endpoint of the microservice.
 
 #### Receiving the response

--- a/content/streaming-analytics/epl-apps-bundle/microservices.md
+++ b/content/streaming-analytics/epl-apps-bundle/microservices.md
@@ -84,7 +84,7 @@ monitor CallAnotherMicroservice {
 
 First we create the `Request` with: the type of request, the request path and the payload `any()` because we do not need to put anything in the payload in this example.
 
-We then use execute to send the request and provide an action to be called with the response.
+We then use `execute` to send the request and provide an action to be called with the response.
 
 ```java
 action sendHealthRequest()

--- a/content/streaming-analytics/epl-apps-bundle/microservices.md
+++ b/content/streaming-analytics/epl-apps-bundle/microservices.md
@@ -1,18 +1,18 @@
 ---
 weight: 70
-title: Connecting Apama to Zementis and other microservices
+title: Connecting Apama to other microservices
 layout: redirect
 ---
 
 ### Overview
 
-Streaming analytics applications using Apama can make use of applications running in other microservices. This section uses a Machine Learning application built with the Zementis microservice, but the steps apply to connecting to any other microservice running inside {{< product-c8y-iot >}}. This section is going to show you how to create a connection to the {{< product-c8y-iot >}} platform from within Apama EPL which can be used to invoke other microservices directly. It will then show you how to make a request and decode the result.
+Streaming analytics applications using Apama can make use of applications running in other microservices. This section uses the health endpoint of an Apama microservice, but the steps apply to connecting to any other microservice running inside {{< product-c8y-iot >}}. This section is going to show you how to create a connection to the {{< product-c8y-iot >}} platform from within Apama EPL which can be used to invoke other microservices directly. It will then show you how to make a request and decode the result.
 
-We will assume that you are developing an EPL app using the EPL editor that is part of the Streaming Analytics application and demonstrate talking to a Machine Learning model loaded through the Zementis microservice. The steps in this guide will also work with any other way you could be creating an Apama application and can be used to interact with any microservice.
+We will assume that you are developing an EPL app using the EPL editor that is part of the Streaming Analytics application and demonstrate a request to a microservice. The steps in this guide will also work with any other way you could be creating an Apama application and can be used to interact with any microservice.
 
 ### Creating an EPL app
 
-Click the Streaming Analytics icon in the application switcher. On the resulting home screen, navigate to the **EPL Apps** page and then click **New EPL app**. You will now see an EPL editor window in which to create the app which interacts with the Zementis microservice.
+Click the Streaming Analytics icon in the application switcher. On the resulting home screen, navigate to the **EPL Apps** page and then click **New EPL app**. You will now see an EPL editor window in which to create the app which interacts with another microservice.
 
 ### Connecting to the {{< product-c8y-iot >}} platform
 
@@ -59,108 +59,60 @@ req.execute(responseCallback);
 
 The response will also be decoded from JSON and the response payload uses the `AnyExtractor` pattern which you can find linked from the `Response` event in the HTTP Client transport documentation. The above example will be equivalent to the REST request `GET http://cumulocity/service/otherService/data?type=object`.
 
-### Combining streaming analytics with machine learning
+### Example request to a microservice endpoint
 
-Apama can process incoming data and then use a Machine Learning model in the Zementis microservice to make decisions on the processed data. We will assume you have already created a model following the [Machine Learning guide](/machine-learning). Each model has a name and you execute the model with a JSON-encoded data string in the query parameters of a GET request to that name. For example, you might execute a simple model with a request like this:
+The following is a very simple application that shows how to query another microserivce using the microservices's health endpoint as an example.
 
-```http
-GET /service/zementis/apply/modelName?record=%7B%22name%22:%22fred%22,%22age%22:37%7D
-```
-
-Special characters like quotes (") and curly braces must be encoded in the request. This will happen automatically when using the `setQueryParameter` API.
-
-The rest of this guide will assume you have a model with a single parameter which analyzes the RSSI value of WiFi networks
-
-The response will be a JSON document with the results of executing the model.
+We will start with EPL which connects to {{< product-c8y-iot >}} and calls an action to send the request.
 
 ```java
-{
-  "model" : "modelName",
-  "outputs" : [ {
-    "normalizedAnomalyScore" : 0.36550809046915766,
-    "decisionFunction" : -0.27619546519420546,
-    "rawAnomalyScore" : 5.5437220118668105,
-    "outlier" : false
-  } ]
-}
-```
-
-We will start with EPL which connects to {{< product-c8y-iot >}} and starts listening for measurements from a specific device.
-
-```java
-using com.apama.json.JSONPlugin;
 using com.apama.cumulocity.CumulocityRequestInterface;
 using com.softwareag.connectivity.httpclient.Request;
 using com.softwareag.connectivity.httpclient.Response;
-using com.apama.cumulocity.Alarm;
-using com.apama.cumulocity.Measurement;
 
-monitor LookForWifiAnomalies
+monitor CallAnotherMicroservice {
+
+	CumulocityRequestInterface requestIface;
+
+	action onload() {
+		requestIface := CumulocityRequestInterface.connectToCumulocity();
+		sendHealthRequest();
+	}
+```
+
+#### Sending the request
+
+First we create the Request specifying the type of request, the request path and as this is a simple query we use any() for the payload, as we have nothing to add in this case.
+We will use an Apama microservice for this example, which has the context path of "/cep". To modify this for another microservice substitute "/cep" with the context path as defined in the manifest for your microservice. The "/health" endpoint completes the request path for this example, but could be replaced with any valid endpoint of the microservice.
+We then use execute to send the request and provide an action to be called with the response.
+
+```java
+action sendHealthRequest()
 {
-    CumulocityRequestInterface cumulocity;
-    action onload()
-   {
-           cumulocity := CumulocityRequestInterface.connectToCumulocity();
-           listenForSignalStrength("idOfDevice", "nameOfMachineLearningModel");
-   }
+	Request healthRequest:=
+		requestIface.createRequest("GET", "/service/cep/health", any());
+	healthRequest.execute(responseHandler);
 }
 ```
 
-You must replace the device identifier and the name of the Machine Learning model for your installation.
+#### Receiving the response
 
-#### Looking for events
-
-First we must collect some data from measurements. This will use techniques which were previously introduced in this guide. In this case, we will be looking for measurements which arrive from a particular device, check whether they have a given key and if so query the Zementis microservice to decide how we should respond.
-
-```java
-action listenForSignalStrength(string deviceId, string modelName)
-{
-    monitor.subscribe(Measurement.SUBSCRIBE_CHANNEL);
-    on all Measurement(source = deviceId) as m {
-        if (m.measurements.hasKey("c8y_SignalStrengthWifi")) {
-            string record := convertMeasurementToRecord(m);
-            Request zementisRequest := cumulocity.createRequest("GET", "/service/zementis/apply/"+modelName, any());
-            zementisRequest.setQueryParameter("record", record);
-            zementisRequest.execute(ZementisHandler(deviceId).requestHandler);
-        }
-    }
-}
-```
-
-#### Converting measurements to Zementis records
-
-In order to execute the Machine Learning model, we must convert the {{< product-c8y-iot >}} request into a record suitable for passing to the Zementis microservice. This will consist of constructing a dictionary corresponding to a JSON object and then encoding it as a string with the JSON EPL plug-in.
+Here is the defined action that we used when sending the request. This action is called on response to the sent request and is provided with the Response object.
+For this example we simply check the health request was successful and log the health of the microservice.
 
 ```java
-action convertMeasurementToRecord(Measurement m) returns string
+action responseHandler(Response healthResponse)
 {
-    dictionary<string, any> json := {};
-    json["rssi"] := m.measurements.getOrDefault("c8y_SignalStrengthWifi").getOrDefault("rssi").value;
-    json["source"] := m.source;
-    json["time"] := m.time;
-    return JSONPlugin.toJSON(json);
-}
-```
-
-#### Receiving the response from the Zementis microservice
-
-The response from the Zementis microservice will be passed to the request handler once the model has finished executing. It will contain a payload which has been parsed from JSON and will tell us if this is an outlier. We want to raise alarms in {{< product-c8y-iot >}} for any outliers, which we will do by sending an `Alarm` event. We are using an event with an action on it so that we can create a closure around the device identifier.
-
-```java
-event ZementisHandler
-{
-    string deviceId;
-    action requestHandler(Response zementisResponse)
-    {
-        integer statusCode := zementisResponse.statusCode;
-        if (statusCode = 200 and <boolean> zementisResponse.payload.getSequence("outputs")[0].getEntry("outlier") = true) {
-            send Alarm("", "AnomalyDetectionAlarm", deviceId, currentTime,
-                "Anomaly detected", "ACTIVE", "CRITICAL", 1, new dictionary<string, any>) to Alarm.SEND_CHANNEL;
-        }
-    }
+	integer statusCode:= healthResponse.statusCode;
+	if (statusCode = 200)
+	{
+		log "Health response received: " + "status code: " + 
+			statusCode.toString() + ": " + healthResponse.payload.data.toString()
+			at INFO;
+	}
 }
 ```
 
 ### Other microservices
 
-This section was demonstrating talking to a Zementis microservice to execute a model. However, you can also access any other microservice through {{< product-c8y-iot >}} as long as it uses standard REST requests with JSON payloads. You must simply construct the appropriate */service* URL using the name of your microservice followed by the path of the request within your microservice.
+This section was demonstrating talking to an Apama microservice. However, you can also access any other microservice through {{< product-c8y-iot >}} as long as it uses standard REST requests with JSON payloads. You must simply construct the appropriate */service* URL using the name of your microservice followed by the path of the request within your microservice.

--- a/content/streaming-analytics/epl-apps-bundle/microservices.md
+++ b/content/streaming-analytics/epl-apps-bundle/microservices.md
@@ -102,16 +102,15 @@ The `/health` endpoint completes the request path for this example, but could be
 
 Here is the defined action that we used when sending the request. This action is called on response to the sent request and is provided with the `Response` object.
 
-For this example we simply log the `health` of the microservice if it was successful.
+For this example we simply log the status code and the body, of the response.
 
 ```java
 action responseHandler(Response healthResponse)
 {
-	integer statusCode:= healthResponse.statusCode;
-	if (statusCode = 200)
-	{
-		log "Health response received: " + healthResponse.payload.data.toString() at INFO;
-	}
+	integer statusCode := healthResponse.statusCode;
+	string payload := healthResponse.payload.data.toString();
+	log "Health response status code = " + statusCode.toString() +
+		", response body = " + payload at INFO;
 }
 ```
 

--- a/content/streaming-analytics/epl-apps-bundle/microservices.md
+++ b/content/streaming-analytics/epl-apps-bundle/microservices.md
@@ -102,7 +102,7 @@ The "/health" endpoint completes the request path for this example, but could be
 
 Here is the defined action that we used when sending the request. This action is called on response to the sent request and is provided with the Response object.
 
-For this example we simply check the health request was successful and log the health of the microservice.
+For this example we simply log the health of the microservice if it was successful.
 
 ```java
 action responseHandler(Response healthResponse)
@@ -110,9 +110,7 @@ action responseHandler(Response healthResponse)
 	integer statusCode:= healthResponse.statusCode;
 	if (statusCode = 200)
 	{
-		log "Health response received: " + "status code: " + 
-			statusCode.toString() + ": " + healthResponse.payload.data.toString()
-			at INFO;
+		log "Health response received: " + healthResponse.payload.data.toString() at INFO;
 	}
 }
 ```

--- a/content/streaming-analytics/epl-apps-bundle/microservices.md
+++ b/content/streaming-analytics/epl-apps-bundle/microservices.md
@@ -95,8 +95,8 @@ action sendHealthRequest()
 }
 ```
 
-We use an Apama-ctrl microservice for this example, which has the context path of */cep*. To modify this for another microservice substitute */cep* with the context path as defined in the manifest for your microservice.
-The */health* endpoint completes the request path for this example, but could be replaced with any valid endpoint of the microservice.
+We use an Apama-ctrl microservice for this example, which has the context path of `/cep`. To modify this for another microservice substitute `/cep` with the context path as defined in the manifest for your microservice.
+The `/health` endpoint completes the request path for this example, but could be replaced with any valid endpoint of the microservice.
 
 #### Receiving the response
 

--- a/content/streaming-analytics/epl-apps-bundle/microservices.md
+++ b/content/streaming-analytics/epl-apps-bundle/microservices.md
@@ -61,7 +61,7 @@ The response will also be decoded from JSON and the response payload uses the `A
 
 ### Example request to a microservice endpoint
 
-The following is a very simple application that shows how to query another microservice. We will be using the `/health` endpoint of an Apama-ctrl microservice as an example.
+The following is a very simple application that shows how to query another microservice. We are using the `/health` endpoint of an Apama-ctrl microservice as an example.
 
 We will start with EPL which connects to {{< product-c8y-iot >}} and calls an action to send the request.
 

--- a/content/streaming-analytics/epl-apps-bundle/microservices.md
+++ b/content/streaming-analytics/epl-apps-bundle/microservices.md
@@ -61,7 +61,7 @@ The response will also be decoded from JSON and the response payload uses the `A
 
 ### Example request to a microservice endpoint
 
-The following is a very simple application that shows how to query another microservice using the microservices's `health` endpoint as an example.
+The following is a very simple application that shows how to query another microservice. We will be using the `health` endpoint of the Apama-ctrl microservice as an example.
 
 We will start with EPL which connects to {{< product-c8y-iot >}} and calls an action to send the request.
 

--- a/content/streaming-analytics/epl-apps-bundle/microservices.md
+++ b/content/streaming-analytics/epl-apps-bundle/microservices.md
@@ -102,7 +102,7 @@ The `/health` endpoint completes the request path for this example, but could be
 
 Here is the defined action that we used when sending the request. This action is called in response to the sent request and is provided with the `Response` object.
 
-For this example we simply log the status code and the body, of the response.
+For this example, we simply log the status code and the body of the response.
 
 ```java
 action responseHandler(Response healthResponse)

--- a/content/streaming-analytics/epl-apps-bundle/microservices.md
+++ b/content/streaming-analytics/epl-apps-bundle/microservices.md
@@ -116,4 +116,4 @@ action responseHandler(Response healthResponse)
 
 ### Other microservices
 
-This section was demonstrating talking to an Apama-ctrl microservice. However, you can also access any other microservice through {{< product-c8y-iot >}} as long as it uses standard REST requests with JSON payloads. You must simply construct the appropriate */service* URL using the name of your microservice followed by the path of the request within your microservice.
+This section was demonstrating talking to an Apama-ctrl microservice. However, you can also access any other microservice through {{< product-c8y-iot >}} as long as it uses standard REST requests with JSON payloads. You must simply construct the appropriate `/service` URL using the name of your microservice followed by the path of the request within your microservice.

--- a/content/streaming-analytics/epl-apps-bundle/microservices.md
+++ b/content/streaming-analytics/epl-apps-bundle/microservices.md
@@ -100,7 +100,7 @@ The `/health` endpoint completes the request path for this example, but could be
 
 #### Receiving the response
 
-Here is the defined action that we used when sending the request. This action is called on response to the sent request and is provided with the `Response` object.
+Here is the defined action that we used when sending the request. This action is called in response to the sent request and is provided with the `Response` object.
 
 For this example we simply log the status code and the body, of the response.
 

--- a/content/streaming-analytics/epl-apps-bundle/microservices.md
+++ b/content/streaming-analytics/epl-apps-bundle/microservices.md
@@ -61,7 +61,7 @@ The response will also be decoded from JSON and the response payload uses the `A
 
 ### Example request to a microservice endpoint
 
-The following is a very simple application that shows how to query another microserivce using the microservices's health endpoint as an example.
+The following is a very simple application that shows how to query another microservice using the microservices's health endpoint as an example.
 
 We will start with EPL which connects to {{< product-c8y-iot >}} and calls an action to send the request.
 
@@ -83,7 +83,7 @@ monitor CallAnotherMicroservice {
 #### Sending the request
 
 First we create the Request specifying the type of request, the request path and as this is a simple query we use any() for the payload, as we have nothing to add in this case.
-We will use an Apama microservice for this example, which has the context path of "/cep". To modify this for another microservice substitute "/cep" with the context path as defined in the manifest for your microservice. The "/health" endpoint completes the request path for this example, but could be replaced with any valid endpoint of the microservice.
+
 We then use execute to send the request and provide an action to be called with the response.
 
 ```java
@@ -95,9 +95,13 @@ action sendHealthRequest()
 }
 ```
 
+We use an Apama microservice for this example, which has the context path of "/cep". To modify this for another microservice substitute "/cep" with the context path as defined in the manifest for your microservice.
+The "/health" endpoint completes the request path for this example, but could be replaced with any valid endpoint of the microservice.
+
 #### Receiving the response
 
 Here is the defined action that we used when sending the request. This action is called on response to the sent request and is provided with the Response object.
+
 For this example we simply check the health request was successful and log the health of the microservice.
 
 ```java

--- a/content/streaming-analytics/epl-apps-bundle/microservices.md
+++ b/content/streaming-analytics/epl-apps-bundle/microservices.md
@@ -100,7 +100,7 @@ The */health* endpoint completes the request path for this example, but could be
 
 #### Receiving the response
 
-Here is the defined action that we used when sending the request. This action is called on response to the sent request and is provided with the Response object.
+Here is the defined action that we used when sending the request. This action is called on response to the sent request and is provided with the `Response` object.
 
 For this example we simply log the `health` of the microservice if it was successful.
 

--- a/content/streaming-analytics/epl-apps-bundle/microservices.md
+++ b/content/streaming-analytics/epl-apps-bundle/microservices.md
@@ -82,7 +82,7 @@ monitor CallAnotherMicroservice {
 
 #### Sending the request
 
-First we create the `Request` with: the type of request, the request path and the payload `any()` because we do not need to put anything in the payload in this example.
+First, we create the `Request` with: the request type, the request path, and the payload `any()` because in this example we do not need to put anything in the payload.
 
 We then use `execute` to send the request and provide an action to be called with the response.
 

--- a/content/streaming-analytics/epl-apps-bundle/microservices.md
+++ b/content/streaming-analytics/epl-apps-bundle/microservices.md
@@ -6,7 +6,7 @@ layout: redirect
 
 ### Overview
 
-Streaming analytics applications using Apama can make use of applications running in other microservices. This section uses the `health` endpoint of an Apama-ctrl microservice, but the steps apply to connecting to any other microservice running inside {{< product-c8y-iot >}}. This section is going to show you how to create a connection to the {{< product-c8y-iot >}} platform from within Apama EPL which can be used to invoke other microservices directly. It will then show you how to make a request and decode the result.
+Streaming analytics applications using Apama can make use of applications running in other microservices. This section uses the `/health` endpoint of an Apama-ctrl microservice, but the steps apply to connecting to any other microservice running inside {{< product-c8y-iot >}}. This section is going to show you how to create a connection to the {{< product-c8y-iot >}} platform from within Apama EPL which can be used to invoke other microservices directly. It will then show you how to make a request and decode the result.
 
 We will assume that you are developing an EPL app using the EPL editor that is part of the Streaming Analytics application and demonstrate a request to a microservice. The steps in this guide will also work with any other way you could be creating an Apama application and can be used to interact with any microservice.
 
@@ -61,7 +61,7 @@ The response will also be decoded from JSON and the response payload uses the `A
 
 ### Example request to a microservice endpoint
 
-The following is a very simple application that shows how to query another microservice. We will be using the `health` endpoint of an Apama-ctrl microservice as an example.
+The following is a very simple application that shows how to query another microservice. We will be using the `/health` endpoint of an Apama-ctrl microservice as an example.
 
 We will start with EPL which connects to {{< product-c8y-iot >}} and calls an action to send the request.
 

--- a/content/streaming-analytics/epl-apps-bundle/microservices.md
+++ b/content/streaming-analytics/epl-apps-bundle/microservices.md
@@ -61,7 +61,7 @@ The response will also be decoded from JSON and the response payload uses the `A
 
 ### Example request to a microservice endpoint
 
-The following is a very simple application that shows how to query another microservice. We will be using the `health` endpoint of the Apama-ctrl microservice as an example.
+The following is a very simple application that shows how to query another microservice. We will be using the `health` endpoint of an Apama-ctrl microservice as an example.
 
 We will start with EPL which connects to {{< product-c8y-iot >}} and calls an action to send the request.
 

--- a/content/streaming-analytics/epl-apps-bundle/microservices.md
+++ b/content/streaming-analytics/epl-apps-bundle/microservices.md
@@ -82,7 +82,7 @@ monitor CallAnotherMicroservice {
 
 #### Sending the request
 
-First we create the Request specifying the type of request, the request path and as this is a simple query we use any() for the payload, as we have nothing to add in this case.
+First we create the `Request` with: the type of request, the request path and the payload `any()` because we do not need to put anything in the payload in this example.
 
 We then use execute to send the request and provide an action to be called with the response.
 

--- a/content/streaming-analytics/epl-apps-bundle/microservices.md
+++ b/content/streaming-analytics/epl-apps-bundle/microservices.md
@@ -95,8 +95,8 @@ action sendHealthRequest()
 }
 ```
 
-We use an Apama-ctrl microservice for this example, which has the context path of "/cep". To modify this for another microservice substitute "/cep" with the context path as defined in the manifest for your microservice.
-The `/health` endpoint completes the request path for this example, but could be replaced with any valid endpoint of the microservice.
+We use an Apama-ctrl microservice for this example, which has the context path of */cep*. To modify this for another microservice substitute */cep* with the context path as defined in the manifest for your microservice.
+The */health* endpoint completes the request path for this example, but could be replaced with any valid endpoint of the microservice.
 
 #### Receiving the response
 


### PR DESCRIPTION
For [PAB-3991](https://itrac.eur.ad.sag/browse/PAB-3991)
Machine learning has been deprecated. 
This serves to replace using Zementis as the example of calling another microservice.