### PR TITLE
Apply a recommendation from PM

### DIFF
--- a/content/device-integration/mqtt-service-bundle/overview.md
+++ b/content/device-integration/mqtt-service-bundle/overview.md
@@ -51,14 +51,14 @@ The table below presents a basic comparison between the standard {{< product-c8y
 |                              | {{< product-c8y-iot >}} MQTT                            | MQTT Service                                                                      |
 |:-----------------------------|:--------------------------------------------------------|:----------------------------------------------------------------------------------|
 | QoS                          | 0, 1, 2                                                 | 0, 1                                                                              |
-| Clean session                | Starting with clean session is recommended                 | Starting with clean session is recommended                                           |
+| Clean session                | Starting with clean session is recommended              | Starting with clean session is recommended                                        |
 | Retained flag                | Not supported                                           | Not supported                                                                     |
 | Last will                    | Supported                                               | Supported                                                                         |
 | MQTT 5.0 features            | Not supported                                           | Support is planned                                                                |
 | Authentication               | Basic and device certificate                            | Basic authentication is supported, device certificate support is planned          |
-| Scalability                  | Together with {{< product-c8y-iot >}}                   | Independent                                                                       |
-| Topic format                 | Determined by the SmartREST 2.0 protocol                | Unrestricted, SmartREST topic names are reserved and cannot currently be used     |                                                                     |
-| Payload                      | Determined by the SmartREST 2.0 protocol                | Unrestricted, maximum message size is 1048576 bytes (1 MiB) including all headers |                                                                   |
+| Scalability                  | Horizontal                                              | Horizontal                                                                        |
+| Topic format                 | Determined by the SmartREST 2.0 protocol                | Unrestricted, SmartREST topic names are reserved and cannot currently be used     |
+| Payload                      | Determined by the SmartREST 2.0 protocol                | Unrestricted, maximum message size is 1048576 bytes (1 MiB) including all headers |
 | Extensibility                | Limited by SmartREST 2.0 custom templates               | Custom mapping microservices can support arbitrary MQTT-based protocols           |
 | Message processors/consumers | Build-in message processor for each SmartREST 2.0 topic | Custom mapping microservices can support multiple processors for a topic          |
-| JSON via MQTT                | Limited feature set                                     | Custom mapping microservices can support arbitrary JSON payloads                  |                                                  |
+| JSON via MQTT                | Limited feature set                                     | Custom mapping microservices can support arbitrary JSON payloads                  |


### PR DESCRIPTION
Comment from Niko:

> IMO, we should not write this in the public documentation. While it is true and can be added to the operations guide, as far as public cloud customers are concerned both MQTT implementations scale horizontally and it is our job to do so (and our problem if the old MQTT interface scales at higher expenses...)

Happy to accept better wording if anyone can suggest something.  I also cleaned up some of the table formatting while I was in there.  Ignore whitespace changes to see the important stuff.