### PR TITLE
PAQ 2024 release note for /prometheus improvement (PAB-4411)

### DIFF
--- a/content/change-logs/analytics/apama-in-c8y-20240319-More-efficient-implementation-of-the-prometheus-endpoint-in-the-Streaming-Analytics-microservices.md
+++ b/content/change-logs/analytics/apama-in-c8y-20240319-More-efficient-implementation-of-the-prometheus-endpoint-in-the-Streaming-Analytics-microservices.md
@@ -12,6 +12,6 @@ build_artifact:
   - value: tc-KXXmo2SUR
     label: apama-in-c8y
 ticket: PAB-4411
-version: 
+version:
 ---
 The implementation of the `/prometheus` endpoint has been optimized by removing redundant calls to other internal endpoints.

--- a/content/change-logs/analytics/apama-in-c8y-20240319-More-efficient-implementation-of-the-prometheus-endpoint-in-the-Streaming-Analytics-microservices.md
+++ b/content/change-logs/analytics/apama-in-c8y-20240319-More-efficient-implementation-of-the-prometheus-endpoint-in-the-Streaming-Analytics-microservices.md
@@ -1,5 +1,5 @@
 ---
-date: 2024-03-19
+date: 2024-05-09
 title: More efficient implementation of the /prometheus endpoint in the Streaming Analytics microservices
 change_type:
   - value: change-VSkj2iV9m
@@ -12,6 +12,6 @@ build_artifact:
   - value: tc-KXXmo2SUR
     label: apama-in-c8y
 ticket: PAB-4411
-version:
+version: 24.41.8
 ---
 The implementation of the `/prometheus` endpoint has been optimized by removing redundant calls to other internal endpoints.

--- a/content/change-logs/analytics/apama-in-c8y-20240319-More-efficient-implementation-of-the-prometheus-endpoint-in-the-Streaming-Analytics-microservices.md
+++ b/content/change-logs/analytics/apama-in-c8y-20240319-More-efficient-implementation-of-the-prometheus-endpoint-in-the-Streaming-Analytics-microservices.md
@@ -1,0 +1,17 @@
+---
+date: 2024-03-19
+title: More efficient implementation of the /prometheus endpoint in the Streaming Analytics microservices
+change_type:
+  - value: change-VSkj2iV9m
+    label: Fix
+product_area: Analytics
+component:
+  - value: component-M5-cepIIS
+    label: Streaming Analytics
+build_artifact:
+  - value: tc-KXXmo2SUR
+    label: apama-in-c8y
+ticket: PAB-4411
+version: 
+---
+The implementation of the `/prometheus` endpoint has been optimized by removing redundant calls to other internal endpoints.


### PR DESCRIPTION
Copied the Prometheus change log entry from develop to y2024 and removed the version. The version is to be filled in during the deployment meeting.