### PR TITLE
MTM-59870 Adding missing information about allowed characters to the description of name and context-path fields

### DIFF
--- a/content/microservice-sdk/general-aspects-bundle/microservice-manifest.md
+++ b/content/microservice-sdk/general-aspects-bundle/microservice-manifest.md
@@ -94,7 +94,7 @@ See below for detailed information about available settings.
 <tr>
 <td style="text-align:left">contextPath</td>
 <td style="text-align:left">String</td>
-<td style="text-align:left">Microservice contextPath is used to define extension points. The accepted letters are lowercase (a-z) and uppercase (A-Z) characters, digits, hyphens (-), dots (.), underscores (_), or tildes (~)<br>Default: Microservice name </td>
+<td style="text-align:left">Microservice contextPath is used to define extension points. The accepted letters are lowercase (a-z) and uppercase (A-Z) characters, digits, hyphens (-), dots (.), underscores (_), or tildes (~).<br>Default: Microservice name </td>
 <td style="text-align:left">No</td>
 </tr>
 <tr>

--- a/content/microservice-sdk/general-aspects-bundle/microservice-manifest.md
+++ b/content/microservice-sdk/general-aspects-bundle/microservice-manifest.md
@@ -88,13 +88,13 @@ See below for detailed information about available settings.
 <tr>
 <td style="text-align:left">name</td>
 <td style="text-align:left">String</td>
-<td style="text-align:left">Application name</td>
+<td style="text-align:left">Application name. The accepted letters are lowercase characters (a-z), digits (0-9), or hyphens (-). The maximum length for the name is 23 characters.</td>
 <td style="text-align:left">No</td>
 </tr>
 <tr>
 <td style="text-align:left">contextPath</td>
 <td style="text-align:left">String</td>
-<td style="text-align:left">Microservice contextPath is used to define extension points. <br>Default: Microservice name </td>
+<td style="text-align:left">Microservice contextPath is used to define extension points. The accepted letters are lowercase (a-z) and uppercase (A-Z) characters, digits, hyphens (-), dots (.), underscores (_), or tildes (~)<br>Default: Microservice name </td>
 <td style="text-align:left">No</td>
 </tr>
 <tr>


### PR DESCRIPTION
Adding missing information about allowed characters to the description of name and context-path fields