### PR TITLE
[GRAFT][DM-3121] Missing translations of descriptions of some numeric fields

### DIFF
--- a/content/change-logs/device-management/ui-c8y-10-19-5-12-missing-translations-of-descriptions-of-some-numeric-fields.md
+++ b/content/change-logs/device-management/ui-c8y-10-19-5-12-missing-translations-of-descriptions-of-some-numeric-fields.md
@@ -1,0 +1,17 @@
+---
+date: ""
+title: Missing translations of descriptions of some numeric fields
+product_area: Device management & connectivity
+change_type:
+  - value: change-VSkj2iV9m
+    label: Fix
+component:
+  - value: component-YbYJ3gLU_
+    label: Web SDK
+build_artifact:
+  - value: tc-pjJiURv9Y
+    label: ui-c8y
+ticket: DM-3121
+version: 10.19.5.12
+---
+The description of some numeric fields may have appeared only in its English version. This is now fixed and description of numeric fields should appear in the selected platform language.

--- a/content/change-logs/device-management/ui-c8y-10-19-5-12-missing-translations-of-descriptions-of-some-numeric-fields.md
+++ b/content/change-logs/device-management/ui-c8y-10-19-5-12-missing-translations-of-descriptions-of-some-numeric-fields.md
@@ -14,4 +14,4 @@ build_artifact:
 ticket: DM-3121
 version: 10.19.5.12
 ---
-The descriptions of some numeric fields may have appeared only in its English version. This is now fixed and the descriptions of numeric fields appears in the selected platform language.
+The descriptions of some numeric fields may have appeared only in its English version. This is now fixed and the descriptions of numeric fields appear in the selected platform language.

--- a/content/change-logs/device-management/ui-c8y-10-19-5-12-missing-translations-of-descriptions-of-some-numeric-fields.md
+++ b/content/change-logs/device-management/ui-c8y-10-19-5-12-missing-translations-of-descriptions-of-some-numeric-fields.md
@@ -14,4 +14,4 @@ build_artifact:
 ticket: DM-3121
 version: 10.19.5.12
 ---
-The description of some numeric fields may have appeared only in its English version. This is now fixed and description of numeric fields should appear in the selected platform language.
+The descriptions of some numeric fields may have appeared only in its English version. This is now fixed and the descriptions of numeric fields appears in the selected platform language.


### PR DESCRIPTION
# Backport

This will backport the following commits from `develop` to `release/y2024`:
 - [Merge pull request #1724 from SoftwareAG/bugfix/ui-c8y-10-19-5-12-missing-translations-of-descriptions-of-some-numeric-fields](https://github.com/SoftwareAG/c8y-docs/pull/1724)

<!--- Backport version: 9.4.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)