### PR TITLE
[GRAFT][release/y2024] Add note regarding identical release notes

### DIFF
--- a/content/change-logs/edge/edge-appliance-vm-10-18-0-Release-identical-to-10-18.md
+++ b/content/change-logs/edge/edge-appliance-vm-10-18-0-Release-identical-to-10-18.md
@@ -1,0 +1,13 @@
+---
+date: 2024-05-08
+title: 2024 release of Cumulocity IoT Edge Appliance VM identical to 10.18 release
+change_type:
+  - value: change-inv-3bw8e
+    label: Announcement
+product_area: Edge
+component:
+  - value: component-IpOEfM7nQ
+    label: Edge Appliance VM
+version: 10.18.0
+---
+The Cumulocity IoT Edge Appliance VM version of the 2024 release is identical to the version of the 10.18 release. For details on the release see the [10.18 release notes](https://cumulocity.com/releasenotes/release-10-18-0/edge-10-18-0/). You can find the documentation for **Cumulocity IoT Edge Appliance VM** at https://cumulocity.com/docs/edge/edge-introduction/.

--- a/content/change-logs/edge/edge-on-kubernetes-10-18-0-Release-identical-to-10-18.md
+++ b/content/change-logs/edge/edge-on-kubernetes-10-18-0-Release-identical-to-10-18.md
@@ -1,0 +1,13 @@
+---
+date: 2024-05-08
+title: 2024 release of Cumulocity IoT Edge on Kubernetes identical to 10.18 release
+change_type:
+  - value: change-inv-3bw8e
+    label: Announcement
+product_area: Edge
+component:
+  - value: component-g7hnfbu4J
+    label: Edge on Kubernetes
+version: 10.18.0
+---
+The Cumulocity IoT Edge on Kubernetes version of the 2024 release is identical to the version of the 10.18 release. For details on the release see the [10.18 release notes](https://cumulocity.com/releasenotes/release-10-18-0/edge-10-18-0/). You can find the documentation for **Cumulocity IoT Edge on Kubernetes** at https://cumulocity.com/docs/edge-kubernetes/k8-edge-introduction/.


### PR DESCRIPTION
# Backport

This will backport the following commits from `develop` to `release/y2024`:
 - [Merge pull request #2024 from SoftwareAG/Edge-release-notes-2024-identical-to-1018](https://github.com/SoftwareAG/c8y-docs/pull/2024)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)