### PR TITLE
added missing release note dates for opcua 1018.523.0 and lwm2m 1018.540.184 and before

### DIFF
--- a/content/change-logs/device-management/cumulocity-10-18-514-0-OPC-UA-Gateway-run-on-arm64.md
+++ b/content/change-logs/device-management/cumulocity-10-18-514-0-OPC-UA-Gateway-run-on-arm64.md
@@ -1,5 +1,5 @@
 ---
-date: 
+date: 2024-09-02
 title: OPC UA gateway no longer fails to start on ARM64 Docker images
 change_type:
   - value: change-VSkj2iV9m

--- a/content/change-logs/device-management/cumulocity-10-18-523-0-OPC-UA-Gateway-run-on-arm64-without-speciffic-64bist-system-libs.md
+++ b/content/change-logs/device-management/cumulocity-10-18-523-0-OPC-UA-Gateway-run-on-arm64-without-speciffic-64bist-system-libs.md
@@ -1,5 +1,5 @@
 ---
-date: 
+date: 2024-09-02
 title: OPC UA gateway no longer fails when attempting to call a missing 64-bit system function
 change_type:
   - value: change-VSkj2iV9m

--- a/content/change-logs/device-management/cumulocity-10-18-540-0-LWM2M-REST-documentation-additions.md
+++ b/content/change-logs/device-management/cumulocity-10-18-540-0-LWM2M-REST-documentation-additions.md
@@ -1,5 +1,5 @@
 ---
-date:
+date: 2024-09-02
 title: Added documentation for REST-based LWM2M device registration
 change_type:
   - value: change-2c7RdTdXo4


### PR DESCRIPTION
- opcua: The actual 2024.8 GA2 release done before but I published opcua-device-gateway  with the version 1018.523.0 to public directory http://resources.cumulocity.com/examples/opc-ua/ today (2024-09-02) Therefore, added the current date.

- lwm2m: Info about documentation change, feature always existed. To not add sth. to the existing release notes. Added the current date.