### PR TITLE
Create ui-c8y-1019-13-2-manually-provided-units-should-have-a-higher-priority-compared-to-the.md

### DIFF
--- a/content/change-logs/application-enablement/ui-c8y-1019-13-2-manually-provided-units-should-have-a-higher-priority-compared-to-the.md
+++ b/content/change-logs/application-enablement/ui-c8y-1019-13-2-manually-provided-units-should-have-a-higher-priority-compared-to-the.md
@@ -1,0 +1,17 @@
+---
+date: ""
+title: manually provided units should have a higher priority compared to the actual datapoint units (#5903) [GRAFT][release/cd] (#5921)
+product_area: Application enablement & solutions
+change_type:
+  - value: change-VSkj2iV9m
+    label: Fix
+component:
+  - value: component-YdSEScrEC
+    label: Cockpit
+build_artifact:
+  - value: tc-pjJiURv9Y
+    label: ui-c8y
+ticket: MTM-58426
+version: 1019.13.2
+---
+manually provided units should have a higher priority compared to the actual datapoint units (#5903) [GRAFT][release/cd] (#5921)


### PR DESCRIPTION
Release note created by c8y-ui-automations[bot]

Ticket: [MTM-58426](https://cumulocity.atlassian.net/browse/MTM-58426)
Original PR: [5921](https://github.softwareag.com/IOTA/cumulocity-ui/pull/5921)