### PR TITLE
Create ui-c8y-1020-39-1-the-delete-popup-now-closes-correctly-if-another-delete-button-is.md

### DIFF
--- a/content/change-logs/application-enablement/ui-c8y-1020-39-1-the-delete-popup-now-closes-correctly-if-another-delete-button-is.md
+++ b/content/change-logs/application-enablement/ui-c8y-1020-39-1-the-delete-popup-now-closes-correctly-if-another-delete-button-is.md
@@ -14,4 +14,4 @@ build_artifact:
 ticket: MTM-60830
 version: 1020.39.1
 ---
-In certain scenarios, clicking on a delete button while the delete confirmation popup was already open would lead to unexpected behavior and the popup not closing properly. This issue has now been resolved. The delete confirmation popup will now always close correctly when clicking on another delete button, allowing users to smoothly continue their workflow without any interruptions. This change improves the overall user experience and consistency when working with delete confirmations in the bookmark edit view.
+In the bookmark edit view, clicking on a delete button while the delete confirmation popup was already open would lead to unexpected behavior and the popup not closing properly. This issue has now been resolved. The delete confirmation popup will now always close correctly when clicking on another delete button, allowing users to smoothly continue their workflow without any interruptions. This change improves the overall user experience and consistency when working with delete confirmations.

--- a/content/change-logs/application-enablement/ui-c8y-1020-39-1-the-delete-popup-now-closes-correctly-if-another-delete-button-is.md
+++ b/content/change-logs/application-enablement/ui-c8y-1020-39-1-the-delete-popup-now-closes-correctly-if-another-delete-button-is.md
@@ -1,0 +1,17 @@
+---
+date: ""
+title: The delete popup now closes correctly if another delete button is hit. (#7339) (#7369)
+product_area: Application enablement & solutions
+change_type:
+  - value: change-VSkj2iV9m
+    label: Fix
+component:
+  - value: component-YdSEScrEC
+    label: Cockpit
+build_artifact:
+  - value: tc-pjJiURv9Y
+    label: ui-c8y
+ticket: MTM-60830
+version: 1020.39.1
+---
+The delete popup now closes correctly if another delete button is hit. (#7339) (#7369)

--- a/content/change-logs/application-enablement/ui-c8y-1020-39-1-the-delete-popup-now-closes-correctly-if-another-delete-button-is.md
+++ b/content/change-logs/application-enablement/ui-c8y-1020-39-1-the-delete-popup-now-closes-correctly-if-another-delete-button-is.md
@@ -1,6 +1,6 @@
 ---
 date: ""
-title: The delete popup now closes correctly if another delete button is hit. (#7339) (#7369)
+title: Fixed issue with delete popup not closing correctly when hitting another delete button in the bookmark edit view
 product_area: Application enablement & solutions
 change_type:
   - value: change-VSkj2iV9m
@@ -14,4 +14,4 @@ build_artifact:
 ticket: MTM-60830
 version: 1020.39.1
 ---
-The delete popup now closes correctly if another delete button is hit. (#7339) (#7369)
+In certain scenarios, clicking on a delete button while the delete confirmation popup was already open would lead to unexpected behavior and the popup not closing properly. This issue has now been resolved. The delete confirmation popup will now always close correctly when clicking on another delete button, allowing users to smoothly continue their workflow without any interruptions. This change improves the overall user experience and consistency when working with delete confirmations in the bookmark edit view.

--- a/content/change-logs/application-enablement/ui-c8y-1020-39-1-the-delete-popup-now-closes-correctly-if-another-delete-button-is.md
+++ b/content/change-logs/application-enablement/ui-c8y-1020-39-1-the-delete-popup-now-closes-correctly-if-another-delete-button-is.md
@@ -1,6 +1,6 @@
 ---
 date: ""
-title: Fixed issue with delete popup not closing correctly when hitting another delete button in the bookmark edit view
+title: Delete popup now closing correctly when hitting another delete button in the bookmark edit view
 product_area: Application enablement & solutions
 change_type:
   - value: change-VSkj2iV9m


### PR DESCRIPTION
Release note created by c8y-ui-automations[bot]

Ticket: [MTM-60830](https://cumulocity.atlassian.net/browse/MTM-60830)
Original PR: [7369](https://github.com/Cumulocity-IoT/cumulocity-ui/pull/7369)

[MTM-60830]: https://cumulocity.atlassian.net/browse/MTM-60830?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