### PR TITLE
PAM-34661: Copied over PAM release note for toDecimal into PAQ change log

### DIFF
--- a/content/change-logs/analytics/apama-in-c8y-20240308-EPL-improvement-to-string-toDecimal-method.md
+++ b/content/change-logs/analytics/apama-in-c8y-20240308-EPL-improvement-to-string-toDecimal-method.md
@@ -1,0 +1,17 @@
+---
+date: 
+title: EPL improvement to string.toDecimal() method
+change_type:
+  - value: change-2c7RdTdXo4
+    label: Improvement
+product_area: Analytics
+component:
+  - value: component-M5-cepIIS
+    label: Streaming Analytics
+build_artifact:
+  - value: tc-KXXmo2SUR
+    label: apama-in-c8y
+ticket: PAM-34661
+version:
+---
+Previously, performing `string.toDecimal()` for a string with an invalid conversion resulted in a `ParseException` error. This now returns "0.0". This was done to make the experience of using `toDecimal()` similar to using `toFloat()`. If you want the previous strict behavior, use `decimal.parse()` instead.


### PR DESCRIPTION
https://itrac.eur.ad.sag/browse/PAM-34669 says that the apama-in-c8y version containing this is v25.76.0.