### PR TITLE
Create ui-c8y-1019-15-2-fix-log-output-when-running-local-dev-server-wrong-ports-5881.md

### DIFF
--- a/content/change-logs/application-enablement/ui-c8y-1019-15-2-fix-log-output-when-running-local-dev-server-wrong-ports-5881.md
+++ b/content/change-logs/application-enablement/ui-c8y-1019-15-2-fix-log-output-when-running-local-dev-server-wrong-ports-5881.md
@@ -1,6 +1,6 @@
 ---
 date: ""
-title: Fix log output when running local dev server (wrong ports) (#5881) [GRAFT][release/cd] (#5983)
+title: Fix wrong port numbers in log output when running local development server
 product_area: Application enablement & solutions
 change_type:
   - value: change-VSkj2iV9m
@@ -14,4 +14,4 @@ build_artifact:
 ticket: MTM-57344
 version: 1019.15.2
 ---
-Fix log output when running local dev server (wrong ports) (#5881) [GRAFT][release/cd] (#5983)
+When running a local development server with the `ng serve` command, the log output incorrectly displays the port numbers if the default port is already used. This has been fixed to show the correct port numbers that the local development server is actually using. This improves the developer experience by avoiding confusion about which ports are being used.

--- a/content/change-logs/application-enablement/ui-c8y-1019-15-2-fix-log-output-when-running-local-dev-server-wrong-ports-5881.md
+++ b/content/change-logs/application-enablement/ui-c8y-1019-15-2-fix-log-output-when-running-local-dev-server-wrong-ports-5881.md
@@ -1,0 +1,17 @@
+---
+date: ""
+title: Fix log output when running local dev server (wrong ports) (#5881) [GRAFT][release/cd] (#5983)
+product_area: Application enablement & solutions
+change_type:
+  - value: change-VSkj2iV9m
+    label: Fix
+component:
+  - value: component-YbYJ3gLU_
+    label: Web SDK
+build_artifact:
+  - value: tc-pjJiURv9Y
+    label: ui-c8y
+ticket: MTM-57344
+version: 1019.15.2
+---
+Fix log output when running local dev server (wrong ports) (#5881) [GRAFT][release/cd] (#5983)

--- a/content/change-logs/application-enablement/ui-c8y-1019-15-2-fix-log-output-when-running-local-dev-server-wrong-ports-5881.md
+++ b/content/change-logs/application-enablement/ui-c8y-1019-15-2-fix-log-output-when-running-local-dev-server-wrong-ports-5881.md
@@ -1,6 +1,6 @@
 ---
 date: ""
-title: Fix wrong port numbers in log output when running local development server
+title: Correct port numbers shown in log output when running local development server
 product_area: Application enablement & solutions
 change_type:
   - value: change-VSkj2iV9m

--- a/content/change-logs/application-enablement/ui-c8y-1019-15-2-fix-log-output-when-running-local-dev-server-wrong-ports-5881.md
+++ b/content/change-logs/application-enablement/ui-c8y-1019-15-2-fix-log-output-when-running-local-dev-server-wrong-ports-5881.md
@@ -14,4 +14,4 @@ build_artifact:
 ticket: MTM-57344
 version: 1019.15.2
 ---
-When running a local development server with the `ng serve` command, the log output incorrectly displays the port numbers if the default port is already used. This has been fixed to show the correct port numbers that the local development server is actually using. This improves the developer experience by avoiding confusion about which ports are being used.
+When running a local development server with the `ng serve` command, the log output incorrectly displayed the port numbers if the default port was already used. This has been fixed to show the correct port numbers that the local development server is actually using. This improves the developer experience by avoiding confusion about which ports are being used.


### PR DESCRIPTION
Release note created by c8y-ui-automations[bot]

Ticket: [MTM-57344](https://cumulocity.atlassian.net/browse/MTM-57344)
Original PR: [5983](https://github.softwareag.com/IOTA/cumulocity-ui/pull/5983)