### PR TITLE
PAQ: Update links for Apama version to 10.15.5.

### DIFF
--- a/themes/c8ydocs/layouts/shortcodes/link-apama-webhelp.html
+++ b/themes/c8ydocs/layouts/shortcodes/link-apama-webhelp.html
@@ -1,1 +1,1 @@
-{{- "https://documentation.softwareag.com/pam/10.15.4/en/webhelp/pam-webhelp/" -}}
+{{- "https://documentation.softwareag.com/pam/10.15.5/en/webhelp/pam-webhelp/" -}}

--- a/themes/c8ydocs/layouts/shortcodes/link-apamadoc-api.html
+++ b/themes/c8ydocs/layouts/shortcodes/link-apamadoc-api.html
@@ -1,1 +1,1 @@
-{{- "https://documentation.softwareag.com/pam/10.15.4/en/webhelp/related/ApamaDoc/" -}}
+{{- "https://documentation.softwareag.com/pam/10.15.5/en/webhelp/related/ApamaDoc/" -}}


### PR DESCRIPTION
Hi @BeateRixen and @MWindel , these 2 shortcodes should also be copied over into the new structure for the Ops guides, and the links in the Streaming Analytics ops guide should then be adapted to use these shortcodes. Can one of you please take care of this? I'm not sure what's your master branch for the restructured ops doc.