### PR TITLE
[MTM-57974] Release notes for: an error with logging out of a user us…

### DIFF
--- a/content/change-logs/platform-services/cumulocity-10-20-335-0-fixed-logging-out-of-an-user-if-an-error-occurs-during-updating-of-global-roles.md
+++ b/content/change-logs/platform-services/cumulocity-10-20-335-0-fixed-logging-out-of-an-user-if-an-error-occurs-during-updating-of-global-roles.md
@@ -1,6 +1,6 @@
 ---
 date: ""
-title: Fixed logging out of an user if an error occurs during updating user global roles
+title: OAI-Secure users are no longer logged out during unsuccessful global roles updates
 product_area: Platform services
 change_type:
   - value: change-VSkj2iV9m

--- a/content/change-logs/platform-services/cumulocity-10-20-335-0-fixed-logging-out-of-an-user-if-an-error-occurs-during-updating-of-global-roles.md
+++ b/content/change-logs/platform-services/cumulocity-10-20-335-0-fixed-logging-out-of-an-user-if-an-error-occurs-during-updating-of-global-roles.md
@@ -1,0 +1,17 @@
+---
+date: ""
+title: Fixed logging out of an user if an error occurs during updating user global roles
+product_area: Platform services
+change_type:
+  - value: change-VSkj2iV9m
+    label: Fix
+component:
+  - value: q3kclF6pO
+    label: Authentication
+build_artifact:
+  - value: tc-QHwMfWtBk7
+    label: cumulocity
+ticket: MTM-57974
+version: 10.20.335.0
+---
+An error with logging out of a user using OAI-Secure has been fixed, the user is not logged out if an error occurs while assigning or unassigning global roles.

--- a/content/change-logs/platform-services/cumulocity-10-20-335-0-fixed-logging-out-of-an-user-if-an-error-occurs-during-updating-of-global-roles.md
+++ b/content/change-logs/platform-services/cumulocity-10-20-335-0-fixed-logging-out-of-an-user-if-an-error-occurs-during-updating-of-global-roles.md
@@ -14,4 +14,4 @@ build_artifact:
 ticket: MTM-57974
 version: 10.20.335.0
 ---
-An issue has been fixed with logging out users using OAI-Secure during global roles updates. Now users are no longer logged out if an error occurs while assigning or unassigning global roles.
+An issue has been fixed with logging out users using OAI-Secure during user global roles updates. Now users are no longer logged out if an error occurs while assigning or unassigning global roles.

--- a/content/change-logs/platform-services/cumulocity-10-20-335-0-fixed-logging-out-of-an-user-if-an-error-occurs-during-updating-of-global-roles.md
+++ b/content/change-logs/platform-services/cumulocity-10-20-335-0-fixed-logging-out-of-an-user-if-an-error-occurs-during-updating-of-global-roles.md
@@ -14,4 +14,4 @@ build_artifact:
 ticket: MTM-57974
 version: 10.20.335.0
 ---
-An error with logging out of a user using OAI-Secure has been fixed, the user is not logged out if an error occurs while assigning or unassigning global roles.
+An issue has been fixed with logging out users using OAI-Secure during global roles updates. Now users are no longer logged out if an error occurs while assigning or unassigning global roles.


### PR DESCRIPTION
Release notes for: an error with logging out of a user using OAI-Secure has been fixed, the user is not logged out if an error occurs while updating global roles.