### PR TITLE
Update Edge Tile to say Edge 10.18

### DIFF
--- a/content/section/edge_server/_index.md
+++ b/content/section/edge_server/_index.md
@@ -1,5 +1,5 @@
 ---
-title: "Edge"
+title: "Edge 10.18"
 icon: "c8y-icon c8y-icon-cumulocity-iot"
 weight: 60
 svg: '<svg


### PR DESCRIPTION
As discussed, the tile in the 2024 release branch should say Edge 10.18