### PR TITLE
Create ui-c8y-1020-13-0-user-must-reset-password-on-next-login-is-default-option-5660.md

### DIFF
--- a/content/change-logs/platform-services/ui-c8y-1020-13-0-user-must-reset-password-on-next-login-is-default-option-5660.md
+++ b/content/change-logs/platform-services/ui-c8y-1020-13-0-user-must-reset-password-on-next-login-is-default-option-5660.md
@@ -1,0 +1,17 @@
+---
+date: ""
+title: user must reset password on next login is default option (#5660) [GRAFT][release/cd] (#6777)
+product_area: Platform services
+change_type:
+  - value: change-QHu1GdukP
+    label: Feature
+component:
+  - value: q3kclF6pO
+    label: Authentication
+build_artifact:
+  - value: tc-pjJiURv9Y
+    label: ui-c8y
+ticket: MTM-58077
+version: 1020.13.0
+---
+user must reset password on next login is default option (#5660) [GRAFT][release/cd] (#6777)


### PR DESCRIPTION
Release note created by c8y-ui-automations[bot]

Ticket: [MTM-58077](https://cumulocity.atlassian.net/browse/MTM-58077)
Original PR: [6777](https://github.softwareag.com/IOTA/cumulocity-ui/pull/6777)