### PR TITLE
PAQ: Add link to audit logs

### DIFF
--- a/content/streaming-analytics/troubleshooting-bundle/alarms.md
+++ b/content/streaming-analytics/troubleshooting-bundle/alarms.md
@@ -89,7 +89,9 @@ To diagnose the cause of an unexpected restart, you can try the following:
 
     As mentioned in the above point, re-activate the EPL apps and analytic models that were active before and then check the logs.
 
-- Check the audit logs.
+- Check the audit logs. The audit logs are accessible via the Administration application and the audit API.
+See [Administration > Viewing audit logs](/users-guide/administration/#audit-logs) in the *User guide* and
+[Audit API](https://{{< domain-c8y >}}/api/core/{{< c8y-current-version >}}/#tag/Audit-API) in the {{< openapi >}} for details of accessing the audit logs.
 
 In safe mode, all previously active analytic models and EPL apps are deactivated and must be manually re-activated.
 


### PR DESCRIPTION
Copied the text and links from an Analytics Builder topic.

Cannot backport to versions 10.17 and 10.16 as the Streaming Analytics doc is still in the "apama" folder. With the move of the Analytics Builder doc into that guide, the doc is now in the "streaming-analytics" folder.