### PR TITLE
MTM-55111 remove misleading statement about clean session which should be always set to true

### DIFF
--- a/content/device-integration/mqtt-bundle/implementation.md
+++ b/content/device-integration/mqtt-bundle/implementation.md
@@ -155,11 +155,7 @@ For subscriptions to the operation or error topics, we will deliver all messages
 
 #### MQTT clean session
 
-MQTT clients can set the clean session flag to "0" (false). This will ensure that in case the client disconnects, your subscription will still work and when you reconnect the client will receive the missed messages.
-
-{{< c8y-admon-info >}}
 {{< product-c8y-iot >}} requires clean session to be set to "1" (true). Currently we cannot guarantee that disabling clean session will work reliably, hence we recommend you to always enable clean session.
-{{< /c8y-admon-info >}}
 
 #### MQTT retained flag
 


### PR DESCRIPTION
#1385 backport to 10.18 which should be also included into 10.17, 10.16, 10.15