### PR TITLE
[MTM-57937] Announcment: remove the ability to explicitly set a passw…

### DIFF
--- a/content/change-logs/platform-services/cumulocity-10-20-438-0-remove-the-ability-to-explicitly-set-a-password-for-a-device-user.md
+++ b/content/change-logs/platform-services/cumulocity-10-20-438-0-remove-the-ability-to-explicitly-set-a-password-for-a-device-user.md
@@ -14,4 +14,4 @@ build_artifact:
 ticket: MTM-57937
 version: 10.20.438.0
 ---
-To improve security user administrators can no longer explicitly set passwords for device users. This change prevents an attacker from having access to all device users, in case the administrator account is compromised. In case of losing the device password, the registration process should be done again.
+To improve security, user administrators can no longer explicitly set passwords for device users. This change prevents an attacker from having access to all device users, in case the administrator account is compromised. In case of losing the device password, the device must be registered again.

--- a/content/change-logs/platform-services/cumulocity-10-20-438-0-remove-the-ability-to-explicitly-set-a-password-for-a-device-user.md
+++ b/content/change-logs/platform-services/cumulocity-10-20-438-0-remove-the-ability-to-explicitly-set-a-password-for-a-device-user.md
@@ -1,0 +1,17 @@
+---
+date: ""
+title: Remove the ability to explicitly set a password for a device user
+product_area: Platform services
+change_type:
+  - value: change-inv-3bw8e
+    label: Announcement
+component:
+  - value: q3kclF6pO
+    label: Authentication
+build_artifact:
+  - value: tc-QHwMfWtBk7
+    label: cumulocity
+ticket: MTM-57937
+version: 10.20.438.0
+---
+To improve security user administrators can no longer explicitly set passwords for device users. This change prevents an attacker from having access to all device users, in case the administrator account is compromised. In case of losing the device password, the registration process should be done again.


### PR DESCRIPTION
Announcement: Remove the ability to explicitly set a password for a device user.
What was done?
In the first drop changing passwords for other standard users was cut. (announcement before)
This change cuts the possibility that the user admin can not change the password even for device users
Device users need to perform registration steps again in case of losing their password.