### PR TITLE
[DM-4048] release notes for the case when lwm2m agent can't process a faulty device requests containing null entries in the Content Format

### DIFF
--- a/content/change-logs/device-management/cumulocity-10-18-540-218-LWM2M-skip-faulty-devices-null-entries-in-the-content-format.md
+++ b/content/change-logs/device-management/cumulocity-10-18-540-218-LWM2M-skip-faulty-devices-null-entries-in-the-content-format.md
@@ -1,0 +1,17 @@
+---
+date: 
+title: Skip null entries in Content Format
+product_area: Device management & connectivity
+change_type:
+  - value: change-VSkj2iV9m
+    label: Fix
+component:
+  - value: component-1KLUzmqfe
+    label: LWM2M
+build_artifact:
+  - value: tc-QHwMfWtBk7
+    label: cumulocity
+ticket: DM-4048
+version: 10.18.540.218
+---
+The LwM2M agent previously didn't process requests when a faulty device sent a content format list containing null values. This issue has now been resolved - the agent skips the null values and continues with the device communication.

--- a/content/change-logs/device-management/cumulocity-10-18-540-218-LWM2M-skip-faulty-devices-null-entries-in-the-content-format.md
+++ b/content/change-logs/device-management/cumulocity-10-18-540-218-LWM2M-skip-faulty-devices-null-entries-in-the-content-format.md
@@ -1,6 +1,6 @@
 ---
 date: 
-title: Skip null entries in Content Format
+title: Skip null entries in Supported Content Format reported by LWM2M devices
 product_area: Device management & connectivity
 change_type:
   - value: change-VSkj2iV9m
@@ -14,4 +14,4 @@ build_artifact:
 ticket: DM-4048
 version: 10.18.540.218
 ---
-The LwM2M agent previously didn't process requests when a faulty device sent a content format list containing null values. This issue has now been resolved - the agent skips the null values and continues with the device communication.
+The LwM2M agent previously didn't process requests when a faulty device sent a supported content format list containing null values. This issue has now been resolved - the agent skips the null values and continues with the device communication.

--- a/content/change-logs/device-management/cumulocity-10-18-540-218-LWM2M-skip-faulty-devices-null-entries-in-the-content-format.md
+++ b/content/change-logs/device-management/cumulocity-10-18-540-218-LWM2M-skip-faulty-devices-null-entries-in-the-content-format.md
@@ -1,6 +1,6 @@
 ---
 date: 
-title: Skip null entries in Supported Content Format reported by LWM2M devices
+title: LWM2M agent skips null entries in supported content format reported by LWM2M devices
 product_area: Device management & connectivity
 change_type:
   - value: change-VSkj2iV9m


### PR DESCRIPTION
… 