### PR TITLE
MTM-60178 Update the Web SDK with information about Angular 18

### DIFF
--- a/content/web/gettingstarted.md
+++ b/content/web/gettingstarted.md
@@ -9,7 +9,7 @@ sector:
 This guide will setup your first application. The first step is to install the `@angular/cli` in the right version.
 
 ```bash
-npx @angular/cli@v17-lts new --style=less --standalone=false
+npx @angular/cli@18 new --style=less
 ```
 
 Second, navigate to the folder and add the `@c8y/websdk` package to your Angular application:

--- a/content/web/introduction.md
+++ b/content/web/introduction.md
@@ -102,6 +102,7 @@ As our releases are bound to the Angular versioning, you must to ensure that you
 
 | Angular version | Web SDK version | Comment |
 | --- | --- | --- |
+| 18.x.x | 1021.x.x | No support for the standalone flag |
 | 17.x.x | 1020.x.x | No support for the standalone flag |
 | 16.x.x | 1019.x.x | Using [Angular CLI tooling](https://angular.io/cli). |
 | 15.x.x | 1018.1.x - 1018.x.x | Using `c8ycli` tooling, only yearly release |

--- a/content/web/upgrade-bundle/upgrading-to-angular-18.md
+++ b/content/web/upgrade-bundle/upgrading-to-angular-18.md
@@ -1,0 +1,15 @@
+---
+title: Upgrading from Angular 17 to Angular 18  
+layout: redirect
+weight: 450
+---
+
+Angular 18 is supported from version `1021.0.0`. The following configuration changes are required before you can run the application:
+
+- Update all `@c8y` dependencies to version `1021.x.x` in your *package.json*.
+- Run the command `ng update @angular/core@18 @angular/cli@18` to update Angular core and CLI to version 18.
+- Update `ngx-bootstrap` to version `18.0.0`.
+- Update `@angular/cdk` to version `18.x.x`.
+- `Node.js`, `TypeScript`, `RxJS`: [Version compatibility](https://angular.dev/reference/versions#actively-supported-versions).
+- Follow the `Angular 18` upgrade guide: [Updating to version 18](https://angular.dev/update-guide?v=17.0-18.0&l=2).
+

--- a/content/web/upgrade-bundle/upgrading-to-angular-18.md
+++ b/content/web/upgrade-bundle/upgrading-to-angular-18.md
@@ -10,6 +10,11 @@ Angular 18 is supported from version `1021.0.0`. The following configuration cha
 - Run the command `ng update @angular/core@18 @angular/cli@18` to update Angular core and CLI to version 18.
 - Update `ngx-bootstrap` to version `18.0.0`.
 - Update `@angular/cdk` to version `18.x.x`.
+- The `brandingEntry` application option can no longer be used to customize the global style of your application.
+  Instead, global styles should now be specified via [the mechanism Angular provides](https://angular.dev/reference/configs/workspace-config#styles-and-scripts-configuration).
+  If you previously did not use the `brandingEntry` in your `cumulocity.config.ts` file, you would now need to reference the `@c8y/style/main.less` file in the `styles` arrays of your `angular.json` file.
+  In case you've previously used the `brandingEntry` in your `cumulocity.config.ts` you would now need to reference the same file in the `styles` arrays of your `angular.json` file.
+  The `brandingEntry` should be removed from the `cumulocity.config.ts` file.
 - `Node.js`, `TypeScript`, `RxJS`: [Version compatibility](https://angular.dev/reference/versions#actively-supported-versions).
 - Follow the `Angular 18` upgrade guide: [Updating to version 18](https://angular.dev/update-guide?v=17.0-18.0&l=2).
 


### PR DESCRIPTION
Should only be merged after 1021 has been released.