### PR TITLE
[MTM-55242] Aligned section labels in JSON context help with their corresponding website section ids

### DIFF
--- a/content/authentication/basic-settings.md
+++ b/content/authentication/basic-settings.md
@@ -8,7 +8,7 @@ outputs:
 section:
   - platform_administration
 helpcontent:
-- label: authentication
+- label: basic-settings
   title: Authentication
   content: "Under **Login settings** you can specify your preferred login mode:
 

--- a/content/cockpit/managing-exports.md
+++ b/content/cockpit/managing-exports.md
@@ -8,7 +8,7 @@ outputs:
 section:
   - app_enablement
 helpcontent:
-  - label: export
+  - label: managing-exports
     title: Managing exports
     content: "The export functionality lets you export specific data to files. In each export, you can specify the output file type (Excel or CSV), schedule the export and specify the target email address(es), and optionally select filters for specific devices, time ranges or fields.
 

--- a/content/cockpit/working-with-dashboards.md
+++ b/content/cockpit/working-with-dashboards.md
@@ -8,7 +8,7 @@ section:
   - app_enablement
 weight: 40
 helpcontent:
-  - label: dashboards
+  - label: working-with-dashboards
     title: Working with Dashboards
     content: "Dashboards let you visualize your data by using a set of widgets. Widgets can display maps, images, graphs, tables, and other graphic representations of data.
 

--- a/content/cockpit/working-with-reports.md
+++ b/content/cockpit/working-with-reports.md
@@ -8,7 +8,7 @@ outputs:
 section:
   - app_enablement
 helpcontent:
-  - label: reports
+  - label: working-with-reports
     title: Working with reports
     content: "Reports enable you to track applications, alarms, assets, and other data by using a set of widgets in a dashboard layout. Widgets can display maps, images, graphs, tables and other graphic representations of data. In contrast to dashboards, reports show global data, regardless of the asset hierarchy.
 

--- a/content/data-broker/data-broker-application-bundle/data-connectors.md
+++ b/content/data-broker/data-broker-application-bundle/data-connectors.md
@@ -5,7 +5,7 @@ layout: bundle
 section:
   - platform_administration
 helpcontent:
-  - label: data-connector
+  - label: data-connectors
     title: Data connector
     content: "The **Data connectors** page shows a list of all currently defined data connectors with their status. A data connector describes the subset of the data that you would like to send to a destination tenant as well as the URL of that destination tenant. To add a data connector, click **Add data connector** at the top right."
 ---

--- a/content/device-management-application/managing-device-data-bundle/managing-configurations.md
+++ b/content/device-management-application/managing-device-data-bundle/managing-configurations.md
@@ -3,7 +3,7 @@ weight: 30
 title: Managing configurations
 layout: redirect
 helpcontent:
-- label: configuration-repository
+- label: managing-configurations
   title: Configuration repository
   content: "In the configuration repository, you can store and manage configuration data retrieved from your devices as 'configuration snaphots'. The configuration data contains the parameters and the initial settings of a device. Such configuration snapshots help you, for example, to apply the same configuration to multiple devices.
 

--- a/content/device-management-application/managing-device-data-bundle/managing-device-credentials.md
+++ b/content/device-management-application/managing-device-data-bundle/managing-device-credentials.md
@@ -3,7 +3,7 @@ weight: 50
 title: Managing device credentials
 layout: redirect
 helpcontent:
-- label: credentials
+- label: managing-device-credentials
   title: Device credentials
   content: "Manage the device credentials that have been generated for your connected devices. Edit, disable, or delete device credentials as required or modify its permissions in the **Global roles** field."
 ---

--- a/content/device-management-application/managing-device-data-bundle/managing-device-profiles.md
+++ b/content/device-management-application/managing-device-data-bundle/managing-device-profiles.md
@@ -3,7 +3,7 @@ weight: 60
 title: Managing device profiles
 layout: redirect
 helpcontent:
-- label: device-profiles
+- label: managing-device-profiles
   title: Device profiles
   content: "Device profiles represent a set of a firmware version, one or multiple software packages, and one or multiple configuration files which can be deployed on a device. Based on device profiles, you can easily deploy a specific target configuration on devices by using bulk operations.
 

--- a/content/device-management-application/managing-device-data-bundle/managing-firmware.md
+++ b/content/device-management-application/managing-device-data-bundle/managing-firmware.md
@@ -3,7 +3,7 @@ weight: 10
 title: Managing firmware
 layout: redirect
 helpcontent:
-- label: firmware-repo
+- label: managing-firmware
   title: Firmware repository
   content: "In the firmware repository, you can collect reference firmware for devices. At the top left, you can filter the firmware items by name, description, or device type.
 

--- a/content/device-management-application/managing-device-data-bundle/managing-software.md
+++ b/content/device-management-application/managing-device-data-bundle/managing-software.md
@@ -3,7 +3,7 @@ weight: 20
 title: Managing software
 layout: redirect
 helpcontent:
-- label: software-repo
+- label: managing-software
   title: Software repository
   content: "In the software repository, you can collect reference software for devices. Multiple software packages can be installed on a device. At the top left, you can filter the repository entries by name, description, or device type.
 

--- a/content/device-management-application/managing-device-data-bundle/managing-trusted-certificates.md
+++ b/content/device-management-application/managing-device-data-bundle/managing-trusted-certificates.md
@@ -3,7 +3,7 @@ weight: 40
 title: Managing trusted certificates
 layout: redirect
 helpcontent:
