### PR TITLE
[DTM] Product name isn't getting substituted in help content

### DIFF
--- a/content/dtm/dtm-introduction.md
+++ b/content/dtm/dtm-introduction.md
@@ -8,7 +8,7 @@ outputs:
 helpcontent:
 - label: dtm-introduction
   title: Digital twin manager
-  content: "The DTM application allows you to create and manage assets around your physical connected devices in {{< product-c8y-iot >}} through the digital representation of a physical hierarchy of assets and devices.
+  content: "The DTM application allows you to create and manage assets around your physical connected devices in Cumulocity IoT through the digital representation of a physical hierarchy of assets and devices.
 
 
   To create an asset, use asset models as the blueprint, which consist of one or more asset properties as well as one or more child asset models.  


### PR DESCRIPTION
Using actual product name as the variable isn't getting substituted in the help content.