### PR TITLE
MTM-54103 Data explorer function "save to library"

### DIFF
--- a/content/users-guide/cockpit-bundle/data-explorer.md
+++ b/content/users-guide/cockpit-bundle/data-explorer.md
@@ -128,9 +128,7 @@ The center of the dialog shows all data points of the selected object. Select th
 
 The right hand side shows all of the selected data points.
 
-To save the data point to the data point library, click the menu icon of the data point and from the context menu select **Save to library**.
-
-For details on the data point library refer to [Data point library](#data-point-library).
+For further information on the data point library refer to [Data point library](#data-point-library).
 
 To remove a data point from the data point list, click the menu icon and select **Remove from list**.
 


### PR DESCRIPTION
Removed the reference of the function "save to library" in the Data explorer in accordance with https://cumulocity.atlassian.net/browse/MTM-54103.

The reference has also to be removed from the releases 10.15.0, 10.16.0 and 10.17.0.