### PR TITLE
[GRAFT][DM-3154] Grid filter text not getting clear

### DIFF
--- a/content/change-logs/device-management/ui-c8y-10-18-0-227-10-19-5-13-10-18-503-44-grid-filter-text-not-getting-clear.md
+++ b/content/change-logs/device-management/ui-c8y-10-18-0-227-10-19-5-13-10-18-503-44-grid-filter-text-not-getting-clear.md
@@ -1,6 +1,6 @@
 ---
 date: ""
-title: Grid filter text not getting clear
+title: Grid filter text not cleared on filter reset
 product_area: Device management & connectivity
 change_type:
   - value: change-VSkj2iV9m
@@ -14,4 +14,4 @@ build_artifact:
 ticket: DM-3154
 version: 10.18.0.227,10.19.5.13,10.18.503.44
 ---
-In data grid columns using the simple FilteringFormRendererComponent to display filter input, the input value was not cleared even though the filter itself was reset. This is now fixed and input value is cleared when filter is reset.
+When using the simple `FilteringFormRendererComponent` in data grid columns to display filter inputs, the input values were not cleared when the filter was reset. This issue has been fixed - now when the filter is reset, the input values are properly cleared.

--- a/content/change-logs/device-management/ui-c8y-10-18-0-227-10-19-5-13-10-18-503-44-grid-filter-text-not-getting-clear.md
+++ b/content/change-logs/device-management/ui-c8y-10-18-0-227-10-19-5-13-10-18-503-44-grid-filter-text-not-getting-clear.md
@@ -1,0 +1,17 @@
+---
+date: ""
+title: Grid filter text not getting clear
+product_area: Device management & connectivity
+change_type:
+  - value: change-VSkj2iV9m
+    label: Fix
+component:
+  - value: component-YbYJ3gLU_
+    label: Web SDK
+build_artifact:
+  - value: tc-pjJiURv9Y
+    label: ui-c8y
+ticket: DM-3154
+version: 10.18.0.227,10.19.5.13,10.18.503.44
+---
+In data grid columns using the simple FilteringFormRendererComponent to display filter input, the input value was not cleared even though the filter itself was reset. This is now fixed and input value is cleared when filter is reset.

--- a/content/change-logs/device-management/ui-c8y-10-18-0-227-10-19-5-13-10-18-503-44-grid-filter-text-not-getting-clear.md
+++ b/content/change-logs/device-management/ui-c8y-10-18-0-227-10-19-5-13-10-18-503-44-grid-filter-text-not-getting-clear.md
@@ -12,6 +12,6 @@ build_artifact:
   - value: tc-pjJiURv9Y
     label: ui-c8y
 ticket: DM-3154
-version: 10.18.0.227,10.19.5.13,10.18.503.44
+version: 10.18.503.44
 ---
 When using the simple `FilteringFormRendererComponent` in data grid columns to display filter inputs, the input values were not cleared when the filter was reset. This issue has been fixed - now when the filter is reset, the input values are properly cleared.


### PR DESCRIPTION
# Backport

This will backport the following commits from `develop` to `release/y2024`:
 - [Merge pull request #1725 from SoftwareAG/bugfix/ui-c8y-10-18-0-227-10-19-5-13-10-18-503-44-grid-filter-text-not-getting-clear](https://github.com/SoftwareAG/c8y-docs/pull/1725)

<!--- Backport version: 9.4.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)