### PR TITLE
Edge - Value of the BASEURL env variable is coming with a trailing new line character

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -37,7 +37,7 @@ jobs:
 
     - name: Setup base URL env var
       run: |
-        echo "BASEURL=https://${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.job }}-pr-${{ github.event.number }}.surge.sh" >> $GITHUB_ENV
+        echo -n "BASEURL=https://${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.job }}-pr-${{ github.event.number }}.surge.sh" >> $GITHUB_ENV
 
     - name: Report base URL env var
       run: echo "${{ env.BASEURL }}"

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -57,7 +57,7 @@ jobs:
         HUGO_ENV: production
       run: |
         hugo \
-          --baseURL "${{ env.BASEURL }}/"
+          --baseURL "${{ env.BASEURL }}"
 
     - uses: actions/setup-node@v3
       with:

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -37,7 +37,7 @@ jobs:
 
     - name: Setup base URL env var
       run: |
-        echo BASEURL="https://${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.job }}-pr-${{ github.event.number }}.surge.sh" >> $GITHUB_ENV
+        echo "BASEURL=https://${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.job }}-pr-${{ github.event.number }}.surge.sh" >> $GITHUB_ENV
 
     - name: Report base URL env var
       run: echo "${{ env.BASEURL }}"

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -62,8 +62,8 @@ jobs:
         else
           suffix=$(echo "${{ steps.extract_branch.outputs.branch }}" | sed  's/release\/y//g')
           echo "Suffix: ${suffix}"
-          echo "BASEURL=${{ secrets.BASE_URL }}/${suffix}" >> $GITHUB_ENV
-          echo "DESTINATION_PATH=${{ secrets.DESTINATION_PATH }}/${suffix}" >> $GITHUB_ENV
+          echo -n "BASEURL=${{ secrets.BASE_URL }}/${suffix}" >> $GITHUB_ENV
+          echo -n "DESTINATION_PATH=${{ secrets.DESTINATION_PATH }}/${suffix}" >> $GITHUB_ENV
         fi
       id: path_to_append
 

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -57,13 +57,13 @@ jobs:
         echo "Branch: ${{ steps.extract_branch.outputs.branch }}"
         if [[ "${{ steps.extract_branch.outputs.branch }}" == "develop" ]]; then
           echo "Branch is develop"
-          echo BASEURL="${{ secrets.BASE_URL }}" >> $GITHUB_ENV
-          echo DESTINATION_PATH="${{ secrets.DESTINATION_PATH }}" >> $GITHUB_ENV
+          echo "BASEURL=${{ secrets.BASE_URL }}" >> $GITHUB_ENV
+          echo "DESTINATION_PATH=${{ secrets.DESTINATION_PATH }}" >> $GITHUB_ENV
         else
           suffix=$(echo "${{ steps.extract_branch.outputs.branch }}" | sed  's/release\/y//g')
           echo "Suffix: ${suffix}"
-          echo BASEURL="${{ secrets.BASE_URL }}/${suffix}" >> $GITHUB_ENV
-          echo DESTINATION_PATH="${{ secrets.DESTINATION_PATH }}/${suffix}" >> $GITHUB_ENV
+          echo "BASEURL=${{ secrets.BASE_URL }}/${suffix}" >> $GITHUB_ENV
+          echo "DESTINATION_PATH=${{ secrets.DESTINATION_PATH }}/${suffix}" >> $GITHUB_ENV
         fi
       id: path_to_append
 

