### PR TITLE
Create ui-c8y-1019-23-4-translations-for-wrong-error-message-of-data-explorer-export-pr-6196.md

### DIFF
--- a/content/change-logs/application-enablement/ui-c8y-1019-23-4-translations-for-wrong-error-message-of-data-explorer-export-pr-6196.md
+++ b/content/change-logs/application-enablement/ui-c8y-1019-23-4-translations-for-wrong-error-message-of-data-explorer-export-pr-6196.md
@@ -1,0 +1,17 @@
+---
+date: ""
+title: Translations for "wrong error message of data explorer export" - PR#6196 [GRAFT][release/cd] (#6218)
+product_area: Application enablement & solutions
+change_type:
+  - value: change-VSkj2iV9m
+    label: Fix
+component:
+  - value: component-YdSEScrEC
+    label: Cockpit
+build_artifact:
+  - value: tc-pjJiURv9Y
+    label: ui-c8y
+ticket: MTM-57881
+version: 1019.23.4
+---
+Translations for "wrong error message of data explorer export" - PR#6196 [GRAFT][release/cd] (#6218)


### PR DESCRIPTION
Release note created by pmic

Ticket: [MTM-57881](https://cumulocity.atlassian.net/browse/MTM-57881)
Original PR: [6218](https://github.softwareag.com/IOTA/cumulocity-ui/pull/6218)