### PR TITLE
add deployment date for various c8y-ui files

### DIFF
--- a/content/change-logs/application-enablement/ui-c8y-1019-11-0-the-size-of-the-measurement-displaying-line-was-increased.md
+++ b/content/change-logs/application-enablement/ui-c8y-1019-11-0-the-size-of-the-measurement-displaying-line-was-increased.md
@@ -1,5 +1,5 @@
 ---
-date: ""
+date: 2024-03-21
 title: Improved measurement display in Linear Gauge and Silo widgets
 product_area: Application enablement & solutions
 change_type:

--- a/content/change-logs/application-enablement/ui-c8y-1019-12-0-services-registry-service-that-introduces-a-hook-do-register-services-in.md
+++ b/content/change-logs/application-enablement/ui-c8y-1019-12-0-services-registry-service-that-introduces-a-hook-do-register-services-in.md
@@ -1,5 +1,5 @@
 ---
-date: ""
+date: 2024-03-21
 title: Introduce service registry with a hook for registering services
 product_area: Application enablement & solutions
 change_type:

--- a/content/change-logs/application-enablement/ui-c8y-1019-13-1-asset-selector-search-now-returning-the-same-as-normal-search-graft.md
+++ b/content/change-logs/application-enablement/ui-c8y-1019-13-1-asset-selector-search-now-returning-the-same-as-normal-search-graft.md
@@ -1,5 +1,5 @@
 ---
-date: ""
+date: 2024-03-27
 title: Asset selector search results now consistent with normal search
 product_area: Application enablement & solutions
 change_type:

--- a/content/change-logs/application-enablement/ui-c8y-1019-13-2-manually-provided-units-should-have-a-higher-priority-compared-to-the.md
+++ b/content/change-logs/application-enablement/ui-c8y-1019-13-2-manually-provided-units-should-have-a-higher-priority-compared-to-the.md
@@ -1,5 +1,5 @@
 ---
-date: ""
+date: 2024-03-27
 title: Custom units overrule datapoint units
 product_area: Application enablement & solutions
 change_type:

--- a/content/change-logs/application-enablement/ui-c8y-1019-13-3-ng-cli-prompt-verison-limit-is-now-5-additionally-the-latest.md
+++ b/content/change-logs/application-enablement/ui-c8y-1019-13-3-ng-cli-prompt-verison-limit-is-now-5-additionally-the-latest.md
@@ -1,5 +1,5 @@
 ---
-date: ""
+date: 2024-03-27
 title: Clearer version selection when scaffolding a new application with Angular CLI
 product_area: Application enablement & solutions
 change_type:

--- a/content/change-logs/application-enablement/ui-c8y-1019-13-5-fixed-an-issue-in-password-reset-form-which-prevented-user-from.md
+++ b/content/change-logs/application-enablement/ui-c8y-1019-13-5-fixed-an-issue-in-password-reset-form-which-prevented-user-from.md
@@ -1,5 +1,5 @@
 ---
-date: ""
+date: 2024-03-27
 title: Users can reset their password properly
 product_area: Application enablement & solutions
 change_type:

--- a/content/change-logs/application-enablement/ui-c8y-1019-15-2-fix-log-output-when-running-local-dev-server-wrong-ports-5881.md
+++ b/content/change-logs/application-enablement/ui-c8y-1019-15-2-fix-log-output-when-running-local-dev-server-wrong-ports-5881.md
@@ -1,5 +1,5 @@
 ---
-date: ""
+date: 2024-04-04
 title: Correct port numbers shown in log output when running local development server
 product_area: Application enablement & solutions
 change_type:

--- a/content/change-logs/application-enablement/ui-c8y-1019-16-0-added-zip-argument-when-building-an-application-5452-graft-release-cd.md
+++ b/content/change-logs/application-enablement/ui-c8y-1019-16-0-added-zip-argument-when-building-an-application-5452-graft-release-cd.md
@@ -1,6 +1,6 @@
 ---
-date: ""
-title: ZIP option now available when building an application 
+date: 2024-04-04
+title: ZIP option now available when building an application
 product_area: Application enablement & solutions
 change_type:
   - value: change-QHu1GdukP

--- a/content/change-logs/application-enablement/ui-c8y-1019-16-4-map-widget-config-latitude-and-longitute-inputs-bugs-fixes-5819-graft.md
+++ b/content/change-logs/application-enablement/ui-c8y-1019-16-4-map-widget-config-latitude-and-longitute-inputs-bugs-fixes-5819-graft.md
@@ -1,5 +1,5 @@
 ---
-date: ""
+date: 2024-04-04
 title: Accurate handling of latitude and longitude inputs in the Map widget
 product_area: Application enablement & solutions
 change_type:

--- a/content/change-logs/application-enablement/ui-c8y-1019-17-1-help-and-service-widget-will-no-longer-open-a-new-tab.md
+++ b/content/change-logs/application-enablement/ui-c8y-1019-17-1-help-and-service-widget-will-no-longer-open-a-new-tab.md
@@ -1,5 +1,5 @@
 ---
-date: ""
+date: 2024-04-04
 title: Help and Service widget no longer opens a new tab when redirecting to the current application
 product_area: Application enablement & solutions
 change_type:

--- a/content/change-logs/application-enablement/ui-c8y-1019-18-1-fix-data-point-list-widget-redirecting-assets-devices-incorrectly-5831-graft.md
+++ b/content/change-logs/application-enablement/ui-c8y-1019-18-1-fix-data-point-list-widget-redirecting-assets-devices-incorrectly-5831-graft.md
@@ -1,5 +1,5 @@
 ---
