### PR TITLE
[DM-3756] [DOC] Wrong template id is referenced documentation

### DIFF
--- a/content/device-integration/fragment-library-bundle/configuration.md
+++ b/content/device-integration/fragment-library-bundle/configuration.md
@@ -112,7 +112,7 @@ The device is expected to perform the following actions:
 The 513 static response template is available to receive ```c8y_Configuration``` operations:
 
 1. Receive ```c8y_Configuration``` operation <br>
-  `511,DeviceSerial,"c8y.url.http=https://management.cumulocity.com\nc8y.url.mqtt=mqtt.cumulocity.com\n"`
+  `513,DeviceSerial,"c8y.url.http=https://management.cumulocity.com\nc8y.url.mqtt=mqtt.cumulocity.com\n"`
 2. Set operation status to EXECUTING <br>
   `501,c8y_Configuration`
 3. Install and apply configuration as included

--- a/content/smartrest/json-via-mqtt.md
+++ b/content/smartrest/json-via-mqtt.md
@@ -88,7 +88,7 @@ The source device ID will automatically be resolved based on the MQTT client ID.
 
 #### Create new event {#create-new-event}
 
-Publish a message on topic <kbd>/event/events/create</kbd> with payload:
+Publish a message on topic <kbd>event/events/create</kbd> with payload:
 
 ```json
 {
@@ -100,7 +100,7 @@ Publish a message on topic <kbd>/event/events/create</kbd> with payload:
 
 #### Create many events {#create-many-events}
 
-Publish a message on topic <kbd>/event/events/createBulk</kbd> with payload:
+Publish a message on topic <kbd>event/events/createBulk</kbd> with payload:
 
 ```json
 {


### PR DESCRIPTION
========== (https://cumulocity.atlassian.net/browse/DM-3756) ============
Description

Reported by Bugherd Reported Jun 4, 2024 at 9:21am, by [reuben.miller@softwareag](mailto:reuben.miller@softwareag.com)

A different template id is referenced as in the previous sentence, e.g. "511" vs "513". Most likely "511" should be replaced with "513"

/device-integration/fragment-library/
![image](https://github.com/SoftwareAG/c8y-docs/assets/92311581/33540f5f-788b-4ce2-9591-9ec4d9883fad)

========== (https://cumulocity.atlassian.net/browse/DM-3757) ============

Description:

Created from  bugherd Reported May 1, 2024 at 3:38am, by [tobias.sommer@softwareag](mailto:tobias.sommer@softwareag.com)

I think the leading / is incorrect. If a customer would copy past like this it would not work. Only for event there is this leading slash in the examples

![image](https://github.com/SoftwareAG/c8y-docs/assets/92311581/2ae13344-6c0f-4b1b-90cb-c11e02772e4c)
