### PR TITLE
Create ui-c8y-1021-0-2-fix-do-not-remove-scripts-from-the-svg-in-the-scada.md

### DIFF
--- a/content/change-logs/application-enablement/ui-c8y-1021-0-2-fix-do-not-remove-scripts-from-the-svg-in-the-scada.md
+++ b/content/change-logs/application-enablement/ui-c8y-1021-0-2-fix-do-not-remove-scripts-from-the-svg-in-the-scada.md
@@ -1,6 +1,6 @@
 ---
 date: ""
-title: fix: do not remove scripts from the svg in the scada widget when none option is set (#7397) (#7463)
+title: script tags are preserved in SCADA widget when 'none' option is selected
 product_area: Application enablement & solutions
 change_type:
   - value: change-VSkj2iV9m
@@ -14,4 +14,4 @@ build_artifact:
 ticket: MTM-61415
 version: 1021.0.2
 ---
-fix: do not remove scripts from the svg in the scada widget when none option is set (#7397) (#7463)
+SCADA widget preserves script tags when 'none' option is selected.

--- a/content/change-logs/application-enablement/ui-c8y-1021-0-2-fix-do-not-remove-scripts-from-the-svg-in-the-scada.md
+++ b/content/change-logs/application-enablement/ui-c8y-1021-0-2-fix-do-not-remove-scripts-from-the-svg-in-the-scada.md
@@ -1,0 +1,17 @@
+---
+date: ""
+title: fix: do not remove scripts from the svg in the scada widget when none option is set (#7397) (#7463)
+product_area: Application enablement & solutions
+change_type:
+  - value: change-VSkj2iV9m
+    label: Fix
+component:
+  - value: component-YdSEScrEC
+    label: Cockpit
+build_artifact:
+  - value: tc-pjJiURv9Y
+    label: ui-c8y
+ticket: MTM-61415
+version: 1021.0.2
+---
+fix: do not remove scripts from the svg in the scada widget when none option is set (#7397) (#7463)

--- a/content/change-logs/application-enablement/ui-c8y-1021-0-2-fix-do-not-remove-scripts-from-the-svg-in-the-scada.md
+++ b/content/change-logs/application-enablement/ui-c8y-1021-0-2-fix-do-not-remove-scripts-from-the-svg-in-the-scada.md
@@ -1,6 +1,6 @@
 ---
 date: ""
-title: script tags are preserved in SCADA widget when 'none' option is selected
+title: Script tags are preserved in SCADA widgets
 product_area: Application enablement & solutions
 change_type:
   - value: change-VSkj2iV9m
@@ -14,4 +14,4 @@ build_artifact:
 ticket: MTM-61415
 version: 1021.0.2
 ---
-SCADA widget preserves script tags when 'none' option is selected.
+The SCADA widget now preserves script tags if the code sanitization option is set to "none".


### PR DESCRIPTION
Release note created by c8y-ui-automations[bot]

Ticket: [MTM-61415](https://cumulocity.atlassian.net/browse/MTM-61415)
Original PR: [7463](https://github.com/Cumulocity-IoT/cumulocity-ui/pull/7463)

[MTM-61415]: https://cumulocity.atlassian.net/browse/MTM-61415?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