### PR TITLE
[MTM-59215]: New port is open for device access token API

### DIFF
--- a/content/device-integration/rest-client-examples-bundle/hello-rest-x509.md
+++ b/content/device-integration/rest-client-examples-bundle/hello-rest-x509.md
@@ -5,7 +5,7 @@ layout: redirect
 ---
 
 In this section, we will learn how to generate a JWT token using mTLS protocol with {{< product-c8y-iot >}}.
-For authentication with {{< product-c8y-iot >}} we use X.509 certificates.
+For authentication with {{< product-c8y-iot >}} we use X.509 certificates. Device access token API is only accessible on port 2443.
 
 ### Prerequisites {#prerequisites}
 
@@ -50,6 +50,7 @@ The following configuration is required before calling the device access token A
 * TRUSTSTORE_PASSWORD - The password to access the truststore.
 * TRUSTSTORE_FORMAT - Either "JKS" or "PKCS12" depending on the file format. The path is provided by TRUSTSTORE.
 * PLATFORM_URL - The URL of the platform.
+* PLATFORM_MTLS_PORT - Port 2443 is available for device access token API
 * DEVICE_ACCESS_TOKEN_PATH API - The endpoint responsible for the mTLS protocol.
 * LOCAL_DEVICE_CHAIN - The whole chain in PEM format.
 
@@ -65,6 +66,7 @@ To change the configuration in the REST Java client, copy the file *chain-with-p
             private static final String TRUSTSTORE_FORMAT = "jks";
             private static final String LOCAL_DEVICE_CHAIN = "-----BEGIN CERTIFICATE----- MIIcQhNJJ0F/lfjm -----END CERTIFICATE-----";
             private static final String PLATFORM_URL = "<URL of the platform>";
+            private static final String PLATFORM_MTLS_PORT = "2443";
 
 The device can now generate a JWT token. Note that before the first connect no other actions are required, for example, creating a user. The user is created during the [auto registration](/device-integration/certificate/#device-certificates) process.
 


### PR DESCRIPTION
https://cumulocity.atlassian.net/browse/MTM-59215
For reviewers: We have bug on CICD environment https://itrac.eur.ad.sag/browse/IOT-20060 so we need to introduce a new port 2443 for device access token API.
Please find more information on https://sagportal.sharepoint.com/:w:/r/sites/IoTAnalyticsRnDOps/_layouts/15/Doc.aspx?sourcedoc=%7B28EC5A74-BB5F-4E5C-B688-D7386F84AD0D%7D&file=mTLS_REST_Popup_Issue.docx&action=default&mobileredirect=true