### PR TITLE
Create ui-c8y-1018-503-90-body-text-in-the-confirmation-modal-for-logging-out-all-users.md

### DIFF
--- a/content/change-logs/platform-services/ui-c8y-1018-503-90-body-text-in-the-confirmation-modal-for-logging-out-all-users.md
+++ b/content/change-logs/platform-services/ui-c8y-1018-503-90-body-text-in-the-confirmation-modal-for-logging-out-all-users.md
@@ -14,4 +14,4 @@ build_artifact:
 ticket: MTM-58016
 version: 1018.503.90
 ---
-In the Cumulocity IoT platform, there is a confirmation modal that appears when an administrator attempts to log out all users. Previously, the body text in this modal was not properly translated and always appeared in English, regardless of the user's language settings. With this change, the body text in the confirmation modal is now correctly translated based on the user's selected language.
+In the Administration application, a confirmation modal appears when an administrator attempts to log out all users. Previously, the body text in this modal was not properly translated and always appeared in English, regardless of the user's language settings. With this change, the body text in the confirmation modal is now correctly translated based on the user's selected language.

--- a/content/change-logs/platform-services/ui-c8y-1018-503-90-body-text-in-the-confirmation-modal-for-logging-out-all-users.md
+++ b/content/change-logs/platform-services/ui-c8y-1018-503-90-body-text-in-the-confirmation-modal-for-logging-out-all-users.md
@@ -1,0 +1,17 @@
+---
+date: ""
+title: Body text in the confirmation modal for logging out all users is not translated (#6281) [GRAFT][release/y2024] (#6435)
+product_area: Platform services
+change_type:
+  - value: change-VSkj2iV9m
+    label: Fix
+component:
+  - value: component-0UgqXH1Ys
+    label: Administration
+build_artifact:
+  - value: tc-pjJiURv9Y
+    label: ui-c8y
+ticket: MTM-58016
+version: 1018.503.90
+---
+Body text in the confirmation modal for logging out all users is not translated (#6281) [GRAFT][release/y2024] (#6435)

--- a/content/change-logs/platform-services/ui-c8y-1018-503-90-body-text-in-the-confirmation-modal-for-logging-out-all-users.md
+++ b/content/change-logs/platform-services/ui-c8y-1018-503-90-body-text-in-the-confirmation-modal-for-logging-out-all-users.md
@@ -1,6 +1,6 @@
 ---
 date: ""
-title: Confirmation modal for logging out all users now translated correctly
+title: Confirmation message on logging out all users now translated correctly
 product_area: Platform services
 change_type:
   - value: change-VSkj2iV9m

--- a/content/change-logs/platform-services/ui-c8y-1018-503-90-body-text-in-the-confirmation-modal-for-logging-out-all-users.md
+++ b/content/change-logs/platform-services/ui-c8y-1018-503-90-body-text-in-the-confirmation-modal-for-logging-out-all-users.md
@@ -1,6 +1,6 @@
 ---
 date: ""
-title: Body text in the confirmation modal for logging out all users is not translated (#6281) [GRAFT][release/y2024] (#6435)
+title: Confirmation modal for logging out all users now translated correctly
 product_area: Platform services
 change_type:
   - value: change-VSkj2iV9m
@@ -14,4 +14,4 @@ build_artifact:
 ticket: MTM-58016
 version: 1018.503.90
 ---
-Body text in the confirmation modal for logging out all users is not translated (#6281) [GRAFT][release/y2024] (#6435)
+In the Cumulocity IoT platform, there is a confirmation modal that appears when an administrator attempts to log out all users. Previously, the body text in this modal was not properly translated and always appeared in English, regardless of the user's language settings. With this change, the body text in the confirmation modal is now correctly translated based on the user's selected language.


### PR DESCRIPTION
Release note created by c8y-ui-automations[bot]

Ticket: [MTM-58016](https://cumulocity.atlassian.net/browse/MTM-58016)
Original PR: [6435](https://github.softwareag.com/IOTA/cumulocity-ui/pull/6435)