### PR TITLE
Change logs: Changed the date/time to manipulate the sort order for Streaming Analytics

### DIFF
--- a/content/change-logs/analytics/2023-12-06_additional-value-types-for-the-constant-value-block.md
+++ b/content/change-logs/analytics/2023-12-06_additional-value-types-for-the-constant-value-block.md
@@ -1,5 +1,5 @@
 ---
-date: 2023-12-06T15:52:48.489Z
+date: 2023-12-06T15:55:48.489Z
 title: Additional value types for the Constant Value block
 change_type:
   - value: change-QHu1GdukP

--- a/content/change-logs/analytics/2023-12-06_apama-correlator-version.md
+++ b/content/change-logs/analytics/2023-12-06_apama-correlator-version.md
@@ -1,5 +1,5 @@
 ---
-date: 2023-12-06T15:43:19.842Z
+date: 2023-12-06T16:01:19.842Z
 title: Apama correlator version
 change_type:
   - value: change-2c7RdTdXo4

--- a/content/change-logs/analytics/2023-12-06_basic-diagnostics-information.md
+++ b/content/change-logs/analytics/2023-12-06_basic-diagnostics-information.md
@@ -1,5 +1,5 @@
 ---
-date: 2023-12-06T15:48:37.951Z
+date: 2023-12-06T15:59:37.951Z
 title: Basic diagnostics information
 change_type:
   - value: change-2c7RdTdXo4

--- a/content/change-logs/analytics/2023-12-06_cumulocity-iot-transport-in-apama-10-15-4.md
+++ b/content/change-logs/analytics/2023-12-06_cumulocity-iot-transport-in-apama-10-15-4.md
@@ -1,5 +1,5 @@
 ---
-date: 2023-12-06T16:00:29.942Z
+date: 2023-12-06T15:50:29.942Z
 title: Cumulocity IoT transport in Apama 10.15.4
 change_type:
   - value: change-QHu1GdukP

--- a/content/change-logs/analytics/2023-12-06_enhanced-cumulocity-iot-transport-in-apama-10-15-4-to-reflect-changes-in-rest-api.md
+++ b/content/change-logs/analytics/2023-12-06_enhanced-cumulocity-iot-transport-in-apama-10-15-4-to-reflect-changes-in-rest-api.md
@@ -1,5 +1,5 @@
 ---
-date: 2023-12-06T11:09:00.513Z
+date: 2023-12-06T15:49:00.513Z
 title: Enhanced Cumulocity IoT transport in Apama 10.15.4 to reflect changes in
   REST API
 change_type:

--- a/content/change-logs/analytics/2023-12-06_epl-enhancements-in-apama-10-15-4.md
+++ b/content/change-logs/analytics/2023-12-06_epl-enhancements-in-apama-10-15-4.md
@@ -1,5 +1,5 @@
 ---
-date: 2023-12-06T16:01:49.474Z
+date: 2023-12-06T15:40:49.474Z
 title: EPL enhancements in Apama 10.15.4
 change_type:
   - value: change-QHu1GdukP

--- a/content/change-logs/analytics/2023-12-06_location-of-diagnostics-links.md
+++ b/content/change-logs/analytics/2023-12-06_location-of-diagnostics-links.md
@@ -1,5 +1,5 @@
 ---
-date: 2023-12-06T15:47:12.550Z
+date: 2023-12-06T16:00:12.550Z
 title: Location of diagnostics links
 change_type:
   - value: change-2c7RdTdXo4

--- a/content/change-logs/analytics/2023-12-06_missing-subassets-in-a-device-group-or-asset-hierarchy.md
+++ b/content/change-logs/analytics/2023-12-06_missing-subassets-in-a-device-group-or-asset-hierarchy.md
@@ -1,5 +1,5 @@
 ---
-date: 2023-12-06T15:58:47.648Z
+date: 2023-12-06T15:52:47.648Z
 title: Missing subassets in a device group or asset hierarchy
 change_type:
   - value: change-2c7RdTdXo4

--- a/content/change-logs/analytics/2023-12-06_new-epl-sample.md
+++ b/content/change-logs/analytics/2023-12-06_new-epl-sample.md
@@ -1,5 +1,5 @@
 ---
-date: 2023-12-06T15:50:53.323Z
+date: 2023-12-06T15:57:53.323Z
 title: New EPL sample
 change_type:
   - value: change-QHu1GdukP

--- a/content/change-logs/analytics/2023-12-06_receive-input-from-all-input-sources-by-default.md
+++ b/content/change-logs/analytics/2023-12-06_receive-input-from-all-input-sources-by-default.md
@@ -1,5 +1,5 @@
 ---
-date: 2023-12-06T15:51:42.169Z
+date: 2023-12-06T15:56:42.169Z
 title: Receive input from all input sources by default
 change_type:
   - value: change-QHu1GdukP

--- a/content/change-logs/analytics/2023-12-06_removal-of-machine-learning.md
+++ b/content/change-logs/analytics/2023-12-06_removal-of-machine-learning.md
@@ -1,5 +1,5 @@
 ---
-date: 2023-12-06T10:56:40.813Z
+date: 2023-12-06T15:51:40.813Z
 title: Removal of Machine Learning
 change_type:
   - value: change-inv-3bw8e

--- a/content/change-logs/analytics/2023-12-06_removing-template-parameters.md
+++ b/content/change-logs/analytics/2023-12-06_removing-template-parameters.md
@@ -1,5 +1,5 @@
 ---
-date: 2023-12-06T15:53:54.308Z
+date: 2023-12-06T15:54:54.308Z
 title: Removing template parameters
 change_type:
   - value: change-2c7RdTdXo4

--- a/content/change-logs/analytics/2023-12-06_renamed-commands-for-downloading-analytic-models-and-epl-apps.md
+++ b/content/change-logs/analytics/2023-12-06_renamed-commands-for-downloading-analytic-models-and-epl-apps.md
@@ -1,5 +1,5 @@
 ---
-date: 2023-12-06
+date: 2023-12-06T15:58:12.550Z
 title: Renamed commands for downloading analytic models and EPL apps
 product_area: Analytics
 change_type:

--- a/content/change-logs/analytics/2023-12-06_selection-lists-for-template-parameters.md
+++ b/content/change-logs/analytics/2023-12-06_selection-lists-for-template-parameters.md
@@ -1,5 +1,5 @@
 ---
-date: 2023-12-06T15:58:07.850Z
+date: 2023-12-06T15:53:07.850Z
 title: Selection lists for template parameters
 change_type:
   - value: change-QHu1GdukP


### PR DESCRIPTION
Hi @BeateRixen ,
you told me yesterday that the date and time influence the sort order of the change logs. So I've updated the times for the Streaming Analytics change logs. When only the "Streaming Analytics" filter is selected, the change logs are now shown in the same order as on https://cumulocity.com/docs/changes-analytics/cl-streaming-analytics/ - where I have inserted the two additional entries from the Breaking Changes section at appropriate positions.

Hope this is OK for you, and you are willing to merge it.