### PR TITLE
Stop using term 'real-time engine'

### DIFF
--- a/content/concepts/realtime-bundle/implementation.md
+++ b/content/concepts/realtime-bundle/implementation.md
@@ -6,9 +6,9 @@ weight: 40
 
 {{< product-c8y-iot >}} provides several processing modes for API requests:
 
-* **persistent** - Stores data in the {{< product-c8y-iot >}} database and sends data to the streaming analytics engine. Afterwards, {{< product-c8y-iot >}} returns the result of the request. This is the default mode.
+* **persistent** - Stores data in the {{< product-c8y-iot >}} database and sends data to the Streaming Analytics engine. Afterwards, {{< product-c8y-iot >}} returns the result of the request. This is the default mode.
 
-* **transient** - Sends data to the streaming analytics engine and immediately returns the results asynchronously but does not store data in {{< product-c8y-iot >}}'s database. This mode saves storage and processing costs and is useful for example when tracking devices in real time without requiring data to be stored.
+* **transient** - Sends data to the Streaming Analytics engine and immediately returns the results asynchronously but does not store data in {{< product-c8y-iot >}}'s database. This mode saves storage and processing costs and is useful for example when tracking devices in real time without requiring data to be stored.
 
 * **quiescent** - Behaves similar to the persistent mode with the exception that no real-time notifications will be sent. The quiescent processing mode is applicable only for measurements and events.
 

--- a/content/concepts/realtime-bundle/implementation.md
+++ b/content/concepts/realtime-bundle/implementation.md
@@ -6,9 +6,9 @@ weight: 40
 
 {{< product-c8y-iot >}} provides several processing modes for API requests:
 
-* **persistent** - Stores data in the {{< product-c8y-iot >}} database and sends data to the real-time engine. Afterwards, {{< product-c8y-iot >}} returns the result of the request. This is the default mode.
+* **persistent** - Stores data in the {{< product-c8y-iot >}} database and sends data to the streaming analytics engine. Afterwards, {{< product-c8y-iot >}} returns the result of the request. This is the default mode.
 
-* **transient** - Sends data to the real-time engine and immediately returns the results asynchronously but does not store data in {{< product-c8y-iot >}}'s database. This mode saves storage and processing costs and is useful for example when tracking devices in real time without requiring data to be stored.
+* **transient** - Sends data to the streaming analytics engine and immediately returns the results asynchronously but does not store data in {{< product-c8y-iot >}}'s database. This mode saves storage and processing costs and is useful for example when tracking devices in real time without requiring data to be stored.
 
 * **quiescent** - Behaves similar to the persistent mode with the exception that no real-time notifications will be sent. The quiescent processing mode is applicable only for measurements and events.
 

--- a/content/concepts/realtime-bundle/realtime-processing-in-cumulocity.md
+++ b/content/concepts/realtime-bundle/realtime-processing-in-cumulocity.md
@@ -4,7 +4,7 @@ layout: bundle
 weight: 1
 ---
 
-On top of {{< product-c8y-iot >}} you can use the Apama streaming analytics engine to define business operations for immediate processing of incoming data from devices or other data sources. These user-defined operations can for example alert applications of new incoming data, create new operations based on the received data (such as sending an alarm when a threshold for a sensor is exceeded), or trigger operations on devices. The operation logic is implemented in Apama's Event Processing Language (EPL).
+On top of {{< product-c8y-iot >}} you can use the Apama Streaming Analytics engine to define business operations for immediate processing of incoming data from devices or other data sources. These user-defined operations can for example alert applications of new incoming data, create new operations based on the received data (such as sending an alarm when a threshold for a sensor is exceeded), or trigger operations on devices. The operation logic is implemented in Apama's Event Processing Language (EPL).
 
 Apama's Event Processing Language covers statements, which are organized into actions and monitors. Monitor files can be edited directly from within {{< product-c8y-iot >}} using the Streaming Analytics application. Alternatively, you can install Apama on your local machine and develop your applications with {{< sag-designer >}} - an Eclipse-based development environment. You can deploy your monitor files as Apama applications to {{< product-c8y-iot >}}, see [Basic functionality](/streaming-analytics/epl-apps/#basic-functionality) for more information.
 


### PR DESCRIPTION
I think it's a legacy from back when this document covered both Esper and Apama. 'streaming analytics engine' is more specific, and is used earlier in https://cumulocity.com/docs/concepts/realtime/#realtime-processing-in-cumulocity