### PR TITLE
Paq more removals in analytics builder section

### DIFF
--- a/content/streaming-analytics/analytics-builder-bundle/monitoring-and-configuration.md
+++ b/content/streaming-analytics/analytics-builder-bundle/monitoring-and-configuration.md
@@ -317,20 +317,6 @@ Analytics Builder chain of models "Model 1", "Model 2", "Model 3" has been activ
 
 See [Accessing the correlator log](/streaming-analytics/analytics-builder/#accessing-the-correlator-log) for information on where to find the correlator log.
 
-#### Viewing diagnostics information {#viewing-diagnostics-information}
-
-To view diagnostics information, you need READ permission for "CEP management". See [Managing permissions](/standard-tenant/managing-permissions/) for more information.
-
-{{< c8y-admon-info>}}
-ADMIN permission for "CEP management" does not include READ permission.
-{{< /c8y-admon-info>}}
-
-If you have READ permission for "CEP management", links for downloading diagnostics information are available when you click the **User** button in the Streaming Analytics application. These will download ZIP files that include log file contents, copies of EPL applications, and much more.
-
-It may be useful to capture this diagnostics information when experiencing problems, or for debugging EPL applications. It is also useful to provide to support if you are filing a support ticket.
-
-See [Troubleshooting and diagnostics](/streaming-analytics/troubleshooting/) for detailed information on the available diagnostics. This also includes information on additional endpoints that are available for REST requests.
-
 ### Configuration {#configuration}
 
 You can customize the settings of Analytics Builder, the so-called “tenant options”, by sending REST requests to {{< product-c8y-iot >}}. The key names that you can use with the REST requests are listed in the topics below. A category name is needed along with the key name; this is always `analytics.builder`.

--- a/content/streaming-analytics/analytics-builder-bundle/monitoring-and-configuration.md
+++ b/content/streaming-analytics/analytics-builder-bundle/monitoring-and-configuration.md
@@ -172,7 +172,7 @@ For more information on `timedelay_secs`, see [Keys for model timeouts](/streami
 
 When chains of models with a high throughput are deployed across multiple workers, it may happen that the chain falls behind in processing input events, creating a backlog of input events that are still to be processed. These chains are referred to as “slow chains”. A message is written to the correlator log if the slowest chain is delayed by more than 1 second. For example:
 "Analytics Builder chain of models "Model 1", "Model 2", "Model 3" is slow by 3 seconds."
-See [Accessing the correlator log](/streaming-analytics/analytics-builder/#accessing-the-correlator-log) for information on where to find the correlator log.
+See [Log files of the Apama-ctrl microservice](/streaming-analytics/troubleshooting/#logfiles) for information on where to find the correlator log.
 
 The following information on the slowest chain is also available in the periodic status that is published as {{< product-c8y-iot >}} operations or events, within the `apama_status` parameter:
 
@@ -315,7 +315,7 @@ Analytics Builder chain of models "Model 1", "Model 2", "Model 3" is being activ
 Analytics Builder chain of models "Model 1", "Model 2", "Model 3" has been activated.
 ```
 
-See [Accessing the correlator log](/streaming-analytics/analytics-builder/#accessing-the-correlator-log) for information on where to find the correlator log.
+See [Log files of the Apama-ctrl microservice](/streaming-analytics/troubleshooting/#logfiles) for information on where to find the correlator log.
 
 ### Configuration {#configuration}
 
@@ -474,7 +474,7 @@ The values for some of the tenant options are logged. These are the following:
 -   `timedelay_secs`
 -   `numWorkerThreads`
 
-If you want to find out which values are currently used for these tenant options, you can look them up in the correlator log. See also [Accessing the correlator log](/streaming-analytics/analytics-builder/#accessing-the-correlator-log).
+If you want to find out which values are currently used for these tenant options, you can look them up in the correlator log. See also [Log files of the Apama-ctrl microservice](/streaming-analytics/troubleshooting/#logfiles).
 
 #### Using curl commands for setting various tenant options {#using-curl-commands-for-setting-various-tenant-options}
 
@@ -506,15 +506,3 @@ where:
 **Example (Bash shell):**
 
 `curl --user User123 -X POST -H 'Content-Type: application/json' -d '{"category": "analytics.builder", "key": "numWorkerThreads", "value": "4"}' -k https://mytenant/tenant/options`
-
-### Accessing the correlator log {#accessing-the-correlator-log}
-
-The location of the correlator log depends on the environment in which you are working:
-
--   {{< product-c8y-iot >}} Core:
-
-    The correlator log is accessible via the Administration application. You can find it on the **Logs** tab of the Apama-ctrl microservice. You have to subscribe to the microservice so that you can see the logs. For more information on microservices and log files, see [Managing microservices](/standard-tenant/ecosystem/#managing-microservices) and [Monitoring microservices](/standard-tenant/ecosystem/#monitoring-microservices).
-
--   {{< product-c8y-iot >}} Edge:
-
-    See [Logging](/edge/operating-edge/#logs-files) for information on the log file location.

--- a/content/streaming-analytics/analytics-builder-bundle/wires-and-blocks.md
+++ b/content/streaming-analytics/analytics-builder-bundle/wires-and-blocks.md
@@ -587,7 +587,7 @@ The input blocks assume that while events may be delivered out of order, they ar
 
 If the time delay value is set too low, then a small delay may result in Apama dropping an event, which can lead to erroneous results. The higher the time delay value is, the larger is the delay before an event is processed. Thus, it is important to pick a suitable value for the time delay to match the environment for events being delivered into Apama.
 
-The correlator logs the number of dropped events periodically to the correlator log file. See [Configuration](/streaming-analytics/analytics-builder/#configuration) for configuring logging throttling and [Accessing the correlator log](/streaming-analytics/analytics-builder/#accessing-the-correlator-log).
+The correlator logs the number of dropped events periodically to the correlator log file. See [Configuration](/streaming-analytics/analytics-builder/#configuration) for configuring logging throttling and [Log files of the Apama-ctrl microservice](/streaming-analytics/troubleshooting/#logfiles).
 
 ### Output blocks and event timing {#output-blocks-and-event-timing}
 

--- a/content/streaming-analytics/troubleshooting-bundle/diagnostics-download.md
+++ b/content/streaming-analytics/troubleshooting-bundle/diagnostics-download.md
@@ -51,9 +51,9 @@ Enhanced diagnostics information is provided in a ZIP file named *diagnostic-enh
 - Contains what is in the above-mentioned *diagnostic-overview&lt;timestamp&gt;.zip* file.
 - In addition, it includes requests that are more resource-intensive and may significantly slow down the correlator. These include the contents of the queues, CPU usage, and so on.
 
-What a user can see or do depends on the permissions:
+What you can see or do depends on your permissions:
 
-- A user with only READ permission for "CEP management" has read-only access to EPL apps and analytic models.
-- Without ADMIN permission for "CEP management", the user is not able to activate or edit EPL apps or analytic models.
-- If a user has both READ and ADMIN permissions for "CEP management", the user has read-write access and can access the diagnostics information.
-- If a user has only the ADMIN permission for "CEP management" and no READ permission, the user is able to load, edit and deploy EPL apps and analytic models, but is not able to see or access the diagnostics information.
+- If you have only READ permission for "CEP management", you have read-only access to EPL apps and analytic models.
+- Without ADMIN permission for "CEP management", you are not able to activate or edit EPL apps or analytic models.
+- If you have both READ and ADMIN permissions for "CEP management", you have read-write access and can access the diagnostics information.
+- If you have only ADMIN permission for "CEP management" and no READ permission, you are able to load, edit and deploy EPL apps and analytic models, but you are not able to see or access the diagnostics information.

--- a/content/streaming-analytics/troubleshooting-bundle/diagnostics-download.md
+++ b/content/streaming-analytics/troubleshooting-bundle/diagnostics-download.md
@@ -8,6 +8,12 @@ layout: redirect
 Diagnostics are not available for the Apama-ctrl-smartrules and Apama-ctrl-smartrulesmt microservices.
 {{< /c8y-admon-info >}}
 
+To download diagnostics information, you need READ permission for "CEP management". See [Managing permissions](/standard-tenant/managing-permissions/) for more information.
+
+{{< c8y-admon-info>}}
+ADMIN permission for "CEP management" does not include READ permission.
+{{< /c8y-admon-info>}}
+
 If you have READ permission for "CEP management", links for downloading diagnostics information are available when you click the **User** button in the Streaming Analytics application.
 This opens the right drawer which contains a **Download diagnostics** section with the following links:
 

--- a/content/streaming-analytics/troubleshooting-bundle/logfiles.md
+++ b/content/streaming-analytics/troubleshooting-bundle/logfiles.md
@@ -6,8 +6,12 @@ layout: redirect
 
 There are two ways to get the logs of the Apama-ctrl microservice:
 
-- Download diagnostics information as described in [Downloading diagnostics and logs](#diagnostics-download).
-- In some cases, it is useful to view the log file of the Apama-ctrl microservice using {{< product-c8y-iot >}} functionality.
-  See [Monitoring microservices](/standard-tenant/ecosystem/#monitoring-microservices) for information on how to view log files.
+- You can download diagnostics information from the Streaming Analytics application as described in [Downloading diagnostics and logs](#diagnostics-download).
+- In some cases, it is useful to view the log file of the Apama-ctrl microservice directly in {{< product-c8y-iot >}}.
+  The log file is accessible via the Administration application. You can find it on the **Logs** tab of the Apama-ctrl microservice. You have to subscribe to the microservice so that you can see the logs. For more information on microservices and log files, see [Managing microservices](/standard-tenant/ecosystem/#managing-microservices) and [Monitoring microservices](/standard-tenant/ecosystem/#monitoring-microservices).
+
+    {{< c8y-admon-info >}}
+  In case of {{< product-c8y-iot >}} Edge, since Apama-ctrl is not deployed as a microservice in Edge, the log file can be retrieved using the diagnostic utility. For more details, see [Apama log file locations](/edge/operating-edge/#apama-log-file-locations) and [Diagnostic utility](/edge/operating-edge/#diagnostics).
+    {{< /c8y-admon-info >}}
 
 Contact [product support](/additional-resources/contacting-support/) if needed.

--- a/content/streaming-analytics/troubleshooting-bundle/logfiles.md
+++ b/content/streaming-analytics/troubleshooting-bundle/logfiles.md
@@ -14,4 +14,6 @@ There are two ways to get the logs of the Apama-ctrl microservice:
   In case of {{< product-c8y-iot >}} Edge, since Apama-ctrl is not deployed as a microservice in Edge, the log file can be retrieved using the diagnostic utility. For more details, see [Apama log file locations](/edge/operating-edge/#apama-log-file-locations) and [Diagnostic utility](/edge/operating-edge/#diagnostics).
     {{< /c8y-admon-info >}}
 
+The correlator log is embedded in the log file of the Apama-ctrl microservice. See also [Descriptions of correlator status log fields]({{< link-apama-webhelp >}}index.html#page/pam-webhelp%2Fco-DepAndManApaApp_logging_correlator_status.html) in the Apama documentation.
+
 Contact [product support](/additional-resources/contacting-support/) if needed.


### PR DESCRIPTION
Removed more duplicate info from the Analytics Builder section. 
Added some info to the Troubleshooting section which was in the removed duplicate topics.
Changed links in Analytics Builder section to point to the Troubleshooting section.
Added a sentence about the correlator log to the Troubleshooting section.