### PR TITLE
add date for cumulocity component deployment

### DIFF
--- a/content/change-logs/platform-services/cumulocity-10-20-131-0-modified-behavior-on-creating-an-external-id-without-an-existing-associated-global-id.md
+++ b/content/change-logs/platform-services/cumulocity-10-20-131-0-modified-behavior-on-creating-an-external-id-without-an-existing-associated-global-id.md
@@ -1,5 +1,5 @@
 ---
-date: ""
+date: 2024-04-04
 title: Modified behavior on creating an external ID without an existing
   associated global ID
 product_area: Platform services

--- a/content/change-logs/platform-services/cumulocity-10-20-135-0-fixed-issue-with-sms-requests-to-bic-provider.md
+++ b/content/change-logs/platform-services/cumulocity-10-20-135-0-fixed-issue-with-sms-requests-to-bic-provider.md
@@ -1,5 +1,5 @@
 ---
-date: ""
+date: 2024-04-04
 title: Fixed issue with SMS requests to Bics provider
 product_area: Platform services
 change_type:

--- a/content/change-logs/platform-services/cumulocity-10-20-266-0-Root-level-managed-object-is-not-obtained-on-query.md
+++ b/content/change-logs/platform-services/cumulocity-10-20-266-0-Root-level-managed-object-is-not-obtained-on-query.md
@@ -1,5 +1,5 @@
 ---
-date: ""
+date: 2024-04-04
 title: Root level managed object is now reliably found when querying with the onlyRoots flag
 product_area: Platform services
 change_type:

--- a/content/change-logs/platform-services/cumulocity-10-20-285-0-add-possibility-to-move-operation-status-from-failed-when-failurereason-was-set.md
+++ b/content/change-logs/platform-services/cumulocity-10-20-285-0-add-possibility-to-move-operation-status-from-failed-when-failurereason-was-set.md
@@ -1,5 +1,5 @@
 ---
-date: ""
+date: 2024-04-04
 title: Status can be changed from FAILED for operations with "failureReason"
 product_area: Platform services
 change_type:
@@ -14,5 +14,5 @@ build_artifact:
 ticket: MTM-51764
 version: 10.20.285.0
 ---
-Previously, the status for operations with a "failureReason" fragment could not be changed from FAILED, since the "failureReason" fragment was not allowed for other statuses. 
+Previously, the status for operations with a "failureReason" fragment could not be changed from FAILED, since the "failureReason" fragment was not allowed for other statuses.
 Now "failureReason" is automatically removed when moving an operation from the FAILED status.

--- a/content/change-logs/platform-services/cumulocity-10-20-294-0-crl-proper-error-code.md
+++ b/content/change-logs/platform-services/cumulocity-10-20-294-0-crl-proper-error-code.md
@@ -1,5 +1,5 @@
 ---
-date: ""
+date: 2024-04-04
 title: Correct HTTP response code sent on missing fields in CRL (Certificate Revocation List) entries
 product_area: Platform services
 change_type:


### PR DESCRIPTION
On April 04th, the cumulocity component was updated to version 10.20.296.0 (from 10.20.73.0). The tickets in this PR need to get the date to show up in the change logs (at least those that are not fixes).