### PR TITLE
PAM-34632: Copied over PAM release note for wew utility functions for the TimeFormat event library

### DIFF
--- a/content/change-logs/analytics/apama-in-c8y-20240307-New-utility-functions-for-the-EPL-TimeFormat-event-library.md
+++ b/content/change-logs/analytics/apama-in-c8y-20240307-New-utility-functions-for-the-EPL-TimeFormat-event-library.md
@@ -1,0 +1,25 @@
+---
+date: 
+title: New utility functions for the EPL TimeFormat event library
+change_type:
+  - value: change-2c7RdTdXo4
+    label: Improvement
+product_area: Analytics
+component:
+  - value: component-M5-cepIIS
+    label: Streaming Analytics
+build_artifact:
+  - value: tc-KXXmo2SUR
+    label: apama-in-c8y
+ticket: PAM-34632
+version:
+---
+The following utility functions have been added to the TimeFormat event library to help with comparing and manipulating datetimes. As with the existing functions, the new utility functions work for the local time zone, an arbitrary time zone and, where appropriate, the UTC time zone.
+
+* `dateComponent`: Gives the datetime for the previous midnight in the time zone at the given datetime.
+* `timeComponent`: Gives the number of seconds since the previous midnight in the time zone at the given datetime.
+* `daysSinceEpoch`: Gives the number of Julian days since the beginning of the epoch at the given datetime.
+* `getOffset`: Gives the offset in seconds of the time zone from UTC at the given datetime, taking into account any daylight savings that may be being applied.
+* `getRawOffset`: Gives the base offset in seconds of the time zone, that is, without daylight savings applied.
+
+For usage information, see the API Reference for EPL (ApamaDoc).


### PR DESCRIPTION
The original release note is at https://docbuilder1.eur.ad.sag/jenkins/job/pam/job/trunk-webhelp_en/lastSuccessfulBuild/artifact/out/webhelp/index.html#page/pam-webhelp%2Fco-ApaRelNot_10155_epl_enhancements.html

@Rob-J-SAG , I've added "EPL" to the title - is this enough for the user to understand that this is about Streaming Analytics?

Also not sure about the reference to the ApamaDoc. As the doc for PAM 1015.5 is not yet live, I cannot add a link. Biut is it possible for the user to see the updated ApamaDoc somewhere? Or should we remove the reference to the ApamaDoc?