### PR TITLE
Cdh 2024 announcement identical 10 18 release

### DIFF
--- a/content/change-logs/analytics/cdh-10-18-0-Release-identical-to-10-18.md
+++ b/content/change-logs/analytics/cdh-10-18-0-Release-identical-to-10-18.md
@@ -1,6 +1,6 @@
 ---
 date: TODO
-title: Apama correlator version
+title: 2024 release of Cumulocity IoT DataHub identical to 10.18 release
 change_type:
   - value: change-inv-3bw8e
     label: Announcement

--- a/content/change-logs/analytics/cdh-10-18-0-Release-identical-to-10-18.md
+++ b/content/change-logs/analytics/cdh-10-18-0-Release-identical-to-10-18.md
@@ -1,0 +1,16 @@
+---
+date: TODO
+title: Apama correlator version
+change_type:
+  - value: change-inv-3bw8e
+    label: Announcement
+product_area: Analytics
+component:
+  - value: component-A8vMaVaTg
+    label: DataHub
+build_artifact:
+  - value: TODO
+    label: TODO
+version: 10.18.0
+---
+The Cumulocity IoT DataHub version of the 2024 release is identical to the version of the 10.18 release. For details on the release see the [10.18 release notes](https://cumulocity.com/releasenotes/release-10-18-0/datahub-10-18-0/) and the [10.18 documentation](https://cumulocity.com/guides/10.18.0/datahub/datahub-overview/).


### PR DESCRIPTION
Hi Beate,

as recently discussed I wanna add a release note that CDH 2024 is identical to 10.18. Which values shall I use for the TODOs?

Thanks
Christoph