### PR TITLE
Create ui-c8y-1020-21-2-async-delete-api-call-makes-empty-container-not-to-work-as.md

### DIFF
--- a/content/change-logs/device-management/ui-c8y-1020-21-2-async-delete-api-call-makes-empty-container-not-to-work-as.md
+++ b/content/change-logs/device-management/ui-c8y-1020-21-2-async-delete-api-call-makes-empty-container-not-to-work-as.md
@@ -1,0 +1,17 @@
+---
+date: ""
+title: Async delete API call makes empty container not to work as expected. [GRAFT][release/cd] (#6977)
+product_area: Device management & connectivity
+change_type:
+  - value: change-VSkj2iV9m
+    label: Fix
+component:
+  - value: component--KIsStyzM
+    label: Device Management app
+build_artifact:
+  - value: tc-pjJiURv9Y
+    label: ui-c8y
+ticket: DM-3704
+version: 1020.21.2
+---
+Async delete API call makes empty container not to work as expected. [GRAFT][release/cd] (#6977)


### PR DESCRIPTION
Release note created by c8y-ui-automations[bot]

Ticket: [DM-3704](https://cumulocity.atlassian.net/browse/DM-3704)
Original PR: [6977](https://github.softwareag.com/IOTA/cumulocity-ui/pull/6977)