### PR TITLE
Create ui-c8y-1019-6-4-map-widget-in-dashboard-created-along-connecting-smartphone-has-no-device-assigned-5350-graft-release-cd-5591.md

### DIFF
--- a/content/change-logs/ui-c8y-1019-6-4-map-widget-in-dashboard-created-along-connecting-smartphone-has-no-device-assigned-5350-graft-release-cd-5591.md
+++ b/content/change-logs/ui-c8y-1019-6-4-map-widget-in-dashboard-created-along-connecting-smartphone-has-no-device-assigned-5350-graft-release-cd-5591.md
@@ -1,0 +1,17 @@
+---
+date: ""
+title: Map widget in dashboard created along connecting smartphone has no device assigned (#5350) [GRAFT][release/cd] (#5591)
+product_area: undefined
+change_type:
+  - value: change-VSkj2iV9m
+    label: Fix
+component:
+  - value: component-YdSEScrEC
+    label: Cockpit
+build_artifact:
+  - value: tc-pjJiURv9Y
+    label: ui-c8y
+ticket: MTM-57689] Map widget in dashboard created along connecting smartphone has no device assigned (#5350) [GRAFT][release/cd
+version: 1019.6.4
+---
+Co-authored-by: Jakub Drewniak <jdre@softwareag.com>

--- a/content/change-logs/ui-c8y-1019-6-4-map-widget-in-dashboard-created-along-connecting-smartphone-has-no-device-assigned-5350-graft-release-cd-5591.md
+++ b/content/change-logs/ui-c8y-1019-6-4-map-widget-in-dashboard-created-along-connecting-smartphone-has-no-device-assigned-5350-graft-release-cd-5591.md
@@ -1,6 +1,6 @@
 ---
 date: ""
-title: Map widget without assigned device in dashboard when connecting smartphone
+title: Map widget correctly assigns smartphone as device
 product_area: Application enablement \u0026 solutions
 change_type:
   - value: change-VSkj2iV9m

--- a/content/change-logs/ui-c8y-1019-6-4-map-widget-in-dashboard-created-along-connecting-smartphone-has-no-device-assigned-5350-graft-release-cd-5591.md
+++ b/content/change-logs/ui-c8y-1019-6-4-map-widget-in-dashboard-created-along-connecting-smartphone-has-no-device-assigned-5350-graft-release-cd-5591.md
@@ -14,4 +14,4 @@ build_artifact:
 ticket: MTM-57689
 version: 1019.6.4
 ---
-The Map widget displayed in the dashboard did not have a device assigned to it when connecting a smartphone. This issue has been fixed so that the Map widget correctly assigns the connected smartphone as the device to display location data from.
+The "Map" widget displayed in the dashboard did not have a device assigned to it when connecting a smartphone. This issue has been fixed so that the "Map" widget correctly assigns the connected smartphone as the device to display location data from.

--- a/content/change-logs/ui-c8y-1019-6-4-map-widget-in-dashboard-created-along-connecting-smartphone-has-no-device-assigned-5350-graft-release-cd-5591.md
+++ b/content/change-logs/ui-c8y-1019-6-4-map-widget-in-dashboard-created-along-connecting-smartphone-has-no-device-assigned-5350-graft-release-cd-5591.md
@@ -1,7 +1,7 @@
 ---
 date: ""
-title: Map widget in dashboard created along connecting smartphone has no device assigned (#5350) [GRAFT][release/cd] (#5591)
-product_area: undefined
+title: Map widget without assigned device in dashboard when connecting smartphone
+product_area: Application enablement \u0026 solutions
 change_type:
   - value: change-VSkj2iV9m
     label: Fix
@@ -11,7 +11,7 @@ component:
 build_artifact:
   - value: tc-pjJiURv9Y
     label: ui-c8y
-ticket: MTM-57689] Map widget in dashboard created along connecting smartphone has no device assigned (#5350) [GRAFT][release/cd
+ticket: MTM-57689
 version: 1019.6.4
 ---
-Co-authored-by: Jakub Drewniak <jdre@softwareag.com>
+The Map widget displayed in the dashboard did not have a device assigned to it when connecting a smartphone. This issue has been fixed so that the Map widget correctly assigns the connected smartphone as the device to display location data from.


### PR DESCRIPTION
Release note created by c8y-ui-automations[bot]

Ticket: [MTM-57689] Map widget in dashboard created along connecting smartphone has no device assigned (#5350) [GRAFT][release/cd](https://cumulocity.atlassian.net/browse/MTM-57689] Map widget in dashboard created along connecting smartphone has no device assigned (#5350) [GRAFT][release/cd)
Original PR: [5591](https://github.softwareag.com/IOTA/cumulocity-ui/pull/5591)