### PR TITLE
[Graft][DTM][10.16] Help content update

### DIFF
--- a/content/dtm/dtm-introduction.md
+++ b/content/dtm/dtm-introduction.md
@@ -8,7 +8,7 @@ outputs:
 helpcontent:
 - label: dtm-introduction
   title: Digital Twin Manager
-  content: "The DTM application allows you to create and manage assets around your physical connected devices in {{< product-c8y-iot >}} through the digital representation of a physical hierarchy of assets and devices.
+  content: "The DTM application allows you to create and manage assets around your physical connected devices in Cumulocity IoT through the digital representation of a physical hierarchy of assets and devices.
 
 
   To create an asset, use asset types as the blueprint, which consist of one or more custom properties as well as one or more child asset types.  


### PR DESCRIPTION
[DTM] Product name isn't getting substituted in help content