### PR TITLE
Create ui-c8y-1020-35-2-fix-typeahead-validation-when-using-json-path-in-display-property.md

### DIFF
--- a/content/change-logs/application-enablement/ui-c8y-1020-35-2-fix-typeahead-validation-when-using-json-path-in-display-property.md
+++ b/content/change-logs/application-enablement/ui-c8y-1020-35-2-fix-typeahead-validation-when-using-json-path-in-display-property.md
@@ -14,4 +14,4 @@ build_artifact:
 ticket: DM-3955
 version: 1020.35.2
 ---
-Previously, when using a JSON path in the 'displayProperty' of a typeahead control, the validation not allowing free entries (allowFreeEntries = false) was not working correctly and could lead to unexpected behavior, like creating orphan entries when an item needs to be assigned to a parent entity, etc. This issue has now been fixed. This change improves the reliability and usability of typeahead controls in forms.
+Previously, when using a JSON path in the `displayProperty` of a typeahead control, the validation not allowing free entries (allowFreeEntries = false) was not working correctly and could lead to unexpected behavior, such as creating orphan entries when an item needs to be assigned to a parent entity. This issue has now been fixed. This change improves the reliability and usability of typeahead controls in forms.

--- a/content/change-logs/application-enablement/ui-c8y-1020-35-2-fix-typeahead-validation-when-using-json-path-in-display-property.md
+++ b/content/change-logs/application-enablement/ui-c8y-1020-35-2-fix-typeahead-validation-when-using-json-path-in-display-property.md
@@ -1,6 +1,6 @@
 ---
 date: ""
-title: Fix typeahead validation when using JSON path in 'displayProperty'
+title: Typeahead control validation fixed when using JSON path in 'displayProperty'
 product_area: Application enablement & solutions
 change_type:
   - value: change-VSkj2iV9m
@@ -14,4 +14,4 @@ build_artifact:
 ticket: DM-3955
 version: 1020.35.2
 ---
-Fix typeahead validation when using JSON path in 'displayProperty'
+Previously, when using a JSON path in the 'displayProperty' of a typeahead control, the validation not allowing free entries (allowFreeEntries = false) was not working correctly and could lead to unexpected behavior, like creating orphan entries when an item needs to be assigned to a parent entity, etc. This issue has now been fixed. This change improves the reliability and usability of typeahead controls in forms.

--- a/content/change-logs/application-enablement/ui-c8y-1020-35-2-fix-typeahead-validation-when-using-json-path-in-display-property.md
+++ b/content/change-logs/application-enablement/ui-c8y-1020-35-2-fix-typeahead-validation-when-using-json-path-in-display-property.md
@@ -1,0 +1,17 @@
+---
+date: ""
+title: Fix typeahead validation when using JSON path in 'displayProperty'
+product_area: Application enablement & solutions
+change_type:
+  - value: change-VSkj2iV9m
+    label: Fix
+component:
+  - value: component-YbYJ3gLU_
+    label: Web SDK
+build_artifact:
+  - value: tc-pjJiURv9Y
+    label: ui-c8y
+ticket: DM-3955
+version: 1020.35.2
+---
+Fix typeahead validation when using JSON path in 'displayProperty'


### PR DESCRIPTION
Release note created by c8y-ui-automations[bot]

Ticket: [DM-3955](https://cumulocity.atlassian.net/browse/DM-3955)
Original PR: [7330](https://github.com/Cumulocity-IoT/cumulocity-ui/pull/7330)

[DM-3955]: https://cumulocity.atlassian.net/browse/DM-3955?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