### PR TITLE
BugherdTask_#817

### DIFF
--- a/content/reference/smartrest-two-bundle/introduction.md
+++ b/content/reference/smartrest-two-bundle/introduction.md
@@ -1,6 +1,6 @@
 ---
 weight: 10
-title: Overview
+title: Introduction
 layout: redirect
 ---
 

--- a/content/reference/smartrest-two-bundle/smartrest-two.md
+++ b/content/reference/smartrest-two-bundle/smartrest-two.md
@@ -4,8 +4,6 @@ title: SmartREST 2.0
 layout: redirect
 ---
 
-### Overview
-
 This section describes the SmartREST 2.0 payload format that can be used with the {{< product-c8y-iot >}} MQTT implementation.
 
 SmartREST 2.0 was designed to make use of the MQTT protocol, so it may reduce the payload even more than the SmartREST 1.0 via HTTP.

--- a/content/reference/smartrest-two.md
+++ b/content/reference/smartrest-two.md
@@ -1,6 +1,6 @@
 ---
 weight: 10
-title: SmartREST 2.0
+title: SmartREST
 layout: bundle
 collection: 'reference/smartrest-two'
 toc: true


### PR DESCRIPTION
- Changed SmartREST 2.0 to SmartREST title because in the overview of the reference guide this section is referred to as such and it does not make sense of the section title to be SmartREST 2.0 and a subsection with that title as well. This is of course just a suggestion. I am still not sure because this whole section is about SmartREST 2.0.
- Overview subsection title changed to "Introduction" as well as file name changed to this.

I am not sure if it would be better to completely organize this section another way.