### PR TITLE
Update links to api documentation to have version number

### DIFF
--- a/content/edge/rest-api.md
+++ b/content/edge/rest-api.md
@@ -4,7 +4,7 @@ title: REST APIs for Edge
 layout: bundle
 ---
 
-For information about the REST APIs for Edge, see the [{{< openapi >}}](https://cumulocity.com/api/edge/).
+For information about the REST APIs for Edge, see the [{{< openapi >}}](https://cumulocity.com/api/edge/10.18.0/).
 
 {{< c8y-admon-important >}}
 

--- a/content/edge/update-bundle/updating-edge-rest.md
+++ b/content/edge/update-bundle/updating-edge-rest.md
@@ -4,4 +4,4 @@ title: Updating Edge using the REST APIs
 layout: redirect
 ---
 
-To update Edge using the REST APIs, see [POST /edge/update](https://cumulocity.com/api/edge/#tag/Update).
+To update Edge using the REST APIs, see [POST /edge/update](https://cumulocity.com/api/edge/10.18.0/#tag/Update).

--- a/content/edge/update.md
+++ b/content/edge/update.md
@@ -8,4 +8,4 @@ This section describes how to update {{< product-c8y-iot >}} Edge using the GUI 
 
 Keeping your Edge appliance updated ensures that the Edge appliance is running the latest version with new features and enhancements, and helps in improving the security vulnerabilities and performance of the Edge appliance.
 
-You can update the Edge appliance using [the GUI](/edge/update/#updating-edge-gui) or [the REST API](https://cumulocity.com/api/edge/#tag/Update).
+You can update the Edge appliance using [the GUI](/edge/update/#updating-edge-gui) or [the REST API](https://cumulocity.com/api/edge/10.18.0/#tag/Update).


### PR DESCRIPTION
Can only be merged once Edge branch release/10.18.0 is published for the api documentation