### PR TITLE
Small change in glossary

### DIFF
--- a/content/glossary/e.md
+++ b/content/glossary/e.md
@@ -26,7 +26,7 @@ For details see [Getting started > Technical concepts > Real-time processing > U
 
 ### EPL Apps {#epl-apps}
 
-EPL Apps is part of the [{{< product-c8y-iot >}} Streaming Analytics](/glossary/c/#streaming-analytics) application. It allows you to develop EPL apps (that is, single *.mon files) directly within {{< product-c8y-iot >}}, written in Apama EPL. You can also import existing*.mon files as EPL apps into {{< product-c8y-iot >}}. When you activate an EPL app from the Streaming Analytics application, you deploy it to {{< product-c8y-iot >}}.
+EPL Apps is part of the [{{< product-c8y-iot >}} Streaming Analytics](/glossary/c/#streaming-analytics) application. It allows you to develop EPL apps (that is, single \*.mon files) directly within {{< product-c8y-iot >}}, written in Apama EPL. You can also import existing \*.mon files as EPL apps into {{< product-c8y-iot >}}. When you activate an EPL app from the Streaming Analytics application, you deploy it to {{< product-c8y-iot >}}.
 
 See also [Event Processing Language (EPL)](/glossary/e/#epl) and [Analytics Builder](/glossary/a/#analytics-builder).
 

--- a/content/glossary/m.md
+++ b/content/glossary/m.md
@@ -51,7 +51,7 @@ For details see [Getting started > Technical concepts > Developing applications 
 
 Used in the context of [Analytics Builder](/glossary/a/#analytics-builder).
 
-A model is a container which can have a network of [Blocks](/glossary/b/#blocks) connected to each other with wires.
+A model is a container which can have a network of [blocks](/glossary/b/#blocks) connected to each other with wires.
 The behavior of a block inside a model does not depend on other blocks. There can be multiple instances of the same block in a model where each instance may behave differently, depending on the configurable parameters or the inputs connected to the block.
 
 


### PR DESCRIPTION
Use initial lowercase on the link. And make sure that the text after the asterisk in "*.mon" is not shown in italics.