### PR TITLE
[DM-3797] Machine Learning missing from the top text

### DIFF
--- a/content/section/data_analytics/_index.md
+++ b/content/section/data_analytics/_index.md
@@ -195,4 +195,4 @@ svg: '<svg
 '
 ---
 
-Find out about customizing immediate processing of incoming data from devices with Streaming Analytics, Machine Learning integration and about advanced analytical querying over device data with {{< product-c8y-iot >}} DataHub.
+Find out about customizing immediate processing of incoming data from devices with Streaming Analytics, about advanced analytical querying over device data with {{< product-c8y-iot >}} DataHub, and about Machine Learning integration.

--- a/content/section/data_analytics/_index.md
+++ b/content/section/data_analytics/_index.md
@@ -195,4 +195,4 @@ svg: '<svg
 '
 ---
 
-Find out about customizing immediate processing of incoming data from devices with Streaming Analytics, and about advanced analytical querying over device data with {{< product-c8y-iot >}} DataHub.
+Find out about customizing immediate processing of incoming data from devices with Streaming Analytics, Machine Learning integration and about advanced analytical querying over device data with {{< product-c8y-iot >}} DataHub.


### PR DESCRIPTION
Reported by Bugherd

Reported Jun 18, 2024 at 9:47am, by [Karin Olivier](mailto:karin.olivier@softwareag.com)

A title for Machine Learning has been added to this page, but the text at the top does not yet mention this.

[Analytics - Cumulocity IoT documentation](https://cumulocity.com/docs/section/data_analytics/) 

![image](https://github.com/SoftwareAG/c8y-docs/assets/92311581/37b90dfd-6603-4ece-a32f-a936601d56b9)
