### PR TITLE
MTM-55444: edge-databroker: add new uninstall steps file

### DIFF
--- a/content/edge/databroker-bundle/databroker-edge-uninstall.md
+++ b/content/edge/databroker-bundle/databroker-edge-uninstall.md
@@ -65,71 +65,9 @@ Enter host password for user 'edge/admin':
   },
   "applications": [
     {
-      "owner": {
-        "self": "https://myown.iot.com/tenant/tenants/edge",
-        "tenant": {
-          "id": "edge"
-        }
-      },
-      "requiredRoles": [
-        "ROLE_DATA_BROKER_READ",
-        "ROLE_INVENTORY_READ",
-        "ROLE_INVENTORY_CREATE",
-        "ROLE_ALARM_ADMIN"
-      ],
-      "manifest": {
-        "livenessProbe": {
-          "failureThreshold": 3,
-          "periodSeconds": 10,
-          "timeoutSeconds": 5,
-          "successThreshold": 1,
-          "initialDelaySeconds": 50,
-          "httpGet": {
-            "path": "/health",
-            "port": 80
-          }
-        },
-        "requiredRoles": [
-          "ROLE_DATA_BROKER_READ",
-          "ROLE_INVENTORY_READ",
-          "ROLE_INVENTORY_CREATE",
-          "ROLE_ALARM_ADMIN"
-        ],
-        "roles": [],
-        "resources": {
-          "cpu": "1000m",
-          "memory": "1Gi"
-        },
-        "isolation": "PER_TENANT",
-        "version": "1017.0.275",
-        "apiVersion": "2",
-        "provider": {
-          "name": "Cumulocity GmbH"
-        },
-        "readinessProbe": {
-          "failureThreshold": 3,
-          "periodSeconds": 10,
-          "timeoutSeconds": 5,
-          "successThreshold": 1,
-          "initialDelaySeconds": 50,
-          "httpGet": {
-            "path": "/health",
-            "port": 80
-          }
-        },
-        "billingMode": "RESOURCES",
-        "name": "databroker-agent-server",
-        "dockerBuildInfo": {
-          "builderInfo": "com.nsn.cumulocity.clients-java:microservice-package-maven-plugin:1017.0.275",
-          "hostOS": "Linux",
-          "hostPlatform": "amd64",
-          "buildDate": "2023-08-11T13:35:08Z",
-          "imageArch": "linux/amd64",
-          "hostOSVersion": "5.4.238-148.347.amzn2.x86_64"
-        },
-        "noAppSwitcher": true,
-        "settingsCategory": null
-      },
+      "owner": { ... truncated ... },
+      "requiredRoles": [ ... truncated ... ],
+      "manifest": { ... truncated ... },
       "roles": [],
       "contextPath": "databroker-agent-server",
       "availability": "MARKET",

--- a/content/edge/databroker-bundle/databroker-edge-uninstall.md
+++ b/content/edge/databroker-bundle/databroker-edge-uninstall.md
@@ -1,22 +1,22 @@
 ---
 weight: 50
-title: Uninstalling the Messaging Service and the microservice-based data broker on Edge
+title: Uninstalling the Messaging Service and the microservice-based data broker
 layout: redirect
 ---
 
 The bundle for the Messaging Service and data broker microservice does not have an uninstall command. 
-If a mistake is made, or and installation fails, the bundle components must be manually uninstalled.
-Once manually uninstalled, the installation can be reattempted.
+If a mistake is made or an installation fails, the bundle components must be uninstalled manually.
+Afterwards, the installation can be reattempted.
 
-#### To manually uninstall:
+### To uninstall manually
 1. Login to {{< product-c8y-iot >}} Edge using SSH.
    
-2. Uninstall the Pulsar helm chart.
+2. Uninstall the Pulsar Helm chart.
 ```shell
 sudo helm uninstall pulsar -n c8y-messaging-service
 ```
 3. Wait for the pulsar pods to terminate.  
-   This command updates its state every 2 seconds. When it reports there are no resources, press CTL-C to return to the command line.
+   This command updates its state every two seconds. When it reports that there are no resources, press Ctrl+C to return to the command line.
 
 ```shell
 watch sudo kubectl get pods -n c8y-messaging-service
@@ -35,7 +35,7 @@ journal0     2Gi        RWO            Retain           Released    c8y-messagin
 ledgers0     10Gi       RWO            Retain           Released    c8y-messaging-service/pulsar-bookie-ledgers-pulsar-bookie-0      local-storage            3h
 zookeeper0   2Gi        RWO            Retain           Released    c8y-messaging-service/pulsar-zookeeper-data-pulsar-zookeeper-0   local-storage            3h
 ```
-6. Delete each of the persistent volumes found in step 5.
+6. Delete each of the persistent volumes found in the previous step.
 ```shell 
 sudo kubectl delete pv journal0 ledgers0 zookeeper0
 ```
@@ -46,12 +46,12 @@ sudo rm -rf /opt/bookie/ledgers /opt/bookie/journal /opt/zookeeper
 8. Unsubscribe the edge tenant from and undeploy, the databroker-agent-server microservice.
 
    The databroker-agent-server application ID is required for the HTTP requests used to do both of these.   
-   To find its application ID, you can use a CURL command of the following form and redirect the output to a JQ command to make it easier to read the JSON response.
-   The general structure of command is:
+   To find its application ID, you can use a cURL command of the following form and redirect the output to a JQ command to make it easier to read the JSON response.
+   The general structure of the command is:
 ```shell
 curl http://<EDGE-HOSTNAME>/application/applicationsByName/databroker-agent-server -su <TENANT>/admin | jq --indent 2
 ```   
-   The ID required is the `id` field at the root level of the JSON response.
+   The ID required is the value of the `id` field at the root level of the JSON response.
    In the following example, it has the value '19' (the penultimate JSON field).
 ```shell
 curl http://myown.iot.com/application/applicationsByName/databroker-agent-server -su edge/admin | jq --indent 2
@@ -143,14 +143,13 @@ Enter host password for user 'edge/admin':
   ]
 }
 ```
-   Use that ID value in the request to unsubscribe from the microserive, and again when deleting it. 
+   Use that ID value in the request to unsubscribe from the microservice and again when deleting it. 
 
    To unsubscribe, use a command of the following form:
 ```shell
 curl -X DELETE http://<EDGE-HOSTNAME>/tenant/tenants/<TENANT>/applications/<APP-ID> -u <TENANT>/admin -v
-
 ```
-   This should return an HTTP 204 (no content) response. For example: 
+   This returns an HTTP 204 (no content) response. For example: 
 ```shell
 curl -X DELETE http://myown.iot.com/tenant/tenants/edge/applications/19 -u edge/admin -v
 Enter host password for user 'edge/admin':
@@ -177,11 +176,11 @@ Enter host password for user 'edge/admin':
 * Connection #0 to host myown.iot.com left intact
 ```
 
-   To delete, the use a command of the form:
+   To delete, use a command of the following form:
 ```shell
 curl -X DELETE http://<EDGE-HOSTNAME>/application/applications/<APP-ID> -su <TENANT>/admin -v
 ```   
-   This should return an HTTP 204 (no content) response. For example:
+   This returns an HTTP 204 (no content) response. For example:
 ```shell
 curl -X DELETE http://myown.iot.com/application/applications/19 -su edge/admin -v
 Enter host password for user 'edge/admin':

--- a/content/edge/databroker-bundle/databroker-edge-uninstall.md
+++ b/content/edge/databroker-bundle/databroker-edge-uninstall.md
@@ -43,7 +43,7 @@ sudo kubectl delete pv journal0 ledgers0 zookeeper0
 ```shell
 sudo rm -rf /opt/bookie/ledgers /opt/bookie/journal /opt/zookeeper
 ```
-8. Unsubscribe the edge tenant from and undeploy, the databroker-agent-server microservice.
+8. Unsubscribe the edge tenant from and delete, the databroker-agent-server microservice.
 
    The databroker-agent-server application ID is required for the HTTP requests used to do both of these.   
    To find its application ID, you can use a cURL command of the following form and redirect the output to a JQ command to make it easier to read the JSON response.

--- a/content/edge/databroker-bundle/databroker-edge-uninstall.md
+++ b/content/edge/databroker-bundle/databroker-edge-uninstall.md
@@ -27,7 +27,7 @@ sudo kubectl delete pvc -n c8y-messaging-service --all
 ```
 5. Find the names of the persistent volumes used by the Pulsar components.
    
-   Here the GREP command is used to filter the output. The names are in the output's leftmost column.
+   Here the grep command is used to filter the output. The names are in the output's leftmost column.
 
 ```shell
 sudo kubectl get pv | grep pulsar
@@ -46,7 +46,7 @@ sudo rm -rf /opt/bookie/ledgers /opt/bookie/journal /opt/zookeeper
 8. Unsubscribe the edge tenant from and delete, the databroker-agent-server microservice.
 
    The databroker-agent-server application ID is required for the HTTP requests used to do both of these.   
-   To find its application ID, you can use a cURL command of the following form and redirect the output to a JQ command to make it easier to read the JSON response.
+   To find its application ID, you can use a cURL command of the following form and redirect the output to a jq command to make it easier to read the JSON response.
    The general structure of the command is:
 ```shell
 curl http://<EDGE-HOSTNAME>/application/applicationsByName/databroker-agent-server -su <TENANT>/<USERNAME> | jq --indent 2

--- a/content/edge/databroker-bundle/databroker-edge-uninstall.md
+++ b/content/edge/databroker-bundle/databroker-edge-uninstall.md
@@ -49,7 +49,7 @@ sudo rm -rf /opt/bookie/ledgers /opt/bookie/journal /opt/zookeeper
    To find its application ID, you can use a cURL command of the following form and redirect the output to a JQ command to make it easier to read the JSON response.
    The general structure of the command is:
 ```shell
-curl http://<EDGE-HOSTNAME>/application/applicationsByName/databroker-agent-server -su <TENANT>/admin | jq --indent 2
+curl http://<EDGE-HOSTNAME>/application/applicationsByName/databroker-agent-server -su <TENANT>/<USERNAME> | jq --indent 2
 ```   
    The ID required is the value of the `id` field at the root level of the JSON response.
    In the following example, it has the value '19' (the penultimate JSON field).
@@ -85,7 +85,7 @@ Enter host password for user 'edge/admin':
 
    To unsubscribe, use a command of the following form:
 ```shell
-curl -X DELETE http://<EDGE-HOSTNAME>/tenant/tenants/<TENANT>/applications/<APP-ID> -u <TENANT>/admin -v
+curl -X DELETE http://<EDGE-HOSTNAME>/tenant/tenants/<TENANT>/applications/<APP-ID> -u <TENANT>/<USERNAME> -v
 ```
    This returns an HTTP 204 (no content) response. For example: 
 ```shell
@@ -116,7 +116,7 @@ Enter host password for user 'edge/admin':
 
    To delete, use a command of the following form:
 ```shell
-curl -X DELETE http://<EDGE-HOSTNAME>/application/applications/<APP-ID> -su <TENANT>/admin -v
+curl -X DELETE http://<EDGE-HOSTNAME>/application/applications/<APP-ID> -su <TENANT>/<USERNAME> -v
 ```   
    This returns an HTTP 204 (no content) response. For example:
 ```shell

--- a/content/edge/databroker-bundle/databroker-edge-uninstall.md
+++ b/content/edge/databroker-bundle/databroker-edge-uninstall.md
@@ -1,0 +1,210 @@
+---
+weight: 50
+title: Uninstalling the Messaging Service and the microservice-based data broker on Edge
+layout: redirect
+---
+
+The bundle for the Messaging Service and data broker microservice does not have an uninstall command. 
+If a mistake is made, or and installation fails, the bundle components must be manually uninstalled.
+Once manually uninstalled, the installation can be reattempted.
+
+#### To manually uninstall:
+1. Login to {{< product-c8y-iot >}} Edge using SSH.
+   
+2. Uninstall the Pulsar helm chart.
+```shell
+sudo helm uninstall pulsar -n c8y-messaging-service
+```
+3. Wait for the pulsar pods to terminate.  
+   This command updates its state every 2 seconds. When it reports there are no resources, press CTL-C to return to the command line.
+
+```shell
+watch sudo kubectl get pods -n c8y-messaging-service
+```
+4. Delete Pulsar's persistent volume claims.
+```shell
+sudo kubectl delete pvc -n c8y-messaging-service --all
+```
+5. Find the names of the persistent volumes used by the Pulsar components.
+   
+   Here the GREP command is used to filter the output. The names are in the output's leftmost column.
+
+```shell
+sudo kubectl get pv | grep pulsar
+journal0     2Gi        RWO            Retain           Released    c8y-messaging-service/pulsar-bookie-journal-pulsar-bookie-0      local-storage            3h
+ledgers0     10Gi       RWO            Retain           Released    c8y-messaging-service/pulsar-bookie-ledgers-pulsar-bookie-0      local-storage            3h
+zookeeper0   2Gi        RWO            Retain           Released    c8y-messaging-service/pulsar-zookeeper-data-pulsar-zookeeper-0   local-storage            3h
+```
+6. Delete each of the persistent volumes found in step 5.
+```shell 
+sudo kubectl delete pv journal0 ledgers0 zookeeper0
+```
+7. Delete the directories used by the persistent volumes.
+```shell
+sudo rm -rf /opt/bookie/ledgers /opt/bookie/journal /opt/zookeeper
+```
+8. Unsubscribe the edge tenant from and undeploy, the databroker-agent-server microservice.
+
+   The databroker-agent-server application ID is required for the HTTP requests used to do both of these.   
+   To find its application ID, you can use a CURL command of the following form and redirect the output to a JQ command to make it easier to read the JSON response.
+   The general structure of command is:
+```shell
+curl http://<EDGE-HOSTNAME>/application/applicationsByName/databroker-agent-server -su <TENANT>/admin | jq --indent 2
+```   
+   The ID required is the `id` field at the root level of the JSON response.
+   In the following example, it has the value '19' (the penultimate JSON field).
+```shell
+curl http://myown.iot.com/application/applicationsByName/databroker-agent-server -su edge/admin | jq --indent 2
+Enter host password for user 'edge/admin':
+{
+  "next": "https://myown.iot.com/application/applications?pageSize=5&currentPage=2",
+  "self": "https://myown.iot.com/application/applications?pageSize=5&currentPage=1",
+  "statistics": {
+    "pageSize": 5,
+    "currentPage": 1
+  },
+  "applications": [
+    {
+      "owner": {
+        "self": "https://myown.iot.com/tenant/tenants/edge",
+        "tenant": {
+          "id": "edge"
+        }
+      },
+      "requiredRoles": [
+        "ROLE_DATA_BROKER_READ",
+        "ROLE_INVENTORY_READ",
+        "ROLE_INVENTORY_CREATE",
+        "ROLE_ALARM_ADMIN"
+      ],
+      "manifest": {
+        "livenessProbe": {
+          "failureThreshold": 3,
+          "periodSeconds": 10,
+          "timeoutSeconds": 5,
+          "successThreshold": 1,
+          "initialDelaySeconds": 50,
+          "httpGet": {
+            "path": "/health",
+            "port": 80
+          }
+        },
+        "requiredRoles": [
+          "ROLE_DATA_BROKER_READ",
+          "ROLE_INVENTORY_READ",
+          "ROLE_INVENTORY_CREATE",
+          "ROLE_ALARM_ADMIN"
+        ],
+        "roles": [],
+        "resources": {
+          "cpu": "1000m",
+          "memory": "1Gi"
+        },
+        "isolation": "PER_TENANT",
+        "version": "1017.0.275",
+        "apiVersion": "2",
+        "provider": {
+          "name": "Cumulocity GmbH"
+        },
+        "readinessProbe": {
+          "failureThreshold": 3,
+          "periodSeconds": 10,
+          "timeoutSeconds": 5,
+          "successThreshold": 1,
+          "initialDelaySeconds": 50,
+          "httpGet": {
+            "path": "/health",
+            "port": 80
+          }
+        },
+        "billingMode": "RESOURCES",
+        "name": "databroker-agent-server",
+        "dockerBuildInfo": {
+          "builderInfo": "com.nsn.cumulocity.clients-java:microservice-package-maven-plugin:1017.0.275",
+          "hostOS": "Linux",
+          "hostPlatform": "amd64",
+          "buildDate": "2023-08-11T13:35:08Z",
+          "imageArch": "linux/amd64",
+          "hostOSVersion": "5.4.238-148.347.amzn2.x86_64"
+        },
+        "noAppSwitcher": true,
+        "settingsCategory": null
+      },
+      "roles": [],
+      "contextPath": "databroker-agent-server",
+      "availability": "MARKET",
+      "type": "MICROSERVICE",
+      "activeVersionId": "1345",
+      "name": "databroker-agent-server",
+      "self": "https://myown.iot.com/application/applications/19",
+      "id": "19",
+      "key": "databroker-agent-server-key"
+    }
+  ]
+}
+```
+   Use that ID value in the request to unsubscribe from the microserive, and again when deleting it. 
+
+   To unsubscribe, use a command of the following form:
+```shell
+curl -X DELETE http://<EDGE-HOSTNAME>/tenant/tenants/<TENANT>/applications/<APP-ID> -u <TENANT>/admin -v
+
+```
+   This should return an HTTP 204 (no content) response. For example: 
+```shell
+curl -X DELETE http://myown.iot.com/tenant/tenants/edge/applications/19 -u edge/admin -v
+Enter host password for user 'edge/admin':
+* About to connect() to myown.iot.com port 80 (#0)
+*   Trying 127.0.0.1...
+* Connected to myown.iot.com (127.0.0.1) port 80 (#0)
+* Server auth using Basic with user 'edge/admin'
+> DELETE /tenant/tenants/edge/applications/19 HTTP/1.1
+> Authorization: Basic ZWRnZS9hZG1pbjpFZGdlN184OV9fX19fX18=
+> User-Agent: curl/7.29.0
+> Host: myown.iot.com
+> Accept: */*
+>
+< HTTP/1.1 204 No Content
+< Date: Thu, 07 Sep 2023 16:27:32 GMT
+< Connection: keep-alive
+< X-Content-Type-Options: nosniff
+< X-XSS-Protection: 1; mode=block
+< Cache-Control: no-cache, no-store, max-age=0, must-revalidate
+< Pragma: no-cache
+< Expires: 0
+< X-Frame-Options: DENY
+<
+* Connection #0 to host myown.iot.com left intact
+```
+
+   To delete, the use a command of the form:
+```shell
+curl -X DELETE http://<EDGE-HOSTNAME>/application/applications/<APP-ID> -su <TENANT>/admin -v
+```   
+   This should return an HTTP 204 (no content) response. For example:
+```shell
+curl -X DELETE http://myown.iot.com/application/applications/19 -su edge/admin -v
+Enter host password for user 'edge/admin':
+* About to connect() to myown.iot.com port 80 (#0)
+*   Trying 127.0.0.1...
+* Connected to myown.iot.com (127.0.0.1) port 80 (#0)
+* Server auth using Basic with user 'edge/admin'
+> DELETE /application/applications/19 HTTP/1.1
+> Authorization: Basic ZWRnZS9hZG1pbjpFZGdlN184OV9fX19fX18=
+> User-Agent: curl/7.29.0
+> Host: myown.iot.com
+> Accept: */*
+>
+< HTTP/1.1 204 No Content
+< Date: Thu, 07 Sep 2023 16:35:11 GMT
+< Content-Type: application/vnd.com.nsn.cumulocity.error+json;charset=UTF-8;ver=0.9
+< Connection: keep-alive
+< X-Content-Type-Options: nosniff
+< X-XSS-Protection: 1; mode=block
+< Cache-Control: no-cache, no-store, max-age=0, must-revalidate
+< Pragma: no-cache
+< Expires: 0
+< X-Frame-Options: DENY
+<
+* Connection #0 to host myown.iot.com left intact
+```

--- a/content/edge/databroker-bundle/index.html
+++ b/content/edge/databroker-bundle/index.html
@@ -1,4 +1,4 @@
 ---
-title: Installing the Messaging Service and the microservice-based data broker on Edge
+title: Messaging Service and the microservice-based data broker on Edge
 headless: true
 ---

--- a/content/edge/databroker.md
+++ b/content/edge/databroker.md
@@ -1,6 +1,6 @@
 ---
 weight: 65
-title: Installing the Messaging Service and the microservice-based data broker on Edge
+title: Messaging Service and the microservice-based data broker on Edge
 layout: bundle
 ---
 


### PR DESCRIPTION
Requested by the edge team.

This is from an earlier PR (https://github.com/SoftwareAG/c8y-docs/pull/1409) that directly targeted 1017 that has been closed (in favor of cherry-picking to 1017 from here). A separate PR for develop will be created also. This guide is expected to not be needed beyond 1017, but we should not assume that that work will be done (otherwise, if it isn't done as expected, well have 'surprise' work to do later on and could overlook the need to do it).  

Possible problem: Not sure why I can't change the title in index.html (and if I should).
It seemed wrong that the (install) heading was duplicated on 2 levels, and wrong that it is the parent of this uninstall guide. Advice on why it's not changing, guidance on how to change will be appreciated (unless this changes links undesirably and should not be done). 

@bbyreddy , please add other Edge-team reviewers you wish (I couldn't spot others).