### PR TITLE
[DM-3747] Announcement snmp no longer supported

### DIFF
--- a/content/change-logs/device-management/SNMP-removed-from-docs.md
+++ b/content/change-logs/device-management/SNMP-removed-from-docs.md
@@ -1,0 +1,15 @@
+---
+date: 2024-06-26T00:00:00.000Z
+title: Deprecation of SNMP
+product_area: Device management
+change_type:
+  - value: change-inv-3bw8e
+    label: Announcement
+component:
+  - value: component--KIsStyzM
+    label: Device Management app
+build_artifact:
+  - value: tc-pjJiURv9Y
+    label: ui-c8y
+---
+SNMP functionality is considered deprecated (since which version?) and the respective documentation have been moved to GitHub repository: [cumulocity-examples](https://github.com/SoftwareAG/cumulocity-examples/snmp). This means that the feature is no longer actively supported by the product team.

--- a/content/change-logs/device-management/SNMP-removed-from-docs.md
+++ b/content/change-logs/device-management/SNMP-removed-from-docs.md
@@ -1,6 +1,6 @@
 ---
 date: 2024-06-26T00:00:00.000Z
-title: Deprecation of SNMP
+title: Moving SNMP documentation
 product_area: Device management
 change_type:
   - value: change-inv-3bw8e

--- a/content/change-logs/device-management/SNMP-removed-from-docs.md
+++ b/content/change-logs/device-management/SNMP-removed-from-docs.md
@@ -1,7 +1,7 @@
 ---
 date: 2024-06-26T00:00:00.000Z
 title: Moving SNMP documentation
-product_area: Device management
+product_area: Device Management
 change_type:
   - value: change-inv-3bw8e
     label: Announcement

--- a/content/change-logs/device-management/SNMP-removed-from-docs.md
+++ b/content/change-logs/device-management/SNMP-removed-from-docs.md
@@ -3,7 +3,7 @@ date: 2024-06-26T00:00:00.000Z
 title: Moving SNMP documentation
 product_area: Device Management
 change_type:
-  - value: change-inv-3bw8e
+  - value: change-2c7RdTdXo4
     label: Improvement
 component:
   - value: component--KIsStyzM

--- a/content/change-logs/device-management/SNMP-removed-from-docs.md
+++ b/content/change-logs/device-management/SNMP-removed-from-docs.md
@@ -1,5 +1,5 @@
 ---
-date: 2024-06-26T00:00:00.000Z
+date: 2024-07-08T00:00:00.000Z
 title: Moving SNMP documentation
 product_area: Device Management
 change_type:

--- a/content/change-logs/device-management/SNMP-removed-from-docs.md
+++ b/content/change-logs/device-management/SNMP-removed-from-docs.md
@@ -4,7 +4,7 @@ title: Moving SNMP documentation
 product_area: Device Management
 change_type:
   - value: change-inv-3bw8e
-    label: Announcement
+    label: Improvement
 component:
   - value: component--KIsStyzM
     label: Device Management app

--- a/content/change-logs/device-management/SNMP-removed-from-docs.md
+++ b/content/change-logs/device-management/SNMP-removed-from-docs.md
@@ -12,4 +12,4 @@ build_artifact:
   - value: tc-pjJiURv9Y
     label: ui-c8y
 ---
-SNMP functionality is considered deprecated (since which version?) and the respective documentation have been moved to GitHub repository: [cumulocity-examples](https://github.com/SoftwareAG/cumulocity-examples/snmp). This means that the feature is no longer actively supported by the product team.
+The documentation of the SNMP device protocol has been moved from the [user documentation](https://cumulocity.com/docs) to the public GitHub repository: [cumulocity-examples](https://github.com/SoftwareAG/cumulocity-examples/snmp). 


### PR DESCRIPTION
Description

SNMP is deprecated but we still have SNMP docs on our website. This has lead to confusion with presales and customers who thought this was still a product feature.


Parent PR https://github.com/SoftwareAG/c8y-docs/pull/2194

**Before we remove the section, we should announce this change, together with a link to the place where it can be found in the future. **