### PR TITLE
[DM-3760] [DOC] Bulk Operation not "COMPLETED" if device is deleted while its operation is EXECUTING

### DIFF
--- a/content/device-management-application/monitoring-and-controlling-devices-bundle/working-with-operations.md
+++ b/content/device-management-application/monitoring-and-controlling-devices-bundle/working-with-operations.md
@@ -229,6 +229,6 @@ This may be useful if the operation is generally a success, but contains operati
 The completion percentage is determined by comparing the total number of initiated operations to the number of operations that have reached a final state (success or failure). The total count is established at operation creation and remains static thereafter. This static value may lead to inaccuracies in the completion percentage if the overall number of operations subsequently changes.
 
 * **Inaccuracy due to operation removal**: Operations can be implicitly removed when their associated devices are deleted. This deletion goes unaccounted for in the completion percentage calculation.
-* **Inaccuracy uue to operation addition**: Retrying failed operations can introduce new entries without modifying the original total count. This again results in a misrepresentation of the completion percentage.
+* **Inaccuracy due to operation addition**: Retrying failed operations can introduce new entries without modifying the original total count. This again results in a misrepresentation of the completion percentage.
 
 In conclusion, the current method of calculating completion percentage might not accurately reflect the actual progress due to the potential for uncaptured changes in the total number of operations.

--- a/content/device-management-application/monitoring-and-controlling-devices-bundle/working-with-operations.md
+++ b/content/device-management-application/monitoring-and-controlling-devices-bundle/working-with-operations.md
@@ -231,4 +231,4 @@ The completion percentage is determined by comparing the total number of initiat
 * **Operation removal**: Operations can be implicitly removed when their associated devices are deleted. This deletion goes unaccounted for in the completion percentage calculation.
 * **Operation addition**: Retrying failed operations can introduce new entries without modifying the original total count. This again results in a misrepresentation of the completion percentage.
 
-In conclusion, completion percentage is calculated based on the information available at the time an operation is created and further changes are not applied.
+The completion percentage is calculated based on the information available at the time an operation is created and further changes are not applied.

--- a/content/device-management-application/monitoring-and-controlling-devices-bundle/working-with-operations.md
+++ b/content/device-management-application/monitoring-and-controlling-devices-bundle/working-with-operations.md
@@ -224,11 +224,11 @@ To do so, click the menu icon <i class="dlt-c8y-icon-menu-vertical text-muted ic
 This may be useful if the operation is generally a success, but contains operation failures on devices that are not too important. These failures would otherwise still leave the bulk operation in status FAILED.
 
 {{< c8y-admon-info >}}
-**Calculation of Completion Percentage**
+**Calculation of completion percentage**
 
 The completion percentage is determined by comparing the total number of initiated operations to the number of operations that have reached a final state (success or failure). The total count is established at operation creation and remains static thereafter. This static value may lead to inaccuracies in the completion percentage if the overall number of operations subsequently changes.
 
-* **Inaccuracy Due to Operation Removal**: Operations can be implicitly removed when their associated devices are deleted. This deletion goes unaccounted for in the completion percentage calculation.
-* **Inaccuracy Due to Operation Addition**: Retrying failed operations can introduce new entries without modifying the original total count. This again results in a misrepresentation of the completion percentage.
+* **Inaccuracy due to operation removal**: Operations can be implicitly removed when their associated devices are deleted. This deletion goes unaccounted for in the completion percentage calculation.
+* **Inaccuracy uue to operation addition**: Retrying failed operations can introduce new entries without modifying the original total count. This again results in a misrepresentation of the completion percentage.
 
 In conclusion, the current method of calculating completion percentage might not accurately reflect the actual progress due to the potential for uncaptured changes in the total number of operations.

--- a/content/device-management-application/monitoring-and-controlling-devices-bundle/working-with-operations.md
+++ b/content/device-management-application/monitoring-and-controlling-devices-bundle/working-with-operations.md
@@ -222,3 +222,13 @@ You may manually set a failed bulk operation to the status SUCCESSFUL.
 To do so, click the menu icon <i class="dlt-c8y-icon-menu-vertical text-muted icon-20"></i> to the right of the bulk operation, then click **Set operation to successful**.
 
 This may be useful if the operation is generally a success, but contains operation failures on devices that are not too important. These failures would otherwise still leave the bulk operation in status FAILED.
