### PR TITLE
MTM-57413 UI data connectors contextual help link is wrong release/r10.16.0

### DIFF
--- a/content/users-guide/enterprise-tenant-bundle/data-broker.md
+++ b/content/users-guide/enterprise-tenant-bundle/data-broker.md
@@ -44,7 +44,7 @@ Be aware of the following limitations of the data broker:
 * Data broker does not guarantee the same order of messages on destination tenants as it was on the source tenant.
 * While we provide backwards compatibility, we cannot ensure that data broker can send data to {{< product-c8y-iot >}} tenants which run on earlier {{< product-c8y-iot >}} versions than the source.
 
-<a name="data-connectors"></a>
+<a name="data-connector"></a>
 ### Data connectors
 
 A data connector describes the subset of the data that you would like to send to a destination tenant as well as the URL of that destination tenant.

--- a/content/users-guide/enterprise-tenant-bundle/data-broker.md
+++ b/content/users-guide/enterprise-tenant-bundle/data-broker.md
@@ -44,7 +44,7 @@ Be aware of the following limitations of the data broker:
 * Data broker does not guarantee the same order of messages on destination tenants as it was on the source tenant.
 * While we provide backwards compatibility, we cannot ensure that data broker can send data to {{< product-c8y-iot >}} tenants which run on earlier {{< product-c8y-iot >}} versions than the source.
 
-<a name="data-broker-connectors"></a>
+<a name="data-connectors"></a>
 ### Data connectors
 
 A data connector describes the subset of the data that you would like to send to a destination tenant as well as the URL of that destination tenant.


### PR DESCRIPTION
Aligned the name of the anchor on the website for "Data connectors" section with the name of the label in JSON.

https://github.com/SoftwareAG/c8y-docs/blob/5d40aebe482d491bfa7b77c3a3ac6480b6b1e12e/content/users-guide/enterprise-tenant-bundle/data-broker.md?plain=1#L11-L48