### PR TITLE
Create ui-c8y-1018-503-125-ui-filtering-the-alarm-audit-logs-with-date-filter-displays-wrong.md

### DIFF
--- a/content/change-logs/platform-services/ui-c8y-1018-503-125-ui-filtering-the-alarm-audit-logs-with-date-filter-displays-wrong.md
+++ b/content/change-logs/platform-services/ui-c8y-1018-503-125-ui-filtering-the-alarm-audit-logs-with-date-filter-displays-wrong.md
@@ -1,6 +1,6 @@
 ---
 date: ""
-title: UI Filtering the Alarm Audit Logs with Date filter displays wrong results (#7025) [GRAFT][release/y2024]
+title: Improved information on time filtering in Audit logs page
 product_area: Platform services
 change_type:
   - value: change-VSkj2iV9m

--- a/content/change-logs/platform-services/ui-c8y-1018-503-125-ui-filtering-the-alarm-audit-logs-with-date-filter-displays-wrong.md
+++ b/content/change-logs/platform-services/ui-c8y-1018-503-125-ui-filtering-the-alarm-audit-logs-with-date-filter-displays-wrong.md
@@ -1,0 +1,17 @@
+---
+date: ""
+title: UI Filtering the Alarm Audit Logs with Date filter displays wrong results (#7025) [GRAFT][release/y2024]
+product_area: Platform services
+change_type:
+  - value: change-VSkj2iV9m
+    label: Fix
+component:
+  - value: component-0UgqXH1Ys
+    label: Administration
+build_artifact:
+  - value: tc-pjJiURv9Y
+    label: ui-c8y
+ticket: MTM-60595
+version: 1018.503.125
+---
+UI Filtering the Alarm Audit Logs with Date filter displays wrong results (#7025) [GRAFT][release/y2024]

--- a/content/change-logs/platform-services/ui-c8y-1018-503-125-ui-filtering-the-alarm-audit-logs-with-date-filter-displays-wrong.md
+++ b/content/change-logs/platform-services/ui-c8y-1018-503-125-ui-filtering-the-alarm-audit-logs-with-date-filter-displays-wrong.md
@@ -14,4 +14,4 @@ build_artifact:
 ticket: MTM-60595
 version: 1018.503.125
 ---
-UI Filtering the Alarm Audit Logs with Date filter displays wrong results (#7025) [GRAFT][release/y2024]
+In the **Audit logs** page, time information is provided in the "Times" column on the left (server time) and inside the audit log card (device time). The information popup has been improved, to make users aware that audit logs cards are filtered by device time which can be different from the server time.


### PR DESCRIPTION
Release note created by pmic-cumulo

Ticket: [MTM-60595](https://cumulocity.atlassian.net/browse/MTM-60595)
Original PR: [7331](https://github.com/Cumulocity-IoT/cumulocity-ui/pull/7331)

[MTM-60595]: https://cumulocity.atlassian.net/browse/MTM-60595?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