### PR TITLE
Automated Handover: 24.x.y Analytics Builder Block Reference Documentation.

### DIFF
--- a/content/streaming-analytics/block-reference-bundle/calculation.md
+++ b/content/streaming-analytics/block-reference-bundle/calculation.md
@@ -741,7 +741,7 @@ The KPI input can provide properties, typically from a KPI-managed object, which
 <tr>
 <th scope="row">Input Source</th>
 <td><span>The device, group, or asset which contains a data point. If specified, then this source (typically the same as the measurement source) is checked to see if it contains a data point for the specified fragment and series. If it contains a data point, the red and yellow range values from the source object are used in place of the KPI values.</span>
-<p>For the KPI block, this parameter must not be set to "All devices".</p>
+<p>For the KPI block, this parameter must not be set to "All Inputs".</p>
 </td>
 <td><span>any</span>
 </td>

--- a/content/streaming-analytics/block-reference-bundle/input.md
+++ b/content/streaming-analytics/block-reference-bundle/input.md
@@ -339,7 +339,7 @@ The parameters that define the input stream of the block are "Input Source" and 
 </tr>
 <tr>
 <th scope="row">Capture Start Value</th>
-<td><span>Outputs the initial value when the model is activated. This parameter must not be selected if the Input Source parameter is set to "All devices".</span>
+<td><span>Outputs the initial value when the model is activated. This parameter must not be selected if the Input Source parameter is set to "All Inputs".</span>
 </td>
 <td><span>boolean</span>
 </td>


### PR DESCRIPTION
No review required. This is just a bot handling already-reviewed material that is intended to go into the target branch without any backports.