### PR TITLE
Create ui-c8y-1020-23-1-error-appears-for-checking-active-filters-on-subtenants-6904-graft-release.md

### DIFF
--- a/content/change-logs/application-enablement/ui-c8y-1020-23-1-error-appears-for-checking-active-filters-on-subtenants-6904-graft-release.md
+++ b/content/change-logs/application-enablement/ui-c8y-1020-23-1-error-appears-for-checking-active-filters-on-subtenants-6904-graft-release.md
@@ -14,4 +14,4 @@ build_artifact:
 ticket: MTM-59337
 version: 1020.23.1
 ---
-error appears for checking active filters on subtenants (#6904) [GRAFT][release/cd] (#6981)
+In some situations, an error occurred when checking active filters on subtenants, preventing users from properly viewing and managing the filters. This issue has been resolved. Subtenants can now reliably check their active filters without encountering an error. This change ensures that the filtering functionality works as expected for all subtenants.

--- a/content/change-logs/application-enablement/ui-c8y-1020-23-1-error-appears-for-checking-active-filters-on-subtenants-6904-graft-release.md
+++ b/content/change-logs/application-enablement/ui-c8y-1020-23-1-error-appears-for-checking-active-filters-on-subtenants-6904-graft-release.md
@@ -14,4 +14,4 @@ build_artifact:
 ticket: MTM-59337
 version: 1020.23.1
 ---
-In some situations, an error occurred when checking active filters on subtenants, preventing users from properly viewing and managing the filters. This issue has been resolved. Subtenants can now reliably check their active filters without encountering an error. This change ensures that the filtering functionality works as expected for all subtenants.
+In some situations an error occurred when checking active filters on subtenants, preventing users from properly viewing and managing the filters. This issue has been resolved. Subtenants can now reliably check their active filters without encountering an error. 

--- a/content/change-logs/application-enablement/ui-c8y-1020-23-1-error-appears-for-checking-active-filters-on-subtenants-6904-graft-release.md
+++ b/content/change-logs/application-enablement/ui-c8y-1020-23-1-error-appears-for-checking-active-filters-on-subtenants-6904-graft-release.md
@@ -6,7 +6,7 @@ change_type:
   - value: change-VSkj2iV9m
     label: Fix
 component:
-  - value: component-YbYJ3gLU_
+  - value: component-0UgqXH1Ys 
     label: Web SDK
 build_artifact:
   - value: tc-pjJiURv9Y

--- a/content/change-logs/application-enablement/ui-c8y-1020-23-1-error-appears-for-checking-active-filters-on-subtenants-6904-graft-release.md
+++ b/content/change-logs/application-enablement/ui-c8y-1020-23-1-error-appears-for-checking-active-filters-on-subtenants-6904-graft-release.md
@@ -7,7 +7,7 @@ change_type:
     label: Fix
 component:
   - value: component-0UgqXH1Ys 
-    label: Web SDK
+    label: Administration
 build_artifact:
   - value: tc-pjJiURv9Y
     label: ui-c8y

--- a/content/change-logs/application-enablement/ui-c8y-1020-23-1-error-appears-for-checking-active-filters-on-subtenants-6904-graft-release.md
+++ b/content/change-logs/application-enablement/ui-c8y-1020-23-1-error-appears-for-checking-active-filters-on-subtenants-6904-graft-release.md
@@ -1,6 +1,6 @@
 ---
 date: ""
-title: Subtenants can now reliably check their active filters
+title: Users can now reliably check active filters for subtenants
 product_area: Application enablement & solutions
 change_type:
   - value: change-VSkj2iV9m

--- a/content/change-logs/application-enablement/ui-c8y-1020-23-1-error-appears-for-checking-active-filters-on-subtenants-6904-graft-release.md
+++ b/content/change-logs/application-enablement/ui-c8y-1020-23-1-error-appears-for-checking-active-filters-on-subtenants-6904-graft-release.md
@@ -14,4 +14,4 @@ build_artifact:
 ticket: MTM-59337
 version: 1020.23.1
 ---
-In some situations an error occurred when checking active filters on subtenants, preventing users from properly viewing and managing the filters. This issue has been resolved. Subtenants can now reliably check their active filters without encountering an error. 
+In some situations an error occurred when checking active filters in the **Subtenants** page, preventing users from properly viewing and managing the filters. This issue has been resolved. Users can now reliably check active filters for subtenants without encountering an error. 

--- a/content/change-logs/application-enablement/ui-c8y-1020-23-1-error-appears-for-checking-active-filters-on-subtenants-6904-graft-release.md
+++ b/content/change-logs/application-enablement/ui-c8y-1020-23-1-error-appears-for-checking-active-filters-on-subtenants-6904-graft-release.md
@@ -1,6 +1,6 @@
 ---
 date: ""
-title: Fix error when checking active filters on subtenants
+title: Subtenants can now reliably check their active filters
 product_area: Application enablement & solutions
 change_type:
   - value: change-VSkj2iV9m

--- a/content/change-logs/application-enablement/ui-c8y-1020-23-1-error-appears-for-checking-active-filters-on-subtenants-6904-graft-release.md
+++ b/content/change-logs/application-enablement/ui-c8y-1020-23-1-error-appears-for-checking-active-filters-on-subtenants-6904-graft-release.md
@@ -1,0 +1,17 @@
+---
+date: ""
+title: error appears for checking active filters on subtenants (#6904) [GRAFT][release/cd] (#6981)
+product_area: Application enablement & solutions
+change_type:
+  - value: change-VSkj2iV9m
+    label: Fix
+component:
+  - value: component-YbYJ3gLU_
+    label: Web SDK
+build_artifact:
+  - value: tc-pjJiURv9Y
+    label: ui-c8y
+ticket: MTM-59337
+version: 1020.23.1
+---
+error appears for checking active filters on subtenants (#6904) [GRAFT][release/cd] (#6981)

--- a/content/change-logs/application-enablement/ui-c8y-1020-23-1-error-appears-for-checking-active-filters-on-subtenants-6904-graft-release.md
+++ b/content/change-logs/application-enablement/ui-c8y-1020-23-1-error-appears-for-checking-active-filters-on-subtenants-6904-graft-release.md
@@ -1,6 +1,6 @@
 ---
 date: ""
-title: error appears for checking active filters on subtenants (#6904) [GRAFT][release/cd] (#6981)
+title: Fix error when checking active filters on subtenants
 product_area: Application enablement & solutions
 change_type:
   - value: change-VSkj2iV9m


### PR DESCRIPTION
Release note created by c8y-ui-automations[bot]

Ticket: [MTM-59337](https://cumulocity.atlassian.net/browse/MTM-59337)
Original PR: [6981](https://github.softwareag.com/IOTA/cumulocity-ui/pull/6981)