### PR TITLE
Create ui-c8y-1020-0-0-navigator-nodes-are-now-correctly-removed-when-refreshing-the-sub-assets.md

### DIFF
--- a/content/change-logs/application-enablement/ui-c8y-1020-0-0-navigator-nodes-are-now-correctly-removed-when-refreshing-the-sub-assets.md
+++ b/content/change-logs/application-enablement/ui-c8y-1020-0-0-navigator-nodes-are-now-correctly-removed-when-refreshing-the-sub-assets.md
@@ -1,0 +1,17 @@
+---
+date: ""
+title: Navigator nodes are now correctly removed when refreshing the sub-assets grid after removing groups via API.
+product_area: Application enablement & solutions
+change_type:
+  - value: change-VSkj2iV9m
+    label: Fix
+component:
+  - value: component-YbYJ3gLU_
+    label: Web SDK
+build_artifact:
+  - value: tc-pjJiURv9Y
+    label: ui-c8y
+ticket: MTM-58562
+version: 1020.0.0
+---
+Navigator nodes are now correctly removed when refreshing the sub-assets grid after removing groups via API.


### PR DESCRIPTION
Release note created by ensu

Ticket: [MTM-58562](https://cumulocity.atlassian.net/browse/MTM-58562)
Original PR: [6149](https://github.softwareag.com/IOTA/cumulocity-ui/pull/6149)