-date: ""
+date: 2024-04-04
 title: Asset names in the "Data point list" widget now redirect to the correct URL
 product_area: Application enablement & solutions
 change_type:

--- a/content/change-logs/application-enablement/ui-c8y-1019-19-7-adjust-ui-info-gauge-widget-labels-6018-graft-release-cd-6049.md
+++ b/content/change-logs/application-enablement/ui-c8y-1019-19-7-adjust-ui-info-gauge-widget-labels-6018-graft-release-cd-6049.md
@@ -1,5 +1,5 @@
 ---
-date: ""
+date: 2024-04-04
 title: Label display in the "Info gauge" widget has been improved
 product_area: Application enablement & solutions
 change_type:

--- a/content/change-logs/application-enablement/ui-c8y-1019-7-11-fix-navigator-app-icon-size.md
+++ b/content/change-logs/application-enablement/ui-c8y-1019-7-11-fix-navigator-app-icon-size.md
@@ -1,5 +1,5 @@
 ---
-date: ""
+date: 2024-03-14
 title: CSS variable now correctly sizes the app icon
 product_area: Application enablement & solutions
 change_type:

--- a/content/change-logs/application-enablement/ui-c8y-1019-7-13-dashboard-availability-is-now-disabled-for-the-home-dashboard.md
+++ b/content/change-logs/application-enablement/ui-c8y-1019-7-13-dashboard-availability-is-now-disabled-for-the-home-dashboard.md
@@ -1,5 +1,5 @@
 ---
-date: ""
+date: 2024-03-14
 title: Dashboard availability setting removed from the Home dashboard
 product_area: Application enablement & solutions
 change_type:

--- a/content/change-logs/application-enablement/ui-c8y-1019-7-14-availability-translation-separated-for-jp.md
+++ b/content/change-logs/application-enablement/ui-c8y-1019-7-14-availability-translation-separated-for-jp.md
@@ -1,5 +1,5 @@
 ---
-date: ""
+date: 2024-03-14
 title: Separate translation for the term "Aavilability" for Japanese
 product_area: Application enablement & solutions
 change_type:

--- a/content/change-logs/application-enablement/ui-c8y-1019-7-8-fix-angular-js-breadcrumbs-to-also-work-with-asynchronously-resolved-values.md
+++ b/content/change-logs/application-enablement/ui-c8y-1019-7-8-fix-angular-js-breadcrumbs-to-also-work-with-asynchronously-resolved-values.md
@@ -1,5 +1,5 @@
 ---
-date: ""
+date: 2024-03-14
 title: AngularJS breadcrumbs updated to work with asynchronous values
 product_area: Device management & connectivity
 change_type:

--- a/content/change-logs/application-enablement/ui-c8y-1019-8-0-input-range-component-improvements.md
+++ b/content/change-logs/application-enablement/ui-c8y-1019-8-0-input-range-component-improvements.md
@@ -1,5 +1,5 @@
 ---
-date: ""
+date: 2024-03-21
 title: Improvements to input range component
 product_area: Application enablement & solutions
 change_type:
@@ -14,4 +14,4 @@ build_artifact:
 ticket: MTM-57884
 version: 1019.8.0
 ---
-The input range component (`c8y-range`) can be used to show a slider to configure a range. The styling and documentation for this component has been improved to better suiting the overall styling of components and forms. 
+The input range component (`c8y-range`) can be used to show a slider to configure a range. The styling and documentation for this component has been improved to better suiting the overall styling of components and forms.

--- a/content/change-logs/application-enablement/ui-c8y-1019-8-2-fix-added-bookmarks-should-show-page-title-label-not-default-value.md
+++ b/content/change-logs/application-enablement/ui-c8y-1019-8-2-fix-added-bookmarks-should-show-page-title-label-not-default-value.md
@@ -1,5 +1,5 @@
 ---
-date: ""
+date: 2024-03-21
 title: Bookmarks now show page title as label instead of default value
 product_area: Application enablement & solutions
 change_type:

--- a/content/change-logs/application-enablement/ui-c8y-1019-9-0-update-btn-text-in-the-cockpit-setup-stepper.md
+++ b/content/change-logs/application-enablement/ui-c8y-1019-9-0-update-btn-text-in-the-cockpit-setup-stepper.md
@@ -1,5 +1,5 @@
 ---
-date: ""
+date: 2024-03-21
 title: Improved button text in Cockpit setup wizard
 product_area: Application enablement & solutions
 change_type:

--- a/content/change-logs/application-enablement/ui-c8y-1019-9-1-fix-add-pipe-to-generate-asset-group-device-map-marker-pop.md
+++ b/content/change-logs/application-enablement/ui-c8y-1019-9-1-fix-add-pipe-to-generate-asset-group-device-map-marker-pop.md
@@ -1,5 +1,5 @@
 ---
-date: ""
+date: 2024-03-21
 title: Map marker popup correctly links to assets and devices
 product_area: Application enablement & solutions
 change_type:


### PR DESCRIPTION
In the last weeks there were a couple of c8y-ui deployments. Currently the respective date must still be added manually to the affected files which I have done in this PR.

Most of the tickets are fixes which means the date is actually not relevant for the CD change logs. I have still added it as it will get relevant with the next yearly release.

@janhommes In the deployment overview the component ui-c8y has been split (cockpit, administration, device management, repository connect). The deployment date is not always the same for these sub-components. How do we know to which of these a ticket belongs? Do we need to split the build artifact in the future as well? For now, I just guessed.