+
+{{< c8y-admon-info >}}
+**Calculation of Completion Percentage**
+
+The completion percentage is determined by comparing the total number of initiated operations to the number of operations that have reached a final state (success or failure). The total count is established at operation creation and remains static thereafter. This static value may lead to inaccuracies in the completion percentage if the overall number of operations subsequently changes.
+
+* **Inaccuracy Due to Operation Removal**: Operations can be implicitly removed when their associated devices are deleted. This deletion goes unaccounted for in the completion percentage calculation.
+* **Inaccuracy Due to Operation Addition**: Retrying failed operations can introduce new entries without modifying the original total count. This again results in a misrepresentation of the completion percentage.
+
+In conclusion, the current method of calculating completion percentage might not accurately reflect the actual progress due to the potential for uncaptured changes in the total number of operations.

--- a/content/device-management-application/monitoring-and-controlling-devices-bundle/working-with-operations.md
+++ b/content/device-management-application/monitoring-and-controlling-devices-bundle/working-with-operations.md
@@ -231,4 +231,4 @@ The completion percentage is determined by comparing the total number of initiat
 * **Inaccuracy due to operation removal**: Operations can be implicitly removed when their associated devices are deleted. This deletion goes unaccounted for in the completion percentage calculation.
 * **Inaccuracy due to operation addition**: Retrying failed operations can introduce new entries without modifying the original total count. This again results in a misrepresentation of the completion percentage.
 
-In conclusion, the current method of calculating completion percentage might not accurately reflect the actual progress due to the potential for uncaptured changes in the total number of operations.
+In conclusion, completion percentage is calculated based on the information available at the time an operation is created and further changes are not applied.

--- a/content/device-management-application/monitoring-and-controlling-devices-bundle/working-with-operations.md
+++ b/content/device-management-application/monitoring-and-controlling-devices-bundle/working-with-operations.md
@@ -228,7 +228,7 @@ This may be useful if the operation is generally a success, but contains operati
 
 The completion percentage is determined by comparing the total number of initiated operations to the number of operations that have reached a final state (success or failure). The total count is established at operation creation and remains static thereafter. This static value may lead to inaccuracies in the completion percentage if the overall number of operations subsequently changes.
 
-* **Inaccuracy due to operation removal**: Operations can be implicitly removed when their associated devices are deleted. This deletion goes unaccounted for in the completion percentage calculation.
+* **Operation removal**: Operations can be implicitly removed when their associated devices are deleted. This deletion goes unaccounted for in the completion percentage calculation.
 * **Inaccuracy due to operation addition**: Retrying failed operations can introduce new entries without modifying the original total count. This again results in a misrepresentation of the completion percentage.
 
 In conclusion, completion percentage is calculated based on the information available at the time an operation is created and further changes are not applied.

--- a/content/device-management-application/monitoring-and-controlling-devices-bundle/working-with-operations.md
+++ b/content/device-management-application/monitoring-and-controlling-devices-bundle/working-with-operations.md
@@ -229,6 +229,6 @@ This may be useful if the operation is generally a success, but contains operati
 The completion percentage is determined by comparing the total number of initiated operations to the number of operations that have reached a final state (success or failure). The total count is established at operation creation and remains static thereafter. This static value may lead to inaccuracies in the completion percentage if the overall number of operations subsequently changes.
 
 * **Operation removal**: Operations can be implicitly removed when their associated devices are deleted. This deletion goes unaccounted for in the completion percentage calculation.
-* **Inaccuracy due to operation addition**: Retrying failed operations can introduce new entries without modifying the original total count. This again results in a misrepresentation of the completion percentage.
+* **Operation addition**: Retrying failed operations can introduce new entries without modifying the original total count. This again results in a misrepresentation of the completion percentage.
 
 In conclusion, completion percentage is calculated based on the information available at the time an operation is created and further changes are not applied.


### PR DESCRIPTION

https://cumulocity.atlassian.net/browse/DM-3760

**Description**
If I create bulk operation for a set of devices, if  one of the devices is deleted while its operation is executing, the bulk operation information in the UI becomes misleading.


@Exalate:

Emmel, Philipp commented: After some more discussion with @User  this is different that I had understood earlier. The issue is related to the counters and the percentage shown for a bulk operation being incorrect in certain situation.

The percentage is being calculated by comparing the all counter to the operations that are completed (meaning in status FAILED or SUCCESSFUL). The all counter is only ste once when the operation is created. It is not updated later on even in situations where the number of operations changes. Operations can be deleted by implicitly deleting the as part of deleting a device. Operations can also be added by retrying individual operations. So in the end when operations are removed or added the the percentage calculation may no longer be accurate.

We should document this limitation as part of user docs

+++ added via workflow action "Update (DEV-GS) - Alert Global Support"  +++

-------------------------