--- a/content/edge-kubernetes/quickstart.md
+++ b/content/edge-kubernetes/quickstart.md
@@ -38,13 +38,13 @@ This section helps you to quickly install Edge on a [Lightweight Kubernetes (K3s
 4. Run the command below to install the Edge Operator and provide the repository credentials when prompted.
 
    ```shell
-   curl -sfL {{ .Site.BaseURL }}/files/edge-k8s/c8yedge-operator-install.sh -O && bash ./c8yedge-operator-install.sh
+   curl -sfL {{< link-c8y-doc-baseurl >}}/files/edge-k8s/c8yedge-operator-install.sh -O && bash ./c8yedge-operator-install.sh
    ```
 
 5. Run the command below to apply Edge CR ([c8yedge-sample.yaml](/files/edge-k8s/c8yedge-sample.yaml)) for installing Edge version **1018.0.0** named **c8yedge** with the domain **myown.iot.com**.
 
    ```shell
-   kubectl apply -f {{ .Site.BaseURL }}/files/edge-k8s/c8yedge-sample.yaml
+   kubectl apply -f {{ link-c8y-doc-baseurl }}/files/edge-k8s/c8yedge-sample.yaml
    ```
 
 6. See [Verifying the Edge installation](/edge-kubernetes/installing-edge-on-k8/#verifying-the-edge-installation) and [Accessing Edge](/edge-kubernetes/installing-edge-on-k8/#accessing-edge) to sign into Edge.

--- a/content/edge-kubernetes/quickstart.md
+++ b/content/edge-kubernetes/quickstart.md
@@ -38,13 +38,13 @@ This section helps you to quickly install Edge on a [Lightweight Kubernetes (K3s
 4. Run the command below to install the Edge Operator and provide the repository credentials when prompted.
 
    ```shell
-   curl -sfL {{ .Site.BaseURL }}/files/edge-k8s/c8yedge-operator-install.sh -O && bash ./c8yedge-operator-install.sh
+   curl -sfL {{< .Site.BaseURL >}}/files/edge-k8s/c8yedge-operator-install.sh -O && bash ./c8yedge-operator-install.sh
    ```
 
 5. Run the command below to apply Edge CR ([c8yedge-sample.yaml](/files/edge-k8s/c8yedge-sample.yaml)) for installing Edge version **1018.0.0** named **c8yedge** with the domain **myown.iot.com**.
 
    ```shell
-   kubectl apply -f {{ .Site.BaseURL }}/files/edge-k8s/c8yedge-sample.yaml
+   kubectl apply -f {{< .Site.BaseURL >}}/files/edge-k8s/c8yedge-sample.yaml
    ```
 
 6. See [Verifying the Edge installation](/edge-kubernetes/installing-edge-on-k8/#verifying-the-edge-installation) and [Accessing Edge](/edge-kubernetes/installing-edge-on-k8/#accessing-edge) to sign into Edge.

--- a/content/edge-kubernetes/quickstart.md
+++ b/content/edge-kubernetes/quickstart.md
@@ -38,13 +38,13 @@ This section helps you to quickly install Edge on a [Lightweight Kubernetes (K3s
 4. Run the command below to install the Edge Operator and provide the repository credentials when prompted.
 
    ```shell
-   curl -sfL {{< link-c8y-doc-baseurl >}}/files/edge-k8s/c8yedge-operator-install.sh -O && bash ./c8yedge-operator-install.sh
+   curl -sfL {{ .Site.BaseURL }}/files/edge-k8s/c8yedge-operator-install.sh -O && bash ./c8yedge-operator-install.sh
    ```
 
 5. Run the command below to apply Edge CR ([c8yedge-sample.yaml](/files/edge-k8s/c8yedge-sample.yaml)) for installing Edge version **1018.0.0** named **c8yedge** with the domain **myown.iot.com**.
 
    ```shell
-   kubectl apply -f {{< link-c8y-doc-baseurl >}}/files/edge-k8s/c8yedge-sample.yaml
+   kubectl apply -f {{ .Site.BaseURL }}/files/edge-k8s/c8yedge-sample.yaml
    ```
 
 6. See [Verifying the Edge installation](/edge-kubernetes/installing-edge-on-k8/#verifying-the-edge-installation) and [Accessing Edge](/edge-kubernetes/installing-edge-on-k8/#accessing-edge) to sign into Edge.

--- a/content/edge-kubernetes/quickstart.md
+++ b/content/edge-kubernetes/quickstart.md
@@ -38,13 +38,13 @@ This section helps you to quickly install Edge on a [Lightweight Kubernetes (K3s
 4. Run the command below to install the Edge Operator and provide the repository credentials when prompted.
 
    ```shell
-   curl -sfL {{< link-c8y-doc-baseurl >}}/files/edge-k8s/c8yedge-operator-install.sh -O && bash ./c8yedge-operator-install.sh
+   curl -sfL {{ .Site.BaseURL }}/files/edge-k8s/c8yedge-operator-install.sh -O && bash ./c8yedge-operator-install.sh
    ```
 
 5. Run the command below to apply Edge CR ([c8yedge-sample.yaml](/files/edge-k8s/c8yedge-sample.yaml)) for installing Edge version **1018.0.0** named **c8yedge** with the domain **myown.iot.com**.
 
    ```shell
-   kubectl apply -f {{ link-c8y-doc-baseurl }}/files/edge-k8s/c8yedge-sample.yaml
+   kubectl apply -f {{ .Site.BaseURL }}/files/edge-k8s/c8yedge-sample.yaml
    ```
 
 6. See [Verifying the Edge installation](/edge-kubernetes/installing-edge-on-k8/#verifying-the-edge-installation) and [Accessing Edge](/edge-kubernetes/installing-edge-on-k8/#accessing-edge) to sign into Edge.


### PR DESCRIPTION
Many static file links in the Edge documentation (especially when rendered as part of Shell commands) are broken as the BASEURL environment variable set by the GitHub action includes a trailing new line character.
Find below the screenshot from the existing docs:
![image](https://github.com/SoftwareAG/c8y-docs/assets/6057063/007e18a1-fe96-4856-8888-0933ce6fce3e)
  