### PR TITLE
[MTM-60974] device ceritifacte authentication using leaf cert prerequ…

### DIFF
--- a/content/device-integration/device-certificates.md
+++ b/content/device-integration/device-certificates.md
@@ -31,6 +31,7 @@ In order to follow this tutorial, check if the following prerequisites are met:
 * Uploaded certificates must have set `BasicConstraints:[CA:true]`.
 * Devices must trust the {{< product-c8y-iot >}} server certificate.
 * Certificates used by devices must contain the certificate chain that includes the uploaded CA certificate.
+* If only the device certificate is provided, then the immediate issuer certificate must be uploaded to the platform’s truststore.
 * Certificates used by devices must be signed either by uploaded CA certificates or by intermediate certificates signed by uploaded CA certificates.
 
 ### Registering devices using certificates {#registering-devices-using-certificates}


### PR DESCRIPTION
Authenticating clients that can send only the leaf device certs, is documented in below sections.

MQTT - [https://cumulocity.com/docs/device-integration/mqtt/#mqtt-authentication](https://eur04.safelinks.protection.outlook.com/?url=https%3A%2F%2Fcumulocity.com%2Fdocs%2Fdevice-integration%2Fmqtt%2F%23mqtt-authentication&data=05%7C02%7CSayan.GuhaRoy%40softwareag.com%7C0ba94ba430054154041608dcd6563e03%7Cd9662eb9ad984e74a8a204ed5d544db6%7C1%7C0%7C638620913116706023%7CUnknown%7CTWFpbGZsb3d8eyJWIjoiMC4wLjAwMDAiLCJQIjoiV2luMzIiLCJBTiI6Ik1haWwiLCJXVCI6Mn0%3D%7C0%7C%7C%7C&sdata=cqJ0qtdhUGbOXJj0yqfE%2F8DjULW9ex1mxgekX3zT%2FaU%3D&reserved=0)

REST - [https://cumulocity.com/docs/device-integration/device-integration-rest/#device-authentication](https://eur04.safelinks.protection.outlook.com/?url=https%3A%2F%2Fcumulocity.com%2Fdocs%2Fdevice-integration%2Fdevice-integration-rest%2F%23device-authentication&data=05%7C02%7CSayan.GuhaRoy%40softwareag.com%7C0ba94ba430054154041608dcd6563e03%7Cd9662eb9ad984e74a8a204ed5d544db6%7C1%7C0%7C638620913116724464%7CUnknown%7CTWFpbGZsb3d8eyJWIjoiMC4wLjAwMDAiLCJQIjoiV2luMzIiLCJBTiI6Ik1haWwiLCJXVCI6Mn0%3D%7C0%7C%7C%7C&sdata=lY2PpnnsDd2rhAePfhsQiY%2BNNzkOLlruPBetN6O6Sys%3D&reserved=0)

 

This seem to be missing in the pre-requisites section - [https://cumulocity.com/docs/device-integration/device-certificates/#prerequisites](https://eur04.safelinks.protection.outlook.com/?url=https%3A%2F%2Fcumulocity.com%2Fdocs%2Fdevice-integration%2Fdevice-certificates%2F%23prerequisites&data=05%7C02%7CSayan.GuhaRoy%40softwareag.com%7C0ba94ba430054154041608dcd6563e03%7Cd9662eb9ad984e74a8a204ed5d544db6%7C1%7C0%7C638620913116735728%7CUnknown%7CTWFpbGZsb3d8eyJWIjoiMC4wLjAwMDAiLCJQIjoiV2luMzIiLCJBTiI6Ik1haWwiLCJXVCI6Mn0%3D%7C0%7C%7C%7C&sdata=UHJF5%2BR%2BxierYbILU%2BVLjmpKntQnIRUFlwNuFBZQmo4%3D&reserved=0)