### PR TITLE
Create ui-c8y-1018-503-70-manually-provided-units-should-have-a-higher-priority-compared-to-the.md

### DIFF
--- a/content/change-logs/application-enablement/ui-c8y-1018-503-70-manually-provided-units-should-have-a-higher-priority-compared-to-the.md
+++ b/content/change-logs/application-enablement/ui-c8y-1018-503-70-manually-provided-units-should-have-a-higher-priority-compared-to-the.md
@@ -1,6 +1,6 @@
 ---
 date: ""
-title: Manually provided units have higher priority than datapoint units
+title: Custom units overrule datapoint units
 product_area: Application enablement & solutions
 change_type:
   - value: change-VSkj2iV9m
@@ -14,4 +14,4 @@ build_artifact:
 ticket: MTM-58426
 version: 1018.503.70
 ---
-In some cases, users want to override the units of a datapoint with a custom unit to better fit their use case. Previously, the units specified on the datapoint would always take precedence over any manually specified units, even if this was not the desired behavior. With this change, manually provided units now have a higher priority and will be used instead of the datapoint units. This allows users to have more control over the units displayed in their dashboards and other assets.
+In some cases, users want to override the units of a datapoint with a custom unit. Previously, the datapoint unit had a higher priority than the manually specified unit, which was not the desired behavior. With this change, manually provided units now have a higher priority compared to the actual datapoint units. This ensures that the custom unit specified by the user is always used instead of the default datapoint unit.

--- a/content/change-logs/application-enablement/ui-c8y-1018-503-70-manually-provided-units-should-have-a-higher-priority-compared-to-the.md
+++ b/content/change-logs/application-enablement/ui-c8y-1018-503-70-manually-provided-units-should-have-a-higher-priority-compared-to-the.md
@@ -1,6 +1,6 @@
 ---
 date: ""
-title: manually provided units should have a higher priority compared to the actual datapoint units (#5903) [GRAFT][release/y2024] (#5920)
+title: Manually provided units have higher priority than datapoint units
 product_area: Application enablement & solutions
 change_type:
   - value: change-VSkj2iV9m
@@ -14,4 +14,4 @@ build_artifact:
 ticket: MTM-58426
 version: 1018.503.70
 ---
-manually provided units should have a higher priority compared to the actual datapoint units (#5903) [GRAFT][release/y2024] (#5920)
+In some cases, users want to override the units of a datapoint with a custom unit to better fit their use case. Previously, the units specified on the datapoint would always take precedence over any manually specified units, even if this was not the desired behavior. With this change, manually provided units now have a higher priority and will be used instead of the datapoint units. This allows users to have more control over the units displayed in their dashboards and other assets.

--- a/content/change-logs/application-enablement/ui-c8y-1018-503-70-manually-provided-units-should-have-a-higher-priority-compared-to-the.md
+++ b/content/change-logs/application-enablement/ui-c8y-1018-503-70-manually-provided-units-should-have-a-higher-priority-compared-to-the.md
@@ -1,0 +1,17 @@
+---
+date: ""
+title: manually provided units should have a higher priority compared to the actual datapoint units (#5903) [GRAFT][release/y2024] (#5920)
+product_area: Application enablement & solutions
+change_type:
+  - value: change-VSkj2iV9m
+    label: Fix
+component:
+  - value: component-YdSEScrEC
+    label: Cockpit
+build_artifact:
+  - value: tc-pjJiURv9Y
+    label: ui-c8y
+ticket: MTM-58426
+version: 1018.503.70
+---
+manually provided units should have a higher priority compared to the actual datapoint units (#5903) [GRAFT][release/y2024] (#5920)


### PR DESCRIPTION
Release note created by c8y-ui-automations[bot]

Ticket: [MTM-58426](https://cumulocity.atlassian.net/browse/MTM-58426)
Original PR: [5920](https://github.softwareag.com/IOTA/cumulocity-ui/pull/5920)