### PR TITLE
Align label of managing-trusted-certificate-settings with anchor on website

### DIFF
--- a/content/device-management-application/managing-device-data-bundle/managing-trusted-certificate-settings.md
+++ b/content/device-management-application/managing-device-data-bundle/managing-trusted-certificate-settings.md
@@ -3,7 +3,7 @@ weight: 41
 title: Managing trusted certificate settings
 layout: redirect
 helpcontent:
-  - label: managing-trusted-certificates-settings
+  - label: managing-trusted-certificate-settings
     title: Trusted certificates settings
     content: "Administrators can configure the Certificate Revocation List (CRL) settings (online or offline). If the revoked certificate information is maintained by the issuing Certificate Authority (CA), the online check option can be selected. If the CA does not maintain the CRL information, the offline setup can be selected. In offline setup, the revoked certificate serial number can either be added manually or can be uploaded in bulk using the file template attached."
 ---

--- a/content/device-management-application/managing-device-data-bundle/managing-trusted-certificate-settings.md
+++ b/content/device-management-application/managing-device-data-bundle/managing-trusted-certificate-settings.md
@@ -3,7 +3,7 @@ weight: 41
 title: Managing trusted certificate settings
 layout: redirect
 helpcontent:
-  - label: trusted-certificates-settings
+  - label: managing-trusted-certificates-settings
     title: Trusted certificates settings
     content: "Administrators can configure the Certificate Revocation List (CRL) settings (online or offline). If the revoked certificate information is maintained by the issuing Certificate Authority (CA), the online check option can be selected. If the CA does not maintain the CRL information, the offline setup can be selected. In offline setup, the revoked certificate serial number can either be added manually or can be uploaded in bulk using the file template attached."
 ---


### PR DESCRIPTION
This is to align the property name and url returned in JSON response with the anchor id on the website.

![2024-03-28_12-03](https://github.com/SoftwareAG/c8y-docs/assets/92171763/d2a9276b-7f54-4457-9369-7df2ee604397)
