### PR TITLE
Create ui-c8y-1018-503-73-new-versions-for-plugins-are-no-longer-marked-as-latest-5770.md

### DIFF
--- a/content/change-logs/platform-services/ui-c8y-1018-503-73-new-versions-for-plugins-are-no-longer-marked-as-latest-5770.md
+++ b/content/change-logs/platform-services/ui-c8y-1018-503-73-new-versions-for-plugins-are-no-longer-marked-as-latest-5770.md
@@ -1,0 +1,17 @@
+---
+date: ""
+title: New versions for plugins are no longer marked as latest. (#5770) [GRAFT][release/y2024] (#5873)
+product_area: Platform services
+change_type:
+  - value: change-VSkj2iV9m
+    label: Fix
+component:
+  - value: component-0UgqXH1Ys
+    label: Administration
+build_artifact:
+  - value: tc-pjJiURv9Y
+    label: ui-c8y
+ticket: MTM-57691
+version: 1018.503.73
+---
+New versions for plugins are no longer marked as latest. (#5770) [GRAFT][release/y2024] (#5873)

--- a/content/change-logs/platform-services/ui-c8y-1018-503-73-new-versions-for-plugins-are-no-longer-marked-as-latest-5770.md
+++ b/content/change-logs/platform-services/ui-c8y-1018-503-73-new-versions-for-plugins-are-no-longer-marked-as-latest-5770.md
@@ -1,6 +1,6 @@
 ---
 date: ""
-title: New versions for plugins are no longer marked as latest. (#5770) [GRAFT][release/y2024] (#5873)
+title: New plugin versions are no longer automatically marked as latest
 product_area: Platform services
 change_type:
   - value: change-VSkj2iV9m
@@ -14,4 +14,4 @@ build_artifact:
 ticket: MTM-57691
 version: 1018.503.73
 ---
-New versions for plugins are no longer marked as latest. (#5770) [GRAFT][release/y2024] (#5873)
+In the past, when a new version of a plugin was uploaded, it was automatically marked as the latest version. This could lead to confusion if an older version of the plugin was intended to be used as the latest one. With this change, new plugin versions are no longer automatically marked as latest when they are uploaded. This gives users more control to explicitly decide which version of a plugin should be marked as the latest one. Existing plugins and their latest version marking are not impacted by this change.


### PR DESCRIPTION
Release note created by c8y-ui-automations[bot]

Ticket: [MTM-57691](https://cumulocity.atlassian.net/browse/MTM-57691)
Original PR: [5873](https://github.softwareag.com/IOTA/cumulocity-ui/pull/5873)