### PR TITLE
[MTM-59297] Skip domain attribute in authorization Set-Cookie header

### DIFF
--- a/content/change-logs/platform-services/cumulocity-10-20-472-0-skip-domain-attribute-in-authorization-set-cookie-header.md
+++ b/content/change-logs/platform-services/cumulocity-10-20-472-0-skip-domain-attribute-in-authorization-set-cookie-header.md
@@ -3,8 +3,8 @@ date: ""
 title: Skip domain attribute in authorization Set-Cookie header
 product_area: Platform services
 change_type:
-  - value: change-inv-3bw8e
-    label: Announcement
+  - value: change-VSkj2iV9m
+    label: Fix
 component:
   - value: q3kclF6pO
     label: Authentication

--- a/content/change-logs/platform-services/cumulocity-10-20-472-0-skip-domain-attribute-in-authorization-set-cookie-header.md
+++ b/content/change-logs/platform-services/cumulocity-10-20-472-0-skip-domain-attribute-in-authorization-set-cookie-header.md
@@ -1,0 +1,17 @@
+---
+date: ""
+title: Skip domain attribute in authorization Set-Cookie header
+product_area: Platform services
+change_type:
+  - value: change-inv-3bw8e
+    label: Announcement
+component:
+  - value: q3kclF6pO
+    label: Authentication
+build_artifact:
+  - value: tc-QHwMfWtBk7
+    label: cumulocity
+ticket: MTM-59297
+version: 10.20.472.0
+---
+While setting a new authorization cookie, the 'domain' attribute by default will be omitted. Skipped this attribute allows the browser to apply cookies only for current document URLs, not including subdomains. Behavior can be changed via a core property: 'auth.cookies.skip.domain: false'

--- a/content/change-logs/platform-services/cumulocity-10-20-472-0-skip-domain-attribute-in-authorization-set-cookie-header.md
+++ b/content/change-logs/platform-services/cumulocity-10-20-472-0-skip-domain-attribute-in-authorization-set-cookie-header.md
@@ -14,4 +14,4 @@ build_artifact:
 ticket: MTM-59297
 version: 10.20.472.0
 ---
-While setting a new authorization cookie, the 'domain' attribute by default will be omitted. Skipped this attribute allows the browser to apply cookies only for current document URLs, not including subdomains. Behavior can be changed via a core property: 'auth.cookies.skip.domain: false'
+While setting a new authorization cookie, the `domain` attribute will now be omitted by default. Skipping this attribute allows the browser to apply cookies only for current document URLs, not including subdomains. The behavior can be changed via a core property: `auth.cookies.skip.domain: false`.


### PR DESCRIPTION
While setting a new authorization cookie, the 'domain' attribute by default will be omitted. Skipped this attribute allows the browser to apply cookies only for current document URLs, not including subdomains. Behavior can be changed via a core property: 'auth.cookies.skip.domain: false'