### PR TITLE
PAB-4371: Change log entry for security vulnerability

### DIFF
--- a/content/change-logs/analytics/apama-in-c8y-25-34-0-Updated-Microservice-SDK-for-vulnerable-third-party-components.md
+++ b/content/change-logs/analytics/apama-in-c8y-25-34-0-Updated-Microservice-SDK-for-vulnerable-third-party-components.md
@@ -1,0 +1,17 @@
+---
+date: 2024-02-07
+title: Updated Microservice SDK for vulnerable third-party components
+product_area: Analytics
+change_type:
+  - value: change-VSkj2iV9m
+    label: Security
+component:
+  - value: component-M5-cepIIS
+    label: Streaming Analytics
+build_artifact:
+  - value: tc-KXXmo2SUR
+    label: apama-in-c8y
+ticket: PAB-4371
+version: 25.34.0
+---
+To fix a security vulnerability, the Microservice SDK has been updated to version 1020.50.0 to use version 1.2.13 of *logback-core* and *logback-classic*.

--- a/content/change-logs/analytics/apama-in-c8y-25-34-0-Updated-Microservice-SDK-for-vulnerable-third-party-components.md
+++ b/content/change-logs/analytics/apama-in-c8y-25-34-0-Updated-Microservice-SDK-for-vulnerable-third-party-components.md
@@ -3,8 +3,8 @@ date: 2024-02-07
 title: Updated Microservice SDK for vulnerable third-party components
 product_area: Analytics
 change_type:
-  - value: change-VSkj2iV9m
-    label: Security
+  - value: change-2c7RdTdXo4
+    label: Improvement
 component:
   - value: component-M5-cepIIS
     label: Streaming Analytics


### PR DESCRIPTION
This is my first go at adding a change log entry. Not sure if I did it right. Note that I did this manually (still need to find out how to install Netlify).

https://itrac.eur.ad.sag/browse/PAB-4377 tells me to use "Security" as a tag. But this type cannot (yet?) be selected from the Hugo-generated doc. And note that I used the "change-VSkj2iV9m" value which is normally used for the Fix type - this needs to be changed to something else.

Looking forward to the feedback/corrections from the C8Y doc team.

The corresponding software build 25.34.0 is to be deployed to eu-latest tomorrow, on Feb 7th.