### PR TITLE
PAB-4292: Removed Machine Learning role

### DIFF
--- a/content/streaming-analytics/analytics-customization-bundle/microservice-permissions.md
+++ b/content/streaming-analytics/analytics-customization-bundle/microservice-permissions.md
@@ -37,6 +37,5 @@ The manifest also specifies the permissions with which the microservice runs. Th
 - ROLE_TENANT_MANAGEMENT_READ
 - ROLE_BULK_OPERATION_ADMIN
 - ROLE_BULK_OPERATION_READ
-- ROLE_MACHINE_LEARNING_READ
 
 You can add other roles to this list (or remove them from it) to grant (or remove) permissions to EPL code.


### PR DESCRIPTION
There are no other occurrences of Machine Learning or Zementis in the doc. Screenshots are clean.
The only place where this still needs to be removed is the block reference - this will be done on a different PR (the automatically created one).