### PR TITLE
Create ui-c8y-1019-7-3-unable-to-switch-tabs-when-dashboard-has-two-widgets-with-dashboard.md

### DIFF
--- a/content/change-logs/ui-c8y-1019-7-3-unable-to-switch-tabs-when-dashboard-has-two-widgets-with-dashboard.md
+++ b/content/change-logs/ui-c8y-1019-7-3-unable-to-switch-tabs-when-dashboard-has-two-widgets-with-dashboard.md
@@ -1,6 +1,6 @@
 ---
 date: ""
-title: Fix inability to switch tabs with multiple widgets using dashboard date context
+title: Switching tabs with multiple widgets using the dashboard date context works smoothly
 product_area: Application enablement & solutions
 change_type:
   - value: change-VSkj2iV9m

--- a/content/change-logs/ui-c8y-1019-7-3-unable-to-switch-tabs-when-dashboard-has-two-widgets-with-dashboard.md
+++ b/content/change-logs/ui-c8y-1019-7-3-unable-to-switch-tabs-when-dashboard-has-two-widgets-with-dashboard.md
@@ -1,6 +1,6 @@
 ---
 date: ""
-title: Unable to switch tabs when dashboard has two widgets with dashboard date context (#5682) [GRAFT][release/cd] (#5707)
+title: Fix inability to switch tabs with multiple widgets using dashboard date context
 product_area: Application enablement & solutions
 change_type:
   - value: change-VSkj2iV9m
@@ -14,4 +14,4 @@ build_artifact:
 ticket: MTM-58128
 version: 1019.7.3
 ---
-Unable to switch tabs when dashboard has two widgets with dashboard date context (#5682) [GRAFT][release/cd] (#5707)
+Fixed an issue where users were unable to switch between dashboard tabs if the dashboard contained two or more widgets using the dashboard date context filter. Users can now smoothly transition between tabs regardless of the number of dashboard date context widgets present.

--- a/content/change-logs/ui-c8y-1019-7-3-unable-to-switch-tabs-when-dashboard-has-two-widgets-with-dashboard.md
+++ b/content/change-logs/ui-c8y-1019-7-3-unable-to-switch-tabs-when-dashboard-has-two-widgets-with-dashboard.md
@@ -1,0 +1,17 @@
+---
+date: ""
+title: Unable to switch tabs when dashboard has two widgets with dashboard date context (#5682) [GRAFT][release/cd] (#5707)
+product_area: Application enablement & solutions
+change_type:
+  - value: change-VSkj2iV9m
+    label: Fix
+component:
+  - value: component-YdSEScrEC
+    label: Cockpit
+build_artifact:
+  - value: tc-pjJiURv9Y
+    label: ui-c8y
+ticket: MTM-58128
+version: 1019.7.3
+---
+Unable to switch tabs when dashboard has two widgets with dashboard date context (#5682) [GRAFT][release/cd] (#5707)


### PR DESCRIPTION
Release note created by c8y-ui-automations[bot]

Ticket: [MTM-58128](https://cumulocity.atlassian.net/browse/MTM-58128)
Original PR: [5707](https://github.softwareag.com/IOTA/cumulocity-ui/pull/5707)