### PR TITLE
[DM-3622] Roll-back DM-3622 changes to y2024. Composite Write transmits data to the device in the specified order

### DIFF
--- a/content/change-logs/device-management/cumulocity-10-18-540-186-lwm2m-transmit-cwrite-data-in-the-specified-order.md
+++ b/content/change-logs/device-management/cumulocity-10-18-540-186-lwm2m-transmit-cwrite-data-in-the-specified-order.md
@@ -1,5 +1,5 @@
 ---
-date: "change_me"
+date: 2024-09-03
 title: Composite Write transmits data to the device in the specified order
 product_area: Device management & connectivity
 change_type:

--- a/content/change-logs/device-management/cumulocity-10-18-540-186-lwm2m-transmit-cwrite-data-in-the-specified-order.md
+++ b/content/change-logs/device-management/cumulocity-10-18-540-186-lwm2m-transmit-cwrite-data-in-the-specified-order.md
@@ -12,6 +12,6 @@ build_artifact:
   - value: tc-QHwMfWtBk7
     label: cumulocity
 ticket: DM-3622
-version: 10.18.change.me
+version: 10.18.540.186
 ---
 The Composite Write (cwrite) operation transmits resource-values data to the device in the exact order specified in the operation.

--- a/content/change-logs/device-management/cumulocity-10-18-540-186-lwm2m-transmit-cwrite-data-in-the-specified-order.md
+++ b/content/change-logs/device-management/cumulocity-10-18-540-186-lwm2m-transmit-cwrite-data-in-the-specified-order.md
@@ -14,4 +14,4 @@ build_artifact:
 ticket: DM-3622
 version: 10.18.540.186
 ---
-The Composite Write (cwrite) operation transmits resource-values data to the device in the exact order specified in the operation.
+The Composite Write (cwrite) operation transmits resource-values data to the device in the exact order specified in the operation. For details, see [Handling LWM2M shell commands](/protocol-integration/lwm2m/#handling-shell-commands).

--- a/content/change-logs/device-management/cumulocity-10-18-540-change_me-lwm2m-transmit-cwrite-data-in-the-specified-order.md
+++ b/content/change-logs/device-management/cumulocity-10-18-540-change_me-lwm2m-transmit-cwrite-data-in-the-specified-order.md
@@ -1,0 +1,17 @@
+---
+date: "change_me"
+title: Composite Write transmits data to the device in the specified order
+product_area: Device management & connectivity
+change_type:
+  - value: change-VSkj2iV9m
+    label: Fix
+component:
+  - value: component-1KLUzmqfe
+    label: LWM2M
+build_artifact:
+  - value: tc-QHwMfWtBk7
+    label: cumulocity
+ticket: DM-3622
+version: 10.18.change.me
+---
+The Composite Write (cwrite) operation transmits resource-values data to the device in the exact order specified in the operation.

--- a/content/protocol-integration/lwm2m-bundle/handling-shell-commands.md
+++ b/content/protocol-integration/lwm2m-bundle/handling-shell-commands.md
@@ -124,7 +124,8 @@ In the next table you will see all available commands and a brief description of
 <tr>
 <td align="left">cwrite /&lt;objectID&gt;/&lt;instanceID&gt;/&lt;resourceID&gt; &lt;value&gt; [/&lt;objectID&gt;/&lt;instanceID&gt;/&lt;resourceID&gt; &lt;value&gt;]</td>
 <td align="center">1.1</td>
-<td align="left">Composite writes of one or more values to a resource on the device. The data will be written to the listed resource paths in a single request</td>
+<td align="left">Composite writes facilitate the transmission of one or more values to LWM2M resources or resource instances on the device. The data will be written to the specified resource paths within a single request, adhering to the specified order.<br><br>
+Writing multiple resource instance values directly to the corresponding resource ID is not permitted; each resource instance ID must be defined with its respective value. When writing multiple resource instance values, the resource instances will be transmitted exactly as defined in the operation, without aggregation or sorting by the resource instance ID.</td>
 </tr>
 <tr>
 <td align="left">writeb /&lt;objectID&gt;/&lt;instanceID&gt;/&lt;resourceID&gt; &lt;hexadecimal-string&gt; <br>


### PR DESCRIPTION
Do not merge! 

This is a Draft PR because the Release note still doesn't have a build number assigned. 