### PR TITLE
Java 17 in microservices SDK announcement

### DIFF
--- a/content/change-logs/application-enablement/cumulocity-undefined-microservices-sdk-java17-announcement
+++ b/content/change-logs/application-enablement/cumulocity-undefined-microservices-sdk-java17-announcement
@@ -12,6 +12,6 @@ build_artifact:
   - value: tc-QHwMfWtBk7
     label: cumulocity
 ---
-Cumulocity IoT Microservices SDK will be updated to use Java 17. This update might lead to the need of adjustments on the microservices side.  
+The {{< product-c8y-iot >}} Microservice SDK will be updated to use Java 17. This update might require adjustments on the microservices side.  
 
 When using the Cumulocity IoT Microservice SDK for developing microservices, ensure to use the proper Java version and to implement the necessary adjustments, in case of any. For more information, refer to the documentation of the provider.

--- a/content/change-logs/application-enablement/cumulocity-undefined-microservices-sdk-java17-announcement
+++ b/content/change-logs/application-enablement/cumulocity-undefined-microservices-sdk-java17-announcement
@@ -14,4 +14,4 @@ build_artifact:
 ---
 The {{< product-c8y-iot >}} Microservice SDK will be updated to use Java 17. This update might require adjustments on the microservices side.  
 
-When using the Cumulocity IoT Microservice SDK for developing microservices, ensure to use the proper Java version and to implement the necessary adjustments, in case of any. For more information, refer to the documentation of the provider.
+When using the {{< product-c8y-iot >}} Microservice SDK for developing microservices, ensure to use the proper Java version and to implement the necessary adjustments, in case of any. For more information, refer to the documentation of the provider.

--- a/content/change-logs/application-enablement/cumulocity-undefined-microservices-sdk-java17-announcement
+++ b/content/change-logs/application-enablement/cumulocity-undefined-microservices-sdk-java17-announcement
@@ -1,6 +1,6 @@
 ---
 date: 2024-02-13T14:53:24.832Z
-title: Update to Java 17 
+title: Microservice SDK update to Java 17 
 change_type:
   - value: change-inv-3bw8e
     label: Announcement

--- a/content/change-logs/application-enablement/cumulocity-undefined-microservices-sdk-java17-announcement
+++ b/content/change-logs/application-enablement/cumulocity-undefined-microservices-sdk-java17-announcement
@@ -1,0 +1,17 @@
+---
+date: 2024-02-13T14:53:24.832Z
+title: Update to Java 17 
+change_type:
+  - value: change-inv-3bw8e
+    label: Announcement
+product_area: Application enablement & solutions
+component:
+  - value: component-Sv2buFZ5l
+    label: Microservice SDK
+build_artifact:
+  - value: tc-QHwMfWtBk7
+    label: cumulocity
+---
+Cumulocity IoT Microservices SDK will be updated to use Java 17. This update might lead to the need of adjustments on the microservices side.  
+
+When using the Cumulocity IoT Microservice SDK for developing microservices, ensure to use the proper Java version and to implement the necessary adjustments, in case of any. For more information, refer to the documentation of the provider.


### PR DESCRIPTION
In the context of the Spring boot update, the microservices SDK must use minimum Java version 17.