### PR TITLE
Bugherd # 698 - Removing reference to Esper

### DIFF
--- a/content/users-guide/cockpit-bundle/smart-rules.md
+++ b/content/users-guide/cockpit-bundle/smart-rules.md
@@ -15,7 +15,7 @@ helpcontent:
 - [Administration > Managing business rules](/users-guide/administration#business-rules) for details on managing smart rules for your devices.
 {{< /c8y-admon-related >}}
 
-{{< product-c8y-iot >}} includes Streaming Analytics which can analyze data in realtime and perform actions based on data.
+{{< product-c8y-iot >}} includes the Streaming Analytics application which can analyze data in realtime and perform actions based on data.
 
 To easily create rules, the Cockpit application includes a smart rules builder which allows you to create rules from templates (so-called smart rule templates).
 

--- a/content/users-guide/cockpit-bundle/smart-rules.md
+++ b/content/users-guide/cockpit-bundle/smart-rules.md
@@ -15,7 +15,7 @@ helpcontent:
 - [Administration > Managing business rules](/users-guide/administration#business-rules) for details on managing smart rules for your devices.
 {{< /c8y-admon-related >}}
 
-{{< product-c8y-iot >}} includes a rule engine to analyze data in realtime and to perform actions based on data.
+{{< product-c8y-iot >}} includes Streaming Analytics which can analyze data in realtime and perform actions based on data.
 
 To easily create rules, the Cockpit application includes a smart rules builder which allows you to create rules from templates (so-called smart rule templates).
 

--- a/content/users-guide/cockpit-bundle/smart-rules.md
+++ b/content/users-guide/cockpit-bundle/smart-rules.md
@@ -15,7 +15,7 @@ helpcontent:
 - [Administration > Managing business rules](/users-guide/administration#business-rules) for details on managing smart rules for your devices.
 {{< /c8y-admon-related >}}
 
-{{< product-c8y-iot >}} includes a rule engine to analyze data in realtime and to perform actions based on data. These rules are specified in a scripting language and are managed in the [Administration application](/users-guide/administration).
+{{< product-c8y-iot >}} includes a rule engine to analyze data in realtime and to perform actions based on data.
 
 To easily create rules, the Cockpit application includes a smart rules builder which allows you to create rules from templates (so-called smart rule templates).
 


### PR DESCRIPTION
Removed sentence in Cockpit > Smart rules which was refering to Esper.

All changes will be cherry-picked to the respective release branches.