### PR TITLE
Reintroduce "MTM-58246 Update the Web SDK with information about Angular 17"

### DIFF
--- a/content/web/gettingstarted.md
+++ b/content/web/gettingstarted.md
@@ -9,7 +9,7 @@ section:
 This guide will setup your first application. The first step is to install the `@angular/cli` in the right version.
 
 ```bash
-npx @angular/cli@17 new --style=less --standalone=false
+npx @angular/cli@v17-lts new --style=less --standalone=false
 ```
 
 Second, navigate to the folder and add the `@c8y/websdk` package to your Angular application:

--- a/content/web/gettingstarted.md
+++ b/content/web/gettingstarted.md
@@ -8,9 +8,8 @@ section:
 
 This guide will setup your first application. The first step is to install the `@angular/cli` in the right version.
 
-
 ```bash
-npx @angular/cli@v16-lts new --style=less --routing=true
+npx @angular/cli@17 new --style=less --standalone=false
 ```
 
 Second, navigate to the folder and add the `@c8y/websdk` package to your Angular application:
@@ -66,6 +65,13 @@ application using the `-u` flag. For example:
 ```bash
 npm start -- -u http://mytenant.acme.iot
 ```
+
+or
+
+```
+ ng serve <appName> -u http://mytenant.acme.iot
+```
+
 
 When you start the command the application begins to compile. After it is compiled, you can navigate to
 `http://localhost:4200/apps/<<your-app-name>>/` and login to your tenant.

--- a/content/web/introduction.md
+++ b/content/web/introduction.md
@@ -102,6 +102,7 @@ As our releases are bound to the Angular versioning, you must to ensure that you
 
 | Angular version | Web SDK version | Comment |
 | --- | --- | --- |
+| 17.x.x | 1020.x.x | No support for the standalone flag |
 | 16.x.x | 1019.x.x | Using [Angular CLI tooling](https://angular.io/cli). |
 | 15.x.x | 1018.1.x - 1018.x.x | Using `c8ycli` tooling, only yearly release |
 | 14.x.x | 1016.x.x - 1018.0.x | Using `c8ycli` tooling |

--- a/content/web/upgrade-bundle/upgrading-to-angular-17.md
+++ b/content/web/upgrade-bundle/upgrading-to-angular-17.md
@@ -13,3 +13,4 @@ Angular 17 is supported from version `1020.0.0`. The following configuration cha
 - Run the command `ng update @angular/core@17 @angular/cli@17` to update Angular core and CLI to version 17.
 - Update `ngx-bootstrap` to version `12.0.0`.
 - Update `@angular/cdk` to version `17.x.x`.
+- Remove any reference of `loginOptions` in the *src/main.ts* file. The `loginOptions` function is now called under the hood as part of the `loadOptions` function.

--- a/content/web/upgrade-bundle/upgrading-to-angular-17.md
+++ b/content/web/upgrade-bundle/upgrading-to-angular-17.md
@@ -1,0 +1,15 @@
+
+---
+title: Upgrading from Angular 16 to Angular 17  
+layout: redirect
+weight: 10
+---
+
+Angular 17 is supported from version `1020.0.0`. The following configuration changes are required before you can run the application:
+
+- Update all `@c8y` dependencies to version `1020.x.x` in your *package.json*.
+- Replace `import 'zone.js/dist/zone'` with `import 'zone.js'` in the *src/polyfills.ts* file.
+- Replace all occurrences of `"browserTarget"` with `"buildTarget"` in the *angular.json* file.
+- Run the command `ng update @angular/core@17 @angular/cli@17` to update Angular core and CLI to version 17.
+- Update `ngx-bootstrap` to version `12.0.0`.
+- Update `@angular/cdk` to version `17.x.x`.


### PR DESCRIPTION
Reintroduces https://github.com/SoftwareAG/c8y-docs/pull/1924
Only merge after 1020.0.0 or higher of the UI was deployed on eu-latest.