### PR TITLE
Create ui-c8y-1020-0-14-c-8-y-select-should-no-longer-throw-an-error-with.md

### DIFF
--- a/content/change-logs/application-enablement/ui-c8y-1020-0-14-c-8-y-select-should-no-longer-throw-an-error-with.md
+++ b/content/change-logs/application-enablement/ui-c8y-1020-0-14-c-8-y-select-should-no-longer-throw-an-error-with.md
@@ -1,0 +1,17 @@
+---
+date: ""
+title: C8y-select should no longer throw an error with selectedFunc.
+product_area: Application enablement & solutions
+change_type:
+  - value: change-VSkj2iV9m
+    label: Fix
+component:
+  - value: component-YbYJ3gLU_
+    label: Web SDK
+build_artifact:
+  - value: tc-pjJiURv9Y
+    label: ui-c8y
+ticket: MTM-59332
+version: 1020.0.14
+---
+C8y-select should no longer throw an error with selectedFunc.


### PR DESCRIPTION
Release note created by c8y-ui-automations[bot]

Ticket: [MTM-59332](https://cumulocity.atlassian.net/browse/MTM-59332)
Original PR: [6492](https://github.softwareag.com/IOTA/cumulocity-ui/pull/6492)