### PR TITLE
MTM-57488-Unify-usage-of-complete-vs-finish

### DIFF
--- a/content/change-logs/device-management/ui-c8y-10-18-242-0-New-wizard-for-device-replacement.md
+++ b/content/change-logs/device-management/ui-c8y-10-18-242-0-New-wizard-for-device-replacement.md
@@ -14,4 +14,4 @@ build_artifact:
 ticket: DM-2168
 version: 10.18.242.0
 ---
-In the Device management application, a wizard has been implemented which guides users through replacing a physical device with another one. The replacing device must be registered in the platform in advance and is removed after the replacement procedure has been finished.
+In the Device management application, a wizard has been implemented which guides users through replacing a physical device with another one. The replacing device must be registered in the platform in advance and is removed after the replacement procedure has been completed.

--- a/content/edge/edge-databroker-bundle/databroker-edge.md
+++ b/content/edge/edge-databroker-bundle/databroker-edge.md
@@ -60,7 +60,7 @@ kube-system              kube-scheduler-localhost                               
 kube-system              metrics-server-5b78d5f9c6-7l45k                                  1/1     Running     0          82m
 tigera-operator          tigera-operator-76bbbcbc85-6clrf                                 1/1     Running     0          82m
 ```
-The key pods that should be running are `pulsar-bookie-0`, `pulsar-broker-0`, `pulsar-zookeeper-0` and `databroker-agent-server`, with a suffix for the pod name specific to the installation. It may take a few minutes for the Kubernetes pods to settle into a running state after the installation has finished.
+The key pods that should be running are `pulsar-bookie-0`, `pulsar-broker-0`, `pulsar-zookeeper-0` and `databroker-agent-server`, with a suffix for the pod name specific to the installation. It may take a few minutes for the Kubernetes pods to settle into a running state after the installation has been completed.
 
 For more information on installing and troubleshooting the Messaging Service see the [Messaging Service Installation & operations guide](https://empower.softwareag.com/sl24sec/SecuredServices/document/java/cumulocity_iot_platform/iot10-15-0/10-15-0_Messaging_Service_Installation_and_Operations_guide.pdf).
 


### PR DESCRIPTION
Replaced usage of “finish” with “complete” wherever this makes sense (is replaceable without changing the meaning).