### PR TITLE
Create ui-c8y-1020-0-22-loading-locals-for-none-default-languages-is-now-possible.md

### DIFF
--- a/content/change-logs/application-enablement/ui-c8y-1020-0-22-loading-locals-for-none-default-languages-is-now-possible.md
+++ b/content/change-logs/application-enablement/ui-c8y-1020-0-22-loading-locals-for-none-default-languages-is-now-possible.md
@@ -1,0 +1,17 @@
+---
+date: ""
+title: loading locals for none default languages is now possible
+product_area: Application enablement & solutions
+change_type:
+  - value: change-VSkj2iV9m
+    label: Fix
+component:
+  - value: component-YbYJ3gLU_
+    label: Web SDK
+build_artifact:
+  - value: tc-pjJiURv9Y
+    label: ui-c8y
+ticket: MTM-57551
+version: 1020.0.22
+---
+loading locals for none default languages is now possible

--- a/content/change-logs/application-enablement/ui-c8y-1020-0-22-loading-locals-for-none-default-languages-is-now-possible.md
+++ b/content/change-logs/application-enablement/ui-c8y-1020-0-22-loading-locals-for-none-default-languages-is-now-possible.md
@@ -14,4 +14,4 @@ build_artifact:
 ticket: MTM-57551
 version: 1020.0.22
 ---
-loading locals for none default languages is now possible
+Previously, it was not possible to load locales for languages other than the default language configured in the system. This change enables the loading of locales for non-default languages. With this enhancement, users can now utilize locales for their preferred languages, even if they differ from the system's default language setting. This improves the user experience by allowing for language-specific formatting and translations across the application.

--- a/content/change-logs/application-enablement/ui-c8y-1020-0-22-loading-locals-for-none-default-languages-is-now-possible.md
+++ b/content/change-logs/application-enablement/ui-c8y-1020-0-22-loading-locals-for-none-default-languages-is-now-possible.md
@@ -1,6 +1,6 @@
 ---
 date: ""
-title: loading locals for none default languages is now possible
+title: Loading locales for non-default languages is now possible
 product_area: Application enablement & solutions
 change_type:
   - value: change-VSkj2iV9m


### PR DESCRIPTION
Release note created by c8y-ui-automations[bot]

Ticket: [MTM-57551](https://cumulocity.atlassian.net/browse/MTM-57551)
Original PR: [6537](https://github.softwareag.com/IOTA/cumulocity-ui/pull/6537)