### PR TITLE
PAQ 2024: Remove "by default" from the title and file name

### DIFF
--- a/content/change-logs/analytics/apama-in-c8y-24-18-0-Receive-input-from-all-input-sources.md
+++ b/content/change-logs/analytics/apama-in-c8y-24-18-0-Receive-input-from-all-input-sources.md
@@ -1,6 +1,6 @@
 ---
 date: 2023-12-06T15:56:42.169Z
-title: Receive input from all input sources by default
+title: Receive input from all input sources
 change_type:
   - value: change-QHu1GdukP
     label: Feature


### PR DESCRIPTION
The automatic backport for this was not possible. Therefore doing this on a separate PR.