### PR TITLE
PAB-4379: Internal error for inconsistent chain ID

### DIFF
--- a/content/change-logs/analytics/apama-in-c8y-20240228-Asynchronous-alarm-inputs-no-longer-cause-internal-errors-in-model-chains.md
+++ b/content/change-logs/analytics/apama-in-c8y-20240228-Asynchronous-alarm-inputs-no-longer-cause-internal-errors-in-model-chains.md
@@ -12,6 +12,6 @@ build_artifact:
   - value: tc-KXXmo2SUR
     label: apama-in-c8y
 ticket: PAB-4379
-version: 25.xx.0
+version: 
 ---
 Asynchronous alarm inputs declared by the **Alarm Output** blocks were considered for connectivity chains between models, leading to "Internal error : inconsistent chain ID" errors in some scenarios. This is now fixed and synchronous inputs declared by a block are now no longer considered for model chains.

--- a/content/change-logs/analytics/apama-in-c8y-20240228-Asynchronous-alarm-inputs-no-longer-cause-internal-errors-in-model-chains.md
+++ b/content/change-logs/analytics/apama-in-c8y-20240228-Asynchronous-alarm-inputs-no-longer-cause-internal-errors-in-model-chains.md
@@ -14,4 +14,4 @@ build_artifact:
 ticket: PAB-4379
 version: 
 ---
-Asynchronous alarm inputs declared by the **Alarm Output** blocks were considered for connectivity chains between models, leading to "Internal error : inconsistent chain ID" errors in some scenarios. This is now fixed and synchronous inputs declared by a block are now no longer considered for model chains.
+Asynchronous alarm inputs declared by the **Alarm Output** blocks were considered for connectivity chains between models, leading to "Internal error : inconsistent chain ID" errors in some scenarios. This is now fixed and asynchronous inputs declared by a block are now no longer considered for model chains.

--- a/content/change-logs/analytics/apama-in-c8y-25-xx-0-Asynchronous-alarm-inputs-no-longer-cause-internal-errors-in-model-chains.md
+++ b/content/change-logs/analytics/apama-in-c8y-25-xx-0-Asynchronous-alarm-inputs-no-longer-cause-internal-errors-in-model-chains.md
@@ -1,0 +1,17 @@
+---
+date: ""
+title: Asynchronous alarm inputs no longer cause internal errors in model chains
+change_type:
+  - value: change-VSkj2iV9m
+    label: Fix
+product_area: Analytics
+component:
+  - value: component-M5-cepIIS
+    label: Streaming Analytics
+build_artifact:
+  - value: tc-KXXmo2SUR
+    label: apama-in-c8y
+ticket: PAB-xxxx
+version: 25.xx.0
+---
+Asynchronous alarm inputs declared by the **Alarm Output** blocks were considered for connectivity chains between models, leading to "Internal error : inconsistent chain ID" errors in some scenarios. This is now fixed and synchronous inputs declared by a block are now no longer considered for model chains.

--- a/content/change-logs/analytics/apama-in-c8y-25-xx-0-Asynchronous-alarm-inputs-no-longer-cause-internal-errors-in-model-chains.md
+++ b/content/change-logs/analytics/apama-in-c8y-25-xx-0-Asynchronous-alarm-inputs-no-longer-cause-internal-errors-in-model-chains.md
@@ -11,7 +11,7 @@ component:
 build_artifact:
   - value: tc-KXXmo2SUR
     label: apama-in-c8y
-ticket: PAB-xxxx
+ticket: PAB-4379
 version: 25.xx.0
 ---
 Asynchronous alarm inputs declared by the **Alarm Output** blocks were considered for connectivity chains between models, leading to "Internal error : inconsistent chain ID" errors in some scenarios. This is now fixed and synchronous inputs declared by a block are now no longer considered for model chains.


### PR DESCRIPTION
This is a first draft of a change log entry without a final version. This is for a fix and will thus only appear in the upcoming yearly release notes. 

As an experiment:
I used "25.xx.0" for the version instead of leaving it blank, both in the file name and in the metadata. Would this be helpful for the deployment meeting attendee when it's time for adding the date and build version?

Took the text from the "Readme Text" field and added a bit more info.. Also tried to add an appropriate title. 
@shrutidogra-23 and @rthrippleton , if you have some better text, then please make a suggestion.