### PR TITLE
[MTM-55028] Document that SSO in c8y does not support SAML based auth…

### DIFF
--- a/content/authentication/sso-bundle/integration-with-azure.md
+++ b/content/authentication/sso-bundle/integration-with-azure.md
@@ -7,7 +7,7 @@ section:
 ---
 
 
-The integration was successfully verified against Azure AD. The configuration steps are available in [https://docs.microsoft.com/en-us/azure/active-directory/develop/v1-protocols-oauth-code](https://docs.microsoft.com/en-us/azure/active-directory/develop/v1-protocols-oauth-code).
+The integration was successfully verified against Azure AD using OAuth2 and OpenID Connect (SAML is not supported). The configuration steps are available in [https://docs.microsoft.com/en-us/azure/active-directory/develop/v1-protocols-oauth-code](https://docs.microsoft.com/en-us/azure/active-directory/develop/v1-protocols-oauth-code).
 
 The following steps illustrate how to use Azure AD (Azure Active Directory) for SSO in {{< product-c8y-iot >}}.
 

--- a/content/authentication/sso-bundle/sso-introduction.md
+++ b/content/authentication/sso-bundle/sso-introduction.md
@@ -6,7 +6,7 @@ section:
   - platform_administration
 ---
 
-{{< product-c8y-iot >}} provides single sign-on (SSO) functionality, that allows a user to login with a single 3rd-party authorization server using the OAuth2 protocol, for example Azure Active Directory (AAD). Currently authorization code grant is supported only with access tokens in form of JWT, SAML is not supported.
+{{< product-c8y-iot >}} provides single sign-on (SSO) functionality, that allows a user to login with a single 3rd-party authorization server using the OAuth2 protocol, for example Azure Active Directory (AAD). Currently authorization code grant is supported only with access tokens in form of JWT. SAML is not supported.
 On top of standard SSO, {{< product-c8y-iot >}} also allows you to access the platform resources using access tokens from your authorization server directly as a Bearer token. For details refer to [Using access tokens from the authorization server](#configuring-access-tokens).
 
 {{< c8y-admon-req >}}

--- a/content/authentication/sso-bundle/sso-introduction.md
+++ b/content/authentication/sso-bundle/sso-introduction.md
@@ -6,7 +6,7 @@ section:
   - platform_administration
 ---
 
-{{< product-c8y-iot >}} provides single sign-on (SSO) functionality, that allows a user to login with a single 3rd-party authorization server using the OAuth2 protocol, for example Azure Active Directory (AAD). Currently authorization code grant is supported only with access tokens in form of JWT.
+{{< product-c8y-iot >}} provides single sign-on (SSO) functionality, that allows a user to login with a single 3rd-party authorization server using the OAuth2 protocol, for example Azure Active Directory (AAD). Currently authorization code grant is supported only with access tokens in form of JWT, SAML is not supported.
 On top of standard SSO, {{< product-c8y-iot >}} also allows you to access the platform resources using access tokens from your authorization server directly as a Bearer token. For details refer to [Using access tokens from the authorization server](#configuring-access-tokens).
 
 {{< c8y-admon-req >}}


### PR DESCRIPTION
Document that SSO in c8y does not support SAML-based authentication, only OpenID and OAuth2