### PR TITLE
[DM-3867] The OPC UA gateway no longer fails when running in a Docker container that lacks specific 64-bit system functions

### DIFF
--- a/content/change-logs/device-management/cumulocity-10-18-523-0-OPC-UA-Gateway-run-on-arm64-without-speciffic-64bist-system-libs.md
+++ b/content/change-logs/device-management/cumulocity-10-18-523-0-OPC-UA-Gateway-run-on-arm64-without-speciffic-64bist-system-libs.md
@@ -1,0 +1,17 @@
+---
+date: 
+title: The OPC UA gateway no longer fails when running in a Docker container that lacks specific 64-bit system functions
+change_type:
+  - value: change-VSkj2iV9m
+    label: Fix
+product_area: Device management & connectivity
+component:
+  - value: component-Tf05_KQ-B
+    label: OPC UA
+build_artifact:
+  - value: tc-MLn0oFRX-
+    label: opcua
+ticket: DM-3867
+version: 10.18.523.0
+---
+In certain ARM64-based environments, the OPC UA gateway may fail when attempting to call a specific 64-bit system function that might be missing in some base Docker images. This issue has now been resolved. If this function is missing, the service will attempt to call a default system function before failing.

--- a/content/change-logs/device-management/cumulocity-10-18-523-0-OPC-UA-Gateway-run-on-arm64-without-speciffic-64bist-system-libs.md
+++ b/content/change-logs/device-management/cumulocity-10-18-523-0-OPC-UA-Gateway-run-on-arm64-without-speciffic-64bist-system-libs.md
@@ -14,4 +14,4 @@ build_artifact:
 ticket: DM-3867
 version: 10.18.523.0
 ---
-In certain ARM64-based environments, the OPC UA gateway may fail when attempting to call a specific 64-bit system function that might be missing in some base Docker images. This issue has now been resolved. If this function is missing, the service will attempt to call a default system function before failing.
+In certain ARM64-based environments, the OPC UA gateway may have failed when attempting to call a specific 64-bit system function that might be missing in some base Docker images. This issue has now been resolved. If this function is missing, the service will attempt to call a default system function instead.

--- a/content/change-logs/device-management/cumulocity-10-18-523-0-OPC-UA-Gateway-run-on-arm64-without-speciffic-64bist-system-libs.md
+++ b/content/change-logs/device-management/cumulocity-10-18-523-0-OPC-UA-Gateway-run-on-arm64-without-speciffic-64bist-system-libs.md
@@ -1,6 +1,6 @@
 ---
 date: 
-title: The OPC UA gateway no longer fails when running in a Docker container that lacks specific 64-bit system functions
+title: OPC UA gateway no longer fails when attempting to call a missing 64-bit system function
 change_type:
   - value: change-VSkj2iV9m
     label: Fix


### PR DESCRIPTION
… 