### PR TITLE
Create ui-c8y-1018-503-81-navigator-nodes-are-now-correctly-removed-when-refreshing-the-sub-assets.md

### DIFF
--- a/content/change-logs/application-enablement/ui-c8y-1018-503-81-navigator-nodes-are-now-correctly-removed-when-refreshing-the-sub-assets.md
+++ b/content/change-logs/application-enablement/ui-c8y-1018-503-81-navigator-nodes-are-now-correctly-removed-when-refreshing-the-sub-assets.md
@@ -1,0 +1,17 @@
+---
+date: ""
+title: Navigator nodes are now correctly removed when refreshing the sub-assets grid after removing groups via API. [GRAFT][release/y2024] (#6205)
+product_area: Application enablement & solutions
+change_type:
+  - value: change-VSkj2iV9m
+    label: Fix
+component:
+  - value: component-YbYJ3gLU_
+    label: Web SDK
+build_artifact:
+  - value: tc-pjJiURv9Y
+    label: ui-c8y
+ticket: MTM-58562
+version: 1018.503.81
+---
+Navigator nodes are now correctly removed when refreshing the sub-assets grid after removing groups via API. [GRAFT][release/y2024] (#6205)

--- a/content/change-logs/application-enablement/ui-c8y-1018-503-81-navigator-nodes-are-now-correctly-removed-when-refreshing-the-sub-assets.md
+++ b/content/change-logs/application-enablement/ui-c8y-1018-503-81-navigator-nodes-are-now-correctly-removed-when-refreshing-the-sub-assets.md
@@ -14,4 +14,4 @@ build_artifact:
 ticket: MTM-58562
 version: 1018.503.81
 ---
-In the Cumulocity IoT user interface, the subassets view and the navigator did not always update correctly after removing a group of devices via the API. This caused the navigator to still show the removed devices and made the UI inconsistent with the actual API state. With this fix, the subassets view and the navigator now correctly refresh after a group of devices is removed through the API, ensuring the user interface stays in sync and provides an accurate view of the current inventory.
+In the Cumulocity IoT user interface, the navigator did not always update correctly after removing a group or device via the subassets view. This caused the navigator to still show the removed groups or devices and made the UI inconsistent. With this fix, the navigator now correctly refreshes after a group or device has been removed through the subassets view, ensuring the user interface stays in sync and provides an accurate view of the current inventory.

--- a/content/change-logs/application-enablement/ui-c8y-1018-503-81-navigator-nodes-are-now-correctly-removed-when-refreshing-the-sub-assets.md
+++ b/content/change-logs/application-enablement/ui-c8y-1018-503-81-navigator-nodes-are-now-correctly-removed-when-refreshing-the-sub-assets.md
@@ -1,6 +1,6 @@
 ---
 date: ""
-title: Groups in the navigator and subassets view now refresh correctly after removing groups via API
+title: Group navigation tree in navigator now refreshes correctly after removing groups via subassets view
 product_area: Application enablement & solutions
 change_type:
   - value: change-VSkj2iV9m

--- a/content/change-logs/application-enablement/ui-c8y-1018-503-81-navigator-nodes-are-now-correctly-removed-when-refreshing-the-sub-assets.md
+++ b/content/change-logs/application-enablement/ui-c8y-1018-503-81-navigator-nodes-are-now-correctly-removed-when-refreshing-the-sub-assets.md
@@ -1,6 +1,6 @@
 ---
 date: ""
-title: Navigator nodes are now correctly removed when refreshing the sub-assets grid after removing groups via API. [GRAFT][release/y2024] (#6205)
+title: Groups in the navigator and subassets view now refresh correctly after removing groups via API
 product_area: Application enablement & solutions
 change_type:
   - value: change-VSkj2iV9m

--- a/content/change-logs/application-enablement/ui-c8y-1018-503-81-navigator-nodes-are-now-correctly-removed-when-refreshing-the-sub-assets.md
+++ b/content/change-logs/application-enablement/ui-c8y-1018-503-81-navigator-nodes-are-now-correctly-removed-when-refreshing-the-sub-assets.md
@@ -14,4 +14,4 @@ build_artifact:
 ticket: MTM-58562
 version: 1018.503.81
 ---
-Navigator nodes are now correctly removed when refreshing the sub-assets grid after removing groups via API. [GRAFT][release/y2024] (#6205)
+In the Cumulocity IoT user interface, the subassets view and the navigator did not always update correctly after removing a group of devices via the API. This caused the navigator to still show the removed devices and made the UI inconsistent with the actual API state. With this fix, the subassets view and the navigator now correctly refresh after a group of devices is removed through the API, ensuring the user interface stays in sync and provides an accurate view of the current inventory.


### PR DESCRIPTION
Release note created by c8y-ui-automations[bot]

Ticket: [MTM-58562](https://cumulocity.atlassian.net/browse/MTM-58562)
Original PR: [6205](https://github.softwareag.com/IOTA/cumulocity-ui/pull/6205)