### PR TITLE
Create ui-c8y-1019-22-2-navigator-nodes-are-now-correctly-removed-when-refreshing-the-sub-assets.md

### DIFF
--- a/content/change-logs/application-enablement/ui-c8y-1019-22-2-navigator-nodes-are-now-correctly-removed-when-refreshing-the-sub-assets.md
+++ b/content/change-logs/application-enablement/ui-c8y-1019-22-2-navigator-nodes-are-now-correctly-removed-when-refreshing-the-sub-assets.md
@@ -1,0 +1,17 @@
+---
+date: ""
+title: Navigator nodes are now correctly removed when refreshing the sub-assets grid after removing groups via API. [GRAFT][release/cd] (#6206)
+product_area: Application enablement & solutions
+change_type:
+  - value: change-VSkj2iV9m
+    label: Fix
+component:
+  - value: component-YbYJ3gLU_
+    label: Web SDK
+build_artifact:
+  - value: tc-pjJiURv9Y
+    label: ui-c8y
+ticket: MTM-58562
+version: 1019.22.2
+---
+Navigator nodes are now correctly removed when refreshing the sub-assets grid after removing groups via API. [GRAFT][release/cd] (#6206)

--- a/content/change-logs/application-enablement/ui-c8y-1019-22-2-navigator-nodes-are-now-correctly-removed-when-refreshing-the-sub-assets.md
+++ b/content/change-logs/application-enablement/ui-c8y-1019-22-2-navigator-nodes-are-now-correctly-removed-when-refreshing-the-sub-assets.md
@@ -14,4 +14,4 @@ build_artifact:
 ticket: MTM-58562
 version: 1019.22.2
 ---
-In the Cumulocity IoT user interface, the the navigator did not always update correctly after removing a group or device via the subassets view. This caused the navigator to still show the removed groups or devices and made the UI inconsistent. With this fix, the navigator now correctly refresh after a group or device is removed through the subassets view, ensuring the user interface stays in sync and provides an accurate view of the current inventory.
+In the Cumulocity IoT user interface, the navigator did not always update correctly after removing a group or device via the subassets view. This caused the navigator to still show the removed groups or devices and made the UI inconsistent. With this fix, the navigator now correctly refreshes after a group or device has been removed through the subassets view, ensuring the user interface stays in sync and provides an accurate view of the current inventory.

--- a/content/change-logs/application-enablement/ui-c8y-1019-22-2-navigator-nodes-are-now-correctly-removed-when-refreshing-the-sub-assets.md
+++ b/content/change-logs/application-enablement/ui-c8y-1019-22-2-navigator-nodes-are-now-correctly-removed-when-refreshing-the-sub-assets.md
@@ -1,6 +1,6 @@
 ---
 date: ""
-title: Navigator nodes are now correctly removed when refreshing the sub-assets grid after removing groups via API. [GRAFT][release/cd] (#6206)
+title: Group navigation tree now refreshes correctly after removing groups via Sub-Asset view
 product_area: Application enablement & solutions
 change_type:
   - value: change-VSkj2iV9m

--- a/content/change-logs/application-enablement/ui-c8y-1019-22-2-navigator-nodes-are-now-correctly-removed-when-refreshing-the-sub-assets.md
+++ b/content/change-logs/application-enablement/ui-c8y-1019-22-2-navigator-nodes-are-now-correctly-removed-when-refreshing-the-sub-assets.md
@@ -1,6 +1,6 @@
 ---
 date: ""
-title: Group navigation tree now refreshes correctly after removing groups via Sub-Asset view
+title: Group navigation tree in navigator now refreshes correctly after removing groups via Subassets view
 product_area: Application enablement & solutions
 change_type:
   - value: change-VSkj2iV9m

--- a/content/change-logs/application-enablement/ui-c8y-1019-22-2-navigator-nodes-are-now-correctly-removed-when-refreshing-the-sub-assets.md
+++ b/content/change-logs/application-enablement/ui-c8y-1019-22-2-navigator-nodes-are-now-correctly-removed-when-refreshing-the-sub-assets.md
@@ -14,4 +14,4 @@ build_artifact:
 ticket: MTM-58562
 version: 1019.22.2
 ---
-In the Cumulocity IoT user interface, the sub-assets grid and navigator did not always update correctly after removing a group of devices via the API. This caused the navigator to still show the removed devices and made the UI inconsistent with the actual API state. With this fix, the sub-assets grid and navigator now correctly refresh after a group of devices is removed through the API, ensuring the user interface stays in sync and provides an accurate view of the current inventory.
+In the Cumulocity IoT user interface, the subassets view and the navigator did not always update correctly after removing a group of devices via the API. This caused the navigator to still show the removed devices and made the UI inconsistent with the actual API state. With this fix, the subassets view and the navigator now correctly refresh after a group of devices is removed through the API, ensuring the user interface stays in sync and provides an accurate view of the current inventory.

--- a/content/change-logs/application-enablement/ui-c8y-1019-22-2-navigator-nodes-are-now-correctly-removed-when-refreshing-the-sub-assets.md
+++ b/content/change-logs/application-enablement/ui-c8y-1019-22-2-navigator-nodes-are-now-correctly-removed-when-refreshing-the-sub-assets.md
@@ -1,6 +1,6 @@
 ---
 date: ""
-title: Group navigation tree in navigator now refreshes correctly after removing groups via Subassets view
+title: Group navigation tree in navigator now refreshes correctly after removing groups via subassets view
 product_area: Application enablement & solutions
 change_type:
   - value: change-VSkj2iV9m
@@ -14,4 +14,4 @@ build_artifact:
 ticket: MTM-58562
 version: 1019.22.2
 ---
-In the Cumulocity IoT user interface, the subassets view and the navigator did not always update correctly after removing a group of devices via the API. This caused the navigator to still show the removed devices and made the UI inconsistent with the actual API state. With this fix, the subassets view and the navigator now correctly refresh after a group of devices is removed through the API, ensuring the user interface stays in sync and provides an accurate view of the current inventory.
+In the Cumulocity IoT user interface, the the navigator did not always update correctly after removing a group or device via the subassets view. This caused the navigator to still show the removed groups or devices and made the UI inconsistent. With this fix, the navigator now correctly refresh after a group or device is removed through the subassets view, ensuring the user interface stays in sync and provides an accurate view of the current inventory.

--- a/content/change-logs/application-enablement/ui-c8y-1019-22-2-navigator-nodes-are-now-correctly-removed-when-refreshing-the-sub-assets.md
+++ b/content/change-logs/application-enablement/ui-c8y-1019-22-2-navigator-nodes-are-now-correctly-removed-when-refreshing-the-sub-assets.md
@@ -14,4 +14,4 @@ build_artifact:
 ticket: MTM-58562
 version: 1019.22.2
 ---
-Navigator nodes are now correctly removed when refreshing the sub-assets grid after removing groups via API. [GRAFT][release/cd] (#6206)
+In the Cumulocity IoT user interface, the sub-assets grid and navigator did not always update correctly after removing a group of devices via the API. This caused the navigator to still show the removed devices and made the UI inconsistent with the actual API state. With this fix, the sub-assets grid and navigator now correctly refresh after a group of devices is removed through the API, ensuring the user interface stays in sync and provides an accurate view of the current inventory.


### PR DESCRIPTION
Release note created by c8y-ui-automations[bot]

Ticket: [MTM-58562](https://cumulocity.atlassian.net/browse/MTM-58562)
Original PR: [6206](https://github.softwareag.com/IOTA/cumulocity-ui/pull/6206)