### PR TITLE
[DM-3625] [DOC] Update example in 506 template

### DIFF
--- a/content/smartrest/mqtt-static-templates.md
+++ b/content/smartrest/mqtt-static-templates.md
@@ -944,7 +944,7 @@ This may let the device send additional parameters that trigger further steps ba
 **Example**
 
 ```text
-506,c8y_Restart
+506,123
 ```
 
 ##### Set EXECUTING operations to FAILED (507) {#507}


### PR DESCRIPTION
Feedback from [korbinian.butz@softwareag.com](mailto:korbinian.butz@softwareag.com)

The example in template 506 is missleading. The template expects the operation ID (as 504 and 505 does), so the example should rather be "506,123" instead of "506,c8y_Restart".

![image](https://github.com/SoftwareAG/c8y-docs/assets/92311581/e6b33ca0-df32-40ad-a589-7a026de785ff)


After the change
![image](https://github.com/SoftwareAG/c8y-docs/assets/92311581/73acd1de-d252-40eb-aa3a-2134485f8f5c)
