### PR TITLE
[backport][y2024] DM-3545 LWM2M docs added for device deletion 

### DIFF
--- a/content/protocol-integration/lwm2m-bundle/registering-lwm2m-devices.md
+++ b/content/protocol-integration/lwm2m-bundle/registering-lwm2m-devices.md
@@ -493,6 +493,51 @@ Allowed values are PACKAGE or PACKAGE_URI. Depending on the value, the LWM2M age
 Firmware updates are also supported for the registration of unsecured devices as well as secured devices. For more information, see [Managing firmware](/device-management-application/managing-device-data/#managing-firmware).
 {{< /c8y-admon-info >}}
 
+#### Registering LWM2M devices using the REST API {#registering-lwm2m-devices-using-restapi}
+
+LWM2M internally uses our [Extensible Device Registration](/concepts/applications/#extensible-device-registration) feature. It provides an API based on JSON Schema and REST to extend {{< company-c8y >}} with arbitrary wizards for device registration.
+
+Before the actual registration of a LWM2M device, it first is important to understand the set of available device properties. This set can be obtained using the `metadata` endpoint of LWM2M:
+
+`
+GET /service/lwm2m-agent/deviceRegistration/metadata
+`
+
+The registration of a new device then can be accomplished by posting a set of these values to the corresponding registration endpoint:
+
+`
+POST  /service/lwm2m-agent/deviceRegistration/
+`
+
+Example request payload:
+
+```
+{
+  "bootstrapSecurity": {
+    "bootstrapSecurityMode": "PSK",
+    "bootstrapId": "98ABCD32",
+    "bootstrapKey": "AABB3104D212"
+  },
+  "serverSecurity": {
+    "securityMode": "X.509"
+  },
+  "bootstrapShortServerId": 0,
+  "lwm2mShortServerId": 1,
+  "securityInstanceOffset": 0,
+  "bindingMode": "UQ",
+  "enableResourceLevelTimestamp": false,
+  "genericUIRetainOldValuesIfError": true,
+  "binaryDeliveryEncoding": "OPAQUE",
+  "disableObjectInstanceActions": false,
+  "disableFirmwareStateMachine": false,
+  "stateMachineResetBeforeFirmwareUpdate": true,
+  "endpointId": "urn:my:example:device",
+  "lwm2mServerUri": "coaps://lwm2m.cumulocity.com:5784",
+  "registrationLifetime": 12000
+}
+```
+
+
 ### Duplicate LWM2M devices {#duplicate-lwm2m-devices}
 
 If a LWM2M device has been registered with the same endpoint ID before, the device registration will not register the device, neither for single nor for bulk device registrations.
@@ -500,7 +545,20 @@ For single device registrations, the duplication error message will be displayed
 For bulk device registrations, the information about duplicate LWM2M devices will be displayed under the [LWM2M connector device](#connector-device)'s bulk upload operation result.
 
 
+
 ### Device deletion {#device-deletion}
 
-During LWM2M device registration the tenant route information is also stored in the cluster tenant.
-To remove the device, delete it from the [All devices](/device-management-application/viewing-all-devices/#to-delete-devices) list.
+To remove a LWM2M device, delete it through the [All devices](/device-management-application/viewing-all-devices/#to-delete-devices) list in the Device Management application.
+
+Alternatively, you can delete a LWM2M device using a REST call. With the managed object ID (device ID) of the device to be deleted, this can be accomplished using the following DELETE request.
+
+
+#### Device deletion using the REST API {#device-deletion-using-restapi}
+
+`
+DELETE /service/lwm2m-agent/deviceRegistration/{device ID}
+`
+
+{{< c8y-admon-important >}}
+It is not recommended to use the inventory API for directly deleting LWM2M devices. This action may result in issues when attempting to register a device with the same endpoint name at a later time.
+{{< /c8y-admon-info >}}


### PR DESCRIPTION
Unfortunately the auto-backport of #2369 broke, most likely due to a pipeline bug.
This PR now ports back the content manually, based on the diff of the original PR:

https://patch-diff.githubusercontent.com/raw/SoftwareAG/c8y-docs/pull/2369.diff

The patch was applied directly to y2024 without any conflicts.