### PR TITLE
Create ui-c8y-1019-24-6-fix-type-error-when-using-hook-device-list-columns-with-factory.md

### DIFF
--- a/content/change-logs/device-management/ui-c8y-1019-24-6-fix-type-error-when-using-hook-device-list-columns-with-factory.md
+++ b/content/change-logs/device-management/ui-c8y-1019-24-6-fix-type-error-when-using-hook-device-list-columns-with-factory.md
@@ -1,6 +1,6 @@
 ---
 date: ""
-title: Fix type error when using `hookDeviceListColumns` with factory
+title: Fixed type error when using hookDeviceListColumns with factory
 product_area: Device management & connectivity
 change_type:
   - value: change-VSkj2iV9m

--- a/content/change-logs/device-management/ui-c8y-1019-24-6-fix-type-error-when-using-hook-device-list-columns-with-factory.md
+++ b/content/change-logs/device-management/ui-c8y-1019-24-6-fix-type-error-when-using-hook-device-list-columns-with-factory.md
@@ -14,4 +14,4 @@ build_artifact:
 ticket: DM-3308
 version: 1019.24.6
 ---
-In Cumulocity IoT, the ‘hookDeviceListColumns‘ API allows customizing the columns displayed in the device list. However, when using this API with a factory, a type error occurred, and explicit type casting was needed. This issue has now been resolved.
+In Cumulocity IoT, the `hookDeviceListColumns` API allows customizing the columns displayed in the device list. However, when using this API with a factory, a type error occurred, and explicit type casting was needed. This issue has now been resolved.

--- a/content/change-logs/device-management/ui-c8y-1019-24-6-fix-type-error-when-using-hook-device-list-columns-with-factory.md
+++ b/content/change-logs/device-management/ui-c8y-1019-24-6-fix-type-error-when-using-hook-device-list-columns-with-factory.md
@@ -14,4 +14,4 @@ build_artifact:
 ticket: DM-3308
 version: 1019.24.6
 ---
-In the Cumulocity IoT platform, the hookDeviceListColumns API allows customizing the columns displayed in the device list. However, when using this API with a factory, a type error occurred, and explicit type casting was needed. This issue has now been resolved.
+In Cumulocity IoT, the ‘hookDeviceListColumns‘ API allows customizing the columns displayed in the device list. However, when using this API with a factory, a type error occurred, and explicit type casting was needed. This issue has now been resolved.

--- a/content/change-logs/device-management/ui-c8y-1019-24-6-fix-type-error-when-using-hook-device-list-columns-with-factory.md
+++ b/content/change-logs/device-management/ui-c8y-1019-24-6-fix-type-error-when-using-hook-device-list-columns-with-factory.md
@@ -14,4 +14,4 @@ build_artifact:
 ticket: DM-3308
 version: 1019.24.6
 ---
-Fix type error when using `hookDeviceListColumns` with factory
+In the Cumulocity IoT platform, the hookDeviceListColumns API allows customizing the columns displayed in the device list. However, when using this API with a factory, a type error occurred, and explicit type casting was needed. This issue has now been resolved.

--- a/content/change-logs/device-management/ui-c8y-1019-24-6-fix-type-error-when-using-hook-device-list-columns-with-factory.md
+++ b/content/change-logs/device-management/ui-c8y-1019-24-6-fix-type-error-when-using-hook-device-list-columns-with-factory.md
@@ -1,0 +1,17 @@
+---
+date: ""
+title: Fix type error when using `hookDeviceListColumns` with factory
+product_area: Device management & connectivity
+change_type:
+  - value: change-VSkj2iV9m
+    label: Fix
+component:
+  - value: component--KIsStyzM
+    label: Device Management app
+build_artifact:
+  - value: tc-pjJiURv9Y
+    label: ui-c8y
+ticket: DM-3308
+version: 1019.24.6
+---
+Fix type error when using `hookDeviceListColumns` with factory


### PR DESCRIPTION
Release note created by bode

Ticket: [DM-3308](https://cumulocity.atlassian.net/browse/DM-3308)
Original PR: [6327](https://github.softwareag.com/IOTA/cumulocity-ui/pull/6327)