### PR TITLE
[DM-3627] [DOC] Missing step to add the following dependency to POM file

### DIFF
--- a/content/protocol-integration/lpwan-custom-codec-bundle/using-the-lpwan-custom-codec-library.md
+++ b/content/protocol-integration/lpwan-custom-codec-bundle/using-the-lpwan-custom-codec-library.md
@@ -11,12 +11,13 @@ To create a custom codec microservice using this library, do the following:
 
 1. Add the following dependency to the pom.xml file:
 
-  <dependency>
-          <groupId>com.nsn.cumulocity.clients-java</groupId>
-          <artifactId>lpwan-custom-codec</artifactId>
-          <version>${c8y.version}</version>
-      </dependency>
-
+        ```xml
+        <dependency>
+                <groupId>com.nsn.cumulocity.clients-java</groupId>
+                <artifactId>lpwan-custom-codec</artifactId>
+                <version>${c8y.version}</version>
+            </dependency>
+        ```
 
 2. Create a Spring Boot application and annotate its main class with:
 

--- a/content/protocol-integration/lpwan-custom-codec-bundle/using-the-lpwan-custom-codec-library.md
+++ b/content/protocol-integration/lpwan-custom-codec-bundle/using-the-lpwan-custom-codec-library.md
@@ -9,13 +9,22 @@ When subscribed, such a custom codec microservice automatically creates the requ
 
 To create a custom codec microservice using this library, do the following:
 
-1. Create a Spring Boot application and annotate its main class with:
+1. Add the following dependency to the pom.xml file:
+
+  <dependency>
+          <groupId>com.nsn.cumulocity.clients-java</groupId>
+          <artifactId>lpwan-custom-codec</artifactId>
+          <version>${c8y.version}</version>
+      </dependency>
+
+
+2. Create a Spring Boot application and annotate its main class with:
 
     ```java
     @CodecMicroserviceApplication `com.cumulocity.microservice.lpwan.codec.annotation.CodecMicroserviceApplication`
     ```
 
-2. Implement the following Java interfaces and annotate them with:
+3. Implement the following Java interfaces and annotate them with:
 
     ```java
     @Component `org.springframework.stereotype.Component`
@@ -65,7 +74,7 @@ To create a custom codec microservice using this library, do the following:
         }
         ```
 
-3. Add the following roles as `requiredRoles` in the microservice manifest file `cumulocity.json`:
+4. Add the following roles as `requiredRoles` in the microservice manifest file `cumulocity.json`:
 
     ```json
     "requiredRoles": [


### PR DESCRIPTION
Feedback fom bugherd:

Reported Nov 28, 2023 at 12:03pm, by [tamer.mazen@softwareag.com](mailto:tamer.mazen@softwareag.com)

There is missing step to add the following dependency to POM file
      <dependency>
          <groupId>com.nsn.cumulocity.clients-java</groupId>
          <artifactId>lpwan-custom-codec</artifactId>
          <version>${c8y.version}</version>
      </dependency>

[LPWAN Custom device protocols - Cumulocity IoT Guides](https://cumulocity.com/guides/protocol-integration/lpwan-custom-codec/) 


/guides/protocol-integration/lpwan-custom-codec/

![image](https://github.com/SoftwareAG/c8y-docs/assets/92311581/8797c550-524c-404c-bbf4-c0580154b48f)

