### PR TITLE
[MTM-50975] Release notes: optional configuration in SSO page, allowi…

### DIFF
--- a/content/change-logs/platform-services/cumulocity-10-20-499-0-single-sign-on-improve-error-information-page.md
+++ b/content/change-logs/platform-services/cumulocity-10-20-499-0-single-sign-on-improve-error-information-page.md
@@ -1,0 +1,19 @@
+---
+date: ""
+title: Single-sign-on improve error information page
+product_area: Platform services
+change_type:
+  - value: change-2c7RdTdXo4
+    label: Improvement
+component:
+  - value: q3kclF6pO
+    label: Authentication
+build_artifact:
+  - value: tc-QHwMfWtBk7
+    label: cumulocity
+ticket: MTM-50975
+version: 10.20.499.0
+---
+SSO configuration has been extended with the optional: `Redirect to the user interface application`.
+If enabled: when login using SSO fails for whatever reason, the error information will be displayed on a proper error page.
+Using this option requires updating the "Valid Redirect URIs" in the authorization server with the value "<tenant_domain>/apps/*".

--- a/content/change-logs/platform-services/cumulocity-10-20-499-0-single-sign-on-improve-error-information-page.md
+++ b/content/change-logs/platform-services/cumulocity-10-20-499-0-single-sign-on-improve-error-information-page.md
@@ -14,6 +14,7 @@ build_artifact:
 ticket: MTM-50975
 version: 10.20.499.0
 ---
-SSO configuration has been extended with the optional: `Redirect to the user interface application`.
-If enabled: when login using SSO fails for whatever reason, the error information will be displayed on a proper error page.
+Previously, when an error occurred on logging in via SSO, the plain HTML error text was displayed in the browser.
+With this change, optional `Redirect to the user interface application` configuration has been added which allows displaying the error text as a standard UI error message.
+The new configuration option is optional and does not affect current SSO configurations.
 Using this option requires updating the "Valid Redirect URIs" in the authorization server with the value "<tenant_domain>/apps/*".

--- a/content/change-logs/platform-services/cumulocity-10-20-499-0-single-sign-on-improve-error-information-page.md
+++ b/content/change-logs/platform-services/cumulocity-10-20-499-0-single-sign-on-improve-error-information-page.md
@@ -16,5 +16,5 @@ version: 10.20.499.0
 ---
 Previously, when an error occurred on logging in via SSO, the plain HTML error text was displayed in the browser.
 With this change, optional `Redirect to the user interface application` configuration has been added which allows displaying the error text as a standard UI error message.
-The new configuration option is optional and does not affect current SSO configurations.
+The new configuration parameter is optional and does not affect current SSO configurations.
 Using this option requires updating the "Valid Redirect URIs" in the authorization server with the value "<tenant_domain>/apps/*".

--- a/content/change-logs/platform-services/cumulocity-10-20-499-0-single-sign-on-improve-error-information-page.md
+++ b/content/change-logs/platform-services/cumulocity-10-20-499-0-single-sign-on-improve-error-information-page.md
@@ -17,4 +17,4 @@ version: 10.20.499.0
 Previously, when an error occurred on logging in via SSO, the plain HTML error text was displayed in the browser.
 With this change, optional `Redirect to the user interface application` configuration has been added which allows displaying the error text as a standard UI error message.
 The new configuration parameter is optional and does not affect current SSO configurations.
-Using this option requires updating the "Valid Redirect URIs" in the authorization server with the value "<tenant_domain>/apps/*".
+Using this option requires updating the "Valid Redirect URIs" in the authorization server with the value "<tenant_domain>/apps/*". For details, refer to [Custom template configuration](/authentication/sso/custom-template).

--- a/content/change-logs/platform-services/cumulocity-10-20-499-0-single-sign-on-improve-error-information-page.md
+++ b/content/change-logs/platform-services/cumulocity-10-20-499-0-single-sign-on-improve-error-information-page.md
@@ -1,6 +1,6 @@
 ---
 date: ""
-title: Single-sign-on improve error information page
+title: Improved error information for single sign-on login
 product_area: Platform services
 change_type:
   - value: change-2c7RdTdXo4


### PR DESCRIPTION
Release notes: optional configuration in SSO page, allowing displaying error from the SSO flow in UI error page, instead of plain HTML as it was before.

Before: when an error occurs in the SSO auth flow the plain HTML is returned in the browser.
Now: Optional configuration was added which allows control flow by UI and in case of any error it can be printed in a pretty error page.

Why Optional? It required an update in the authorization server.
It will not affect the current SSO configuration. 