### PR TITLE
Feature/dm 2860/develop branch/deprecation info lwm2m device audit conf

### DIFF
--- a/content/protocol-integration/lwm2m-bundle/device-details.md
+++ b/content/protocol-integration/lwm2m-bundle/device-details.md
@@ -42,7 +42,7 @@ To view the history of all operations, click **View history**. Note, that you wi
 #### Audit Configuration {#audit-configuration}
 
 {{< c8y-admon-important >}}
-As announced in [release 10.18](https://cumulocity.com/releasenotes/release-10-18-0/announcements-10-18-0), the LWM2M device audit configuration feature is deprecated. This feature will be disabled by default in a future release.
+As announced in the release notes for [release 10.18](https://cumulocity.com/releasenotes/release-10-18-0/announcements-10-18-0), the LWM2M device audit configuration feature is deprecated. This feature will be disabled by default in a future release.
 {{< /c8y-admon-important >}}
 
 In the **Audit configuration** page you can audit the current device by comparing it to a selected reference device. It is also possible to sync properties to the values of the referenced device.

--- a/content/protocol-integration/lwm2m-bundle/device-details.md
+++ b/content/protocol-integration/lwm2m-bundle/device-details.md
@@ -42,7 +42,7 @@ To view the history of all operations, click **View history**. Note, that you wi
 #### Audit Configuration {#audit-configuration}
 
 {{< c8y-admon-important >}}
-As announced in the release notes for [release 10.18](https://cumulocity.com/releasenotes/release-10-18-0/announcements-10-18-0), the LWM2M device audit configuration feature is deprecated. This feature will be disabled by default in a future release.
+As announced in the release notes for [release 10.18](https://cumulocity.com/releasenotes/release-10-18-0/announcements-10-18-0), the LWM2M device audit configuration feature is deprecated. This feature will be disabled by default in a future version.
 {{< /c8y-admon-important >}}
 
 In the **Audit configuration** page you can audit the current device by comparing it to a selected reference device. It is also possible to sync properties to the values of the referenced device.

--- a/content/protocol-integration/lwm2m-bundle/device-details.md
+++ b/content/protocol-integration/lwm2m-bundle/device-details.md
@@ -41,6 +41,10 @@ To view the history of all operations, click **View history**. Note, that you wi
 
 #### Audit Configuration {#audit-configuration}
 
+{{< c8y-admon-important >}}
+As announced in [release 10.18](https://cumulocity.com/releasenotes/release-10-18-0/announcements-10-18-0), the LWM2M device audit configuration feature is deprecated. This feature will be disabled by default in a future release.
+{{< /c8y-admon-important >}}
+
 In the **Audit configuration** page you can audit the current device by comparing it to a selected reference device. It is also possible to sync properties to the values of the referenced device.
 
 Click **Audit configuration** in the right of the top menu bar to navigate to the **Audit configuration** page.


### PR DESCRIPTION
Adding same lwm2m device audit deprecation info from 1018 (https://github.com/SoftwareAG/c8y-docs/pull/1460) to develop