### PR TITLE
Create ui-c8y-1020-2-7-asset-selector-not-emitting-correctly-the-first-selected-item-6511-graft.md

### DIFF
--- a/content/change-logs/application-enablement/ui-c8y-1020-2-7-asset-selector-not-emitting-correctly-the-first-selected-item-6511-graft.md
+++ b/content/change-logs/application-enablement/ui-c8y-1020-2-7-asset-selector-not-emitting-correctly-the-first-selected-item-6511-graft.md
@@ -1,6 +1,6 @@
 ---
 date: ""
-title: Fixed asset selector to correctly emit the first selected item
+title: Asset selector now correctly emits the first selected item
 product_area: Application enablement & solutions
 change_type:
   - value: change-VSkj2iV9m

--- a/content/change-logs/application-enablement/ui-c8y-1020-2-7-asset-selector-not-emitting-correctly-the-first-selected-item-6511-graft.md
+++ b/content/change-logs/application-enablement/ui-c8y-1020-2-7-asset-selector-not-emitting-correctly-the-first-selected-item-6511-graft.md
@@ -14,4 +14,4 @@ build_artifact:
 ticket: MTM-59543
 version: 1020.2.7
 ---
-asset-selector not emitting correctly the first selected item (#6511) [GRAFT][release/cd] (#6581)
+The asset selector component is used to allow users to select an asset from a list. Previously, the first item in the list was not automatically selected. This was changed, but the first selected item was not properly emitted to other components. This led in some cases to data points not showing in the data points selector. This has now been fixed so that the asset selector component will always emit the selected item. This change ensures that the selected asset is properly communicated and depending components can be used as expected.

--- a/content/change-logs/application-enablement/ui-c8y-1020-2-7-asset-selector-not-emitting-correctly-the-first-selected-item-6511-graft.md
+++ b/content/change-logs/application-enablement/ui-c8y-1020-2-7-asset-selector-not-emitting-correctly-the-first-selected-item-6511-graft.md
@@ -1,0 +1,17 @@
+---
+date: ""
+title: asset-selector not emitting correctly the first selected item (#6511) [GRAFT][release/cd] (#6581)
+product_area: Application enablement & solutions
+change_type:
+  - value: change-VSkj2iV9m
+    label: Fix
+component:
+  - value: component-YbYJ3gLU_
+    label: Web SDK
+build_artifact:
+  - value: tc-pjJiURv9Y
+    label: ui-c8y
+ticket: MTM-59543
+version: 1020.2.7
+---
+asset-selector not emitting correctly the first selected item (#6511) [GRAFT][release/cd] (#6581)

--- a/content/change-logs/application-enablement/ui-c8y-1020-2-7-asset-selector-not-emitting-correctly-the-first-selected-item-6511-graft.md
+++ b/content/change-logs/application-enablement/ui-c8y-1020-2-7-asset-selector-not-emitting-correctly-the-first-selected-item-6511-graft.md
@@ -14,4 +14,4 @@ build_artifact:
 ticket: MTM-59543
 version: 1020.2.7
 ---
-The asset selector component is used to allow users to select an asset from a list. Previously, the first item in the list was not automatically selected. This was changed, but the first selected item was not properly emitted to other components. In some cases this led to data points not showing up in the data points selector. This has now been fixed so that the asset selector component will always emit the selected item. This change ensures that the selected asset is properly communicated and depending components can be used as expected.
+The asset selector component is used to allow users to select an asset from a list. Previously, the first item in the list was not automatically selected. This had been changed, but the first selected item was not properly emitted to other components. In some cases this led to data points not showing up in the data points selector. This has now been fixed so that the asset selector component will always emit the selected item. This change ensures that the selected asset is properly communicated and depending components can be used as expected.

--- a/content/change-logs/application-enablement/ui-c8y-1020-2-7-asset-selector-not-emitting-correctly-the-first-selected-item-6511-graft.md
+++ b/content/change-logs/application-enablement/ui-c8y-1020-2-7-asset-selector-not-emitting-correctly-the-first-selected-item-6511-graft.md
@@ -1,6 +1,6 @@
 ---
 date: ""
-title: asset-selector not emitting correctly the first selected item (#6511) [GRAFT][release/cd] (#6581)
+title: Fixed asset selector to correctly emit the first selected item
 product_area: Application enablement & solutions
 change_type:
   - value: change-VSkj2iV9m

--- a/content/change-logs/application-enablement/ui-c8y-1020-2-7-asset-selector-not-emitting-correctly-the-first-selected-item-6511-graft.md
+++ b/content/change-logs/application-enablement/ui-c8y-1020-2-7-asset-selector-not-emitting-correctly-the-first-selected-item-6511-graft.md
@@ -14,4 +14,4 @@ build_artifact:
 ticket: MTM-59543
 version: 1020.2.7
 ---
-The asset selector component is used to allow users to select an asset from a list. Previously, the first item in the list was not automatically selected. This was changed, but the first selected item was not properly emitted to other components. This led in some cases to data points not showing in the data points selector. This has now been fixed so that the asset selector component will always emit the selected item. This change ensures that the selected asset is properly communicated and depending components can be used as expected.
+The asset selector component is used to allow users to select an asset from a list. Previously, the first item in the list was not automatically selected. This was changed, but the first selected item was not properly emitted to other components. In some cases this led to data points not showing up in the data points selector. This has now been fixed so that the asset selector component will always emit the selected item. This change ensures that the selected asset is properly communicated and depending components can be used as expected.


### PR DESCRIPTION
Release note created by c8y-ui-automations[bot]

Ticket: [MTM-59543](https://cumulocity.atlassian.net/browse/MTM-59543)
Original PR: [6581](https://github.softwareag.com/IOTA/cumulocity-ui/pull/6581)