### PR TITLE
added missing dates

### DIFF
--- a/content/change-logs/device-management/ui-c8y-10-18-0-227-grid-filter-text-not-getting-clear.md
+++ b/content/change-logs/device-management/ui-c8y-10-18-0-227-grid-filter-text-not-getting-clear.md
@@ -1,5 +1,5 @@
 ---
-date: ""
+date: 2023-12-06
 title: Grid filter text not cleared on filter reset
 product_area: Device management & connectivity
 change_type:
@@ -12,6 +12,6 @@ build_artifact:
   - value: tc-pjJiURv9Y
     label: ui-c8y
 ticket: DM-3154
-version: 10.18.0.227,10.19.5.13,10.18.503.44
+version: 10.18.0.227
 ---
 When using the simple `FilteringFormRendererComponent` in data grid columns to display filter inputs, the input values were not cleared when the filter was reset. This issue has been fixed - now when the filter is reset, the input values are properly cleared.

--- a/content/change-logs/device-management/ui-c8y-10-18-497-0-breadcrumps-added-to-all-device-tab.md
+++ b/content/change-logs/device-management/ui-c8y-10-18-497-0-breadcrumps-added-to-all-device-tab.md
@@ -1,5 +1,5 @@
 ---
-date: ""
+date: 2023-12-06
 title: Breadcrumps added to all device details tabs
 product_area: Device management & connectivity
 change_type:

--- a/content/change-logs/device-management/ui-c8y-10-18-503-0-Input-in-text-fields-on-the-shell-tab-no-longer-truncated.md
+++ b/content/change-logs/device-management/ui-c8y-10-18-503-0-Input-in-text-fields-on-the-shell-tab-no-longer-truncated.md
@@ -1,5 +1,5 @@
 ---
-date: 
+date: 2023-12-20
 title: Input in text fields on the Shell tab no longer truncated
 product_area: Device management & connectivity
 change_type:

--- a/content/change-logs/device-management/ui-c8y-10-18-503-7-fixed-issues-with-german-translation.md
+++ b/content/change-logs/device-management/ui-c8y-10-18-503-7-fixed-issues-with-german-translation.md
@@ -1,5 +1,5 @@
 ---
-date: ""
+date: 2023-12-20
 title: Fixed issues with German translation
 product_area: Device management & connectivity
 change_type:

--- a/content/change-logs/device-management/ui-c8y-10-18-505-5-prevention-of-html-injection-attacks-through-smartrest-template-names.md
+++ b/content/change-logs/device-management/ui-c8y-10-18-505-5-prevention-of-html-injection-attacks-through-smartrest-template-names.md
@@ -1,5 +1,5 @@
 ---
-date: ""
+date: 2024-13-14
 title: Prevention of HTML injection attacks through SmartREST template names
 product_area: Device management & connectivity
 change_type:

--- a/content/change-logs/device-management/ui-c8y-10-18-507-0-improved-context-help-in-subassets-page.md
+++ b/content/change-logs/device-management/ui-c8y-10-18-507-0-improved-context-help-in-subassets-page.md
@@ -1,7 +1,7 @@
 ---
 date: 2024-13-14
 title: Improved context help in Subassets page
-product_area: Application enablement & solutions
+product_area: Device management & connectivity
 change_type:
   - value: change-2c7RdTdXo4
     label: Improvement

--- a/content/change-logs/device-management/ui-c8y-10-18-507-0-improved-context-help-in-subassets-page.md
+++ b/content/change-logs/device-management/ui-c8y-10-18-507-0-improved-context-help-in-subassets-page.md
@@ -1,5 +1,5 @@
 ---
-date: ""
+date: 2024-13-14
 title: Improved context help in Subassets page
 product_area: Application enablement & solutions
 change_type:

--- a/content/change-logs/device-management/ui-c8y-10-18-510-0-improved-information-on-use-source-timestamp-configuration.md
+++ b/content/change-logs/device-management/ui-c8y-10-18-510-0-improved-information-on-use-source-timestamp-configuration.md
@@ -1,5 +1,5 @@
 ---
-date: ""
+date: 2024-13-14
 title: Improved information on "Use source timestamp" configuration
 product_area: Device management & connectivity
 change_type:

--- a/content/change-logs/device-management/ui-c8y-10-19-2-1-fixed-issue-with-0-as-value-in-custom-event-and-operation-fields.md
+++ b/content/change-logs/device-management/ui-c8y-10-19-2-1-fixed-issue-with-0-as-value-in-custom-event-and-operation-fields.md
@@ -1,5 +1,5 @@
 ---
-date: ""
+date: 2024-13-14
 title: Fixed issue with 0 as value in custom event and operation fields
 product_area: Device management & connectivity
 change_type:

--- a/content/change-logs/device-management/ui-c8y-10-19-2-5-migration-of-the-tracking-tab-to-angular.md
+++ b/content/change-logs/device-management/ui-c8y-10-19-2-5-migration-of-the-tracking-tab-to-angular.md
@@ -1,5 +1,5 @@
 ---
-date: ""
+date: 2024-13-14
 title: Migration of the Tracking tab to Angular
 product_area: Device management & connectivity
 change_type:

--- a/content/change-logs/device-management/ui-c8y-10-19-5-12-missing-translations-of-descriptions-of-some-numeric-fields.md
+++ b/content/change-logs/device-management/ui-c8y-10-19-5-12-missing-translations-of-descriptions-of-some-numeric-fields.md
@@ -1,5 +1,5 @@
 ---
-date: ""
+date: 2024-13-14
 title: Missing translations of descriptions of some numeric fields
 product_area: Device management & connectivity
 change_type:

--- a/content/change-logs/device-management/ui-c8y-1019-6-11-configuration-ui-gets-supported-security-mode-list-from-the-lwm-2.md
+++ b/content/change-logs/device-management/ui-c8y-1019-6-11-configuration-ui-gets-supported-security-mode-list-from-the-lwm-2.md
@@ -1,5 +1,5 @@
 ---
-date: ""
+date: 2024-13-14
 title: Supported security modes retrieved dynamically from LWM2M agent
 product_area: Device management & connectivity
 change_type:


### PR DESCRIPTION
As far as I can see, the following changes for the ui-c8y component have versions that are already deployed. For the fixes, the date is actually not relevant as they will not show up anyway. I just added it for completeness. For other change types, it is relevant and the changes should show up on the website. Please doublecheck. I took the information from this page: https://app.powerbi.com/groups/me/reports/c5ea0410-0991-4d6e-a42a-a77f3f27025f/ReportSection3b30a8dd93ced753ae3a?ctid=d9662eb9-ad98-4e74-a8a2-04ed5d544db6&experience=power-bi. Just checked the ui components and only up to 14.03.2024.