### PR TITLE
PAB-4478: Operation is sent back to device that raised the alarm

### DIFF
--- a/content/cockpit/smart-rules-collection.md
+++ b/content/cockpit/smart-rules-collection.md
@@ -520,8 +520,8 @@ The rule checks once a minute if the configured time interval was exceeded. Ther
 
 **Functionality**
 
-If a certain alarm occurs, the specified operation will be send to the device.
-
+If a certain alarm occurs, the specified operation is sent back to the device that raised the alarm.
+The device ID of the target device specified in the operation is not used in this case.
 
 **Parameters**
 

--- a/content/cockpit/smart-rules-collection.md
+++ b/content/cockpit/smart-rules-collection.md
@@ -521,7 +521,10 @@ The rule checks once a minute if the configured time interval was exceeded. Ther
 **Functionality**
 
 If a certain alarm occurs, the specified operation is sent back to the device that raised the alarm.
-The device ID of the target device specified in the operation is not used in this case.
+
+{{< c8y-admon-info >}}
+Any alternative target device specified in the operation is ignored.
+{{< /c8y-admon-info >}}
 
 **Parameters**
 


### PR DESCRIPTION
This is a doc fix which can be merged immediately.