### PR TITLE
[MTM-59425] allows device to connect to platform using leaf cert only

### DIFF
--- a/content/device-integration/mqtt-bundle/implementation.md
+++ b/content/device-integration/mqtt-bundle/implementation.md
@@ -89,7 +89,7 @@ Every operation received will contain the template ID followed by the ID of the 
 The communication with {{< product-c8y-iot >}} employing MQTT supports authentication in two ways:
 
 *   Username and password. The MQTT username must include the tenant ID and username in the format &lt;tenantID/username>.
-*   Device certificates. For secure communication, the devices must either contain the entire chain of certificates leading to the trusted root certificate, or if only the device certificate is provided, the immediate issuer certificate must be uploaded to the platform's truststore. Also, they must contain the server certificate in their truststore.
+*   Device certificates. For secure communication, devices must contain the entire chain of certificates leading to the trusted root certificate or if only the device certificate is provided, then the immediate issuer certificate must be uploaded to the platform's truststore. Also, they must contain the server certificate in their truststore.
 
 #### Troubleshooting {#troubleshooting}
 

--- a/content/device-integration/mqtt-bundle/implementation.md
+++ b/content/device-integration/mqtt-bundle/implementation.md
@@ -89,7 +89,7 @@ Every operation received will contain the template ID followed by the ID of the 
 The communication with {{< product-c8y-iot >}} employing MQTT supports authentication in two ways:
 
 *   Username and password. The MQTT username must include the tenant ID and username in the format &lt;tenantID/username>.
-*   Device certificates. For secure communication, devices must contain the entire chain of certificates leading to the trusted root certificate or if only the device certificate is provided, then the immediate issuer certificate must be uploaded to the platform's truststore. Also, they must contain the server certificate in their truststore.
+*   Device certificates. For secure communication, devices must contain the entire chain of certificates leading to the trusted root certificate, or if only the device certificate is provided, then the immediate issuer certificate must be uploaded to the platform's truststore. Also, they must contain the server certificate in their truststore.
 
 #### Troubleshooting {#troubleshooting}
 

--- a/content/device-integration/mqtt-bundle/implementation.md
+++ b/content/device-integration/mqtt-bundle/implementation.md
@@ -89,7 +89,7 @@ Every operation received will contain the template ID followed by the ID of the 
 The communication with {{< product-c8y-iot >}} employing MQTT supports authentication in two ways:
 
 *   Username and password. The MQTT username must include the tenant ID and username in the format &lt;tenantID/username>.
-*   Device certificates. The devices must contain the whole chain of certificates leading to the trusted root certificate. Also, they must contain the server certificate in their truststore.
+*   Device certificates. For secure communication, the devices must either contain the entire chain of certificates leading to the trusted root certificate, or if only the device certificate is provided, the immediate issuer certificate must be uploaded to the platform's truststore. Also, they must contain the server certificate in their truststore.
 
 #### Troubleshooting {#troubleshooting}
 

--- a/content/device-integration/mqtt-examples-bundle/hello-mqtt-java-certificates.md
+++ b/content/device-integration/mqtt-examples-bundle/hello-mqtt-java-certificates.md
@@ -23,7 +23,7 @@ If you don't have a valid certificate, you can generate one for testing purposes
 1.  Download the scripts from the [cumulocity-examples](https://github.com/SoftwareAG/cumulocity-examples/tree/develop/mqtt-client/scripts) repository.
 2.  Create a root self-signed certificate (execute the script *00createRootSelfSignedCertificate.sh*) and upload it to your tenant. You can do it via [the Device management application in the UI](/device-management-application/managing-device-data/#managing-trusted-certificates) or via [REST](https://{{< domain-c8y >}}/api/core/#tag/Tenant-API).
 3.  Create and sign the certificate (execute the script *01createSignedCertificate.sh*).
-4.  Move the certificates to keystore (execute the script *02moveCertificatesToKeystore.sh*).
+4.  Move the certificates to keystore (execute the script *02moveCertificatesToKeystore.sh*). Additionally, if only the device leaf certificate is needed in the keystore, use the --leafonly option.
 5.  Finally, import the trusted certificate into keystore running the following command:
 
 ```shell


### PR DESCRIPTION
Device now can connect to platform by leaf certificate only provided the immediate issuer is in the tenant trust store. This PR updates the doc about this change.