### PR TITLE
Create ui-c8y-1020-31-2-opcua-device-protocol-radio-buttons-go-unselect-when-we-expand-another.md

### DIFF
--- a/content/change-logs/device-management/ui-c8y-1020-31-2-opcua-device-protocol-radio-buttons-go-unselect-when-we-expand-another.md
+++ b/content/change-logs/device-management/ui-c8y-1020-31-2-opcua-device-protocol-radio-buttons-go-unselect-when-we-expand-another.md
@@ -14,4 +14,4 @@ build_artifact:
 ticket: DM-1756
 version: 1020.31.2
 ---
-OPCUA Device protocol Radio buttons go unselect when we expand another variable (#7216)
+In the OPC-UA device protocol configuration, users could select a radio button for a specific variable. However, when expanding another variable in the same view, the previously selected radio button would become unselected. This issue has now been resolved. With this fix, the radio button selection is properly maintained even when expanding other variables in the view. Users no longer need to reselect the desired radio button after inspecting other variables.

--- a/content/change-logs/device-management/ui-c8y-1020-31-2-opcua-device-protocol-radio-buttons-go-unselect-when-we-expand-another.md
+++ b/content/change-logs/device-management/ui-c8y-1020-31-2-opcua-device-protocol-radio-buttons-go-unselect-when-we-expand-another.md
@@ -1,6 +1,6 @@
 ---
 date: ""
-title: OPC-UA device protocol: Radio button selection lost when expanding another variable
+title: Radio button selection in OPC UA device protocol configuration maintained when expanding another variable
 product_area: Device management & connectivity
 change_type:
   - value: change-VSkj2iV9m

--- a/content/change-logs/device-management/ui-c8y-1020-31-2-opcua-device-protocol-radio-buttons-go-unselect-when-we-expand-another.md
+++ b/content/change-logs/device-management/ui-c8y-1020-31-2-opcua-device-protocol-radio-buttons-go-unselect-when-we-expand-another.md
@@ -1,0 +1,17 @@
+---
+date: ""
+title: OPCUA Device protocol Radio buttons go unselect when we expand another variable (#7216)
+product_area: Device management & connectivity
+change_type:
+  - value: change-VSkj2iV9m
+    label: Fix
+component:
+  - value: component--KIsStyzM
+    label: Device Management app
+build_artifact:
+  - value: tc-pjJiURv9Y
+    label: ui-c8y
+ticket: DM-1756
+version: 1020.31.2
+---
+OPCUA Device protocol Radio buttons go unselect when we expand another variable (#7216)

--- a/content/change-logs/device-management/ui-c8y-1020-31-2-opcua-device-protocol-radio-buttons-go-unselect-when-we-expand-another.md
+++ b/content/change-logs/device-management/ui-c8y-1020-31-2-opcua-device-protocol-radio-buttons-go-unselect-when-we-expand-another.md
@@ -14,4 +14,4 @@ build_artifact:
 ticket: DM-1756
 version: 1020.31.2
 ---
-In the OPC-UA device protocol configuration, users could select a radio button for a specific variable. However, when expanding another variable in the same view, the previously selected radio button would become unselected. This issue has now been resolved. With this fix, the radio button selection is properly maintained even when expanding other variables in the view. Users no longer need to reselect the desired radio button after inspecting other variables.
+In the OPC UA device protocol configuration, users could select a radio button for a specific variable. However, when expanding another variable in the same view, the previously selected radio button would become unselected. This issue has now been resolved. With this fix, the radio button selection is properly maintained even when expanding other variables in the view. Users no longer need to reselect the desired radio button after inspecting other variables.

--- a/content/change-logs/device-management/ui-c8y-1020-31-2-opcua-device-protocol-radio-buttons-go-unselect-when-we-expand-another.md
+++ b/content/change-logs/device-management/ui-c8y-1020-31-2-opcua-device-protocol-radio-buttons-go-unselect-when-we-expand-another.md
@@ -1,6 +1,6 @@
 ---
 date: ""
-title: OPCUA Device protocol Radio buttons go unselect when we expand another variable (#7216)
+title: OPC-UA device protocol: Radio button selection lost when expanding another variable
 product_area: Device management & connectivity
 change_type:
   - value: change-VSkj2iV9m

--- a/content/change-logs/device-management/ui-c8y-1020-31-2-opcua-device-protocol-radio-buttons-go-unselect-when-we-expand-another.md
+++ b/content/change-logs/device-management/ui-c8y-1020-31-2-opcua-device-protocol-radio-buttons-go-unselect-when-we-expand-another.md
@@ -12,6 +12,6 @@ build_artifact:
   - value: tc-pjJiURv9Y
     label: ui-c8y
 ticket: DM-1756
-version: 1020.31.2
+version: 10.20.31.2
 ---
 In the OPC UA device protocol configuration, users could select a radio button for a specific variable. However, when expanding another variable in the same view, the previously selected radio button would become unselected. This issue has now been resolved. With this fix, the radio button selection is properly maintained even when expanding other variables in the view. Users no longer need to reselect the desired radio button after inspecting other variables.


### PR DESCRIPTION
Release note created by c8y-ui-automations[bot]

Ticket: [DM-1756](https://cumulocity.atlassian.net/browse/DM-1756)
Original PR: [7216](https://github.com/Cumulocity-IoT/cumulocity-ui/pull/7216)