### PR TITLE
PAB-4030: Change "events" to "output" as discussed in review

### DIFF
--- a/content/streaming-analytics/analytics-builder-bundle/wires-and-blocks.md
+++ b/content/streaming-analytics/analytics-builder-bundle/wires-and-blocks.md
@@ -624,6 +624,6 @@ Input and output blocks identify a series of events by specifying a key for the 
 -   For `Alarm` objects, the key is the device and the alarm type.
 
 {{< c8y-admon-important>}}
-In Analytics Builder, for synchronous output types such as measurements, events and alarms \(see also [Output blocks and event timing](/streaming-analytics/analytics-builder/#output-blocks-and-event-timing)\), it is allowed to have more than one output block that generates events with any given key.
+In Analytics Builder, for synchronous output types such as measurements, events and alarms \(see also [Output blocks and event timing](/streaming-analytics/analytics-builder/#output-blocks-and-event-timing)\), it is allowed to have more than one output block that generates output with any given key.
 As there can be connections between the models, ambiguities may occur while processing events in the input blocks if there are multiple output blocks (in different models) generating the same output stream at the same point in time. When using output blocks, ensure that no two blocks generate output of the same stream type at the same time.
 {{< /c8y-admon-important>}}


### PR DESCRIPTION
That's a follow-up to https://github.com/SoftwareAG/c8y-docs/pull/1051