-- label: trusted-certificates
+- label: managing-trusted-certificates
   title: Trusted certificates
   content: "Cumulocity IoT allows devices to connect via MQTT protocol using a X.509 certificate for authentication. To do so, a certificate must be 'trusted' by Cumulocity IoT, that is, added to the trusted certificates."
 ---

--- a/content/device-management-application/monitoring-and-controlling-devices-bundle/troubleshooting-devices.md
+++ b/content/device-management-application/monitoring-and-controlling-devices-bundle/troubleshooting-devices.md
@@ -3,7 +3,7 @@ weight: 60
 title: Troubleshooting devices
 layout: redirect
 helpcontent:
-- label: events-all
+- label: troubleshooting-devices
   title: Events
   content: "Troubleshooting devices at a more detailed level can be done with the help of events. Events are low-level messages sent by devices that are usually used for application-specific processing. For example, a vending device sends its real-time sales in the form of events.
 

--- a/content/device-management-application/monitoring-and-controlling-devices-bundle/working-with-alarms.md
+++ b/content/device-management-application/monitoring-and-controlling-devices-bundle/working-with-alarms.md
@@ -3,7 +3,7 @@ weight: 40
 title: Working with alarms
 layout: redirect
 helpcontent:
-- label: alarm-monitoring
+- label: working-with-alarms
   title: Alarms
   content: "Devices can raise alarms to indicate that there is a problem. You can find an overview of the alarms across all devices here. To check the alarms of a particular device, switch to the **Alarm** tab in the details of the device.
 

--- a/content/device-management-application/monitoring-and-controlling-devices-bundle/working-with-operations.md
+++ b/content/device-management-application/monitoring-and-controlling-devices-bundle/working-with-operations.md
@@ -3,13 +3,13 @@ weight: 50
 title: Working with operations
 layout: redirect
 helpcontent:
-- label: single-operations
+- label: to-view-single-operations
   title: Single operations
   content: "Using operations, you can control devices remotely. **Single operations** show all operations executed on a single device.
 
 
   Single operations can have one of the following four statuses: PENDING, EXECUTED, SUCCESSFUL, FAILED. For each operation, the name, status, and device is provided. Clicking the device leads you to the detailed view of the particular device."
-- label: bulk-operations
+- label: to-view-bulk-operations
   title: Bulk operations
   content: "**Bulk operations** are single operations executed on a set of devices.
 

--- a/content/device-management-application/registering-devices.md
+++ b/content/device-management-application/registering-devices.md
@@ -8,7 +8,7 @@ outputs:
 section:
   - device_management
 helpcontent:
-  - label: connecting-devices
+  - label: registering-devices
     title: Connecting devices
     content: "To connect devices to Cumulocity IoT they must be registered. To register one or more devices, click **Register device** and follow the instructions in the wizard or in the user documentation.
 

--- a/content/device-management-application/viewing-all-devices.md
+++ b/content/device-management-application/viewing-all-devices.md
@@ -8,7 +8,7 @@ outputs:
 section:
   - device_management
 helpcontent:
-  - label: viewing-devices
+  - label: viewing-all-devices
     title: Viewing devices
     content: "The device list shows the most relevant information for all devices connected to your account. The columns shown in the device list may be customized to your needs, see the user documentation for details.
 

--- a/content/device-management-application/working-with-simulators.md
+++ b/content/device-management-application/working-with-simulators.md
@@ -8,7 +8,7 @@ outputs:
 section:
   - device_management
 helpcontent:
-  - label: simulator
+  - label: working-with-simulators
     title: Working with simulators
     content: "With the simulator you can create devices that simulate the same level of functionality as connected hardware devices.
 

--- a/content/standard-tenant/ecosystem-bundle/managing-applications.md
+++ b/content/standard-tenant/ecosystem-bundle/managing-applications.md
@@ -5,7 +5,7 @@ layout: bundle
 section:
   - platform_administration
 helpcontent:
-  - label: applications
+  - label: managing-applications
     title: Applications
     content: "In the **Applications** tab, you can see all applications available in your tenant. There are two kinds of applications:
 

--- a/content/standard-tenant/ecosystem-bundle/managing-microservices.md
+++ b/content/standard-tenant/ecosystem-bundle/managing-microservices.md
@@ -5,7 +5,7 @@ layout: bundle
 section:
   - platform_administration
 helpcontent:
-  - label: microservices
+  - label: managing-microservices
     title: Microservices
     content: "A microservice is a specific type of application, that is a server-side application used to develop further functionality on top of Cumulocity IoT.
 

--- a/content/standard-tenant/managing-data-bundle/file-repository.md
+++ b/content/standard-tenant/managing-data-bundle/file-repository.md
@@ -5,7 +5,7 @@ layout: redirect
 section:
   - platform_administration
 helpcontent:
-- label: files
+- label: file-repository
   title: Files repository
   content: "The file repository provides an overview of the files stored in your account. The files can come from various sources. They can be software images, configuration snapshots taken from devices, log files from devices or web applications uploaded from the **Own applications** page."
 ---


### PR DESCRIPTION
As pointed out in https://github.softwareag.com/IOTA/cumulocity-ui/pull/4228#discussion_r164966, section labels in JSON context help and section ids on the website do not always match. This is to make them consistent.