### PR TITLE
PAB-4302 - Warn about unsupported manifest settings, just in case they get 'discovered'

### DIFF
--- a/content/microservice-sdk/general-aspects-bundle/microservice-manifest.md
+++ b/content/microservice-sdk/general-aspects-bundle/microservice-manifest.md
@@ -191,6 +191,9 @@ See below for detailed information about available settings.
 </tbody>
 </table>
 
+{{< c8y-admon-caution >}}
+Some manifest settings are used exclusively by internal components, and are not documented here. Use of these features outside of internal components is not supported, and is subject to change without notice.
+{{< /c8y-admon-caution >}}
 
 #### Version {#version}
 


### PR DESCRIPTION
In practice, this is to cover the terminationGracePeriodSeconds and lifecycle