### PR TITLE
PAQ: Remove Digital Event Services from doc (APMF-2627)

### DIFF
--- a/content/streaming-analytics/epl-apps-bundle/best-practices.md
+++ b/content/streaming-analytics/epl-apps-bundle/best-practices.md
@@ -62,7 +62,6 @@ When designing an Apama solution to be deployed within any form of {{< product-c
 	The Apama features affected by this include:
 	* Apama Database Connector (ADBC).
 	* Correlator-integrated support for the Java Message Service (JMS).
-	* Digital Event Services.
 	* Distributed memory stores.
 	* Connections between correlators.
 * For security and implementing user access control, {{< product-c8y-iot >}} does not make the correlator port available to external processes, see [Microservices](/concepts/applications#microservices).

--- a/content/streaming-analytics/epl-apps-bundle/best-practices.md
+++ b/content/streaming-analytics/epl-apps-bundle/best-practices.md
@@ -57,7 +57,7 @@ When designing an Apama solution to be deployed within any form of {{< product-c
 * For scalability, a correlator may move between hosts and therefore does not have access to a persistent file system. It is a standard {{< product-c8y-iot >}} constraint that all microservices (either provided by the platform, or custom) must be stateless, see [Microservices](/concepts/applications#microservices).
 	The Apama features affected by this include:
 	* Correlator persistence.
-	* MemoryStore persistence.
+	* MemoryStore persistence. 
 * Non-HTTP/REST connections to an external system or process are mostly impractical. Although if a service is available over the internet, then it can be used (for example, an HTTP client inside Apama could connect to publicly accessible HTTP servers).
 	The Apama features affected by this include:
 	* Apama Database Connector (ADBC).


### PR DESCRIPTION
To be merged when DES has been removed from the PAM release that is used by Streaming Analytics.