### PR TITLE
MTM-61325 changelog, operationsCreated and operationsUpdated counters…

### DIFF
--- a/content/change-logs/platform-services/cumulocity-10-20-611-0-usage-statistics-new-fields-counting-operations.md
+++ b/content/change-logs/platform-services/cumulocity-10-20-611-0-usage-statistics-new-fields-counting-operations.md
@@ -14,7 +14,7 @@ build_artifact:
 ticket: MTM-61325
 version: 10.20.611.0
 ---
-Two new properties `operationsCreatedCount`, `operationsUpdateCount` have been added to all REST endpoints which will return detailed request counters for usage statistics. 
+Two new properties, `operationsCreatedCount` and `operationsUpdateCount`, have been added to all REST endpoints which will return detailed request counters for usage statistics. 
 In a first implementation step, the {{< product-c8y-iot >}} platform returns these properties with `0` values. 
 In a future implementation, counting logic in reaction to REST requests and MQTT messages creating and updating operations will be added.  
 

--- a/content/change-logs/platform-services/cumulocity-10-20-611-0-usage-statistics-new-fields-counting-operations.md
+++ b/content/change-logs/platform-services/cumulocity-10-20-611-0-usage-statistics-new-fields-counting-operations.md
@@ -14,8 +14,8 @@ build_artifact:
 ticket: MTM-61325
 version: 10.20.611.0
 ---
-Two new properties: `operationsCreatedCount`, `operationsUpdateCount` were added to all REST endpoints returning usage statistics detailed requests counters. 
-At the first step of this new feature {{< product-c8y-iot >}} returns those values always equal `0`. 
-Implementation of counting logic in reaction to REST requests and MQTT messages creating and updating operations will be added in the following changes to the 10.20 release.  
+Two new properties `operationsCreatedCount`, `operationsUpdateCount` have been added to all REST endpoints which will return detailed request counters for usage statistics. 
+In a first implementation step, the {{< product-c8y-iot >}} platform returns these properties with `0` values. 
+In a future implementation, counting logic in reaction to REST requests and MQTT messages creating and updating operations will be added.  
 
 

--- a/content/change-logs/platform-services/cumulocity-10-20-611-0-usage-statistics-new-fields-counting-operations.md
+++ b/content/change-logs/platform-services/cumulocity-10-20-611-0-usage-statistics-new-fields-counting-operations.md
@@ -1,0 +1,21 @@
+---
+date:
+title: Added operation request counters to usage statistics
+product_area: Platform services
+change_type:
+  - value: change-QHu1GdukP
+    label: Feature
+component:
+  - value: component-JlFdtOPva
+    label: REST API
+build_artifact:
+  - value: tc-QHwMfWtBk7
+    label: cumulocity
+ticket: MTM-61325
+version: 10.20.611.0
+---
+Two new properties: `operationsCreatedCount`, `operationsUpdateCount` were added to all REST endpoints returning usage statistics detailed requests counters. 
+At the first step of this new feature {{< product-c8y-iot >}} returns those values always equal `0`. 
+Implementation of counting logic in reaction to REST requests and MQTT messages creating and updating operations will be added in the following changes to the 10.20 release.  
+
+

--- a/content/enterprise-tenant/usage-and-billing.md
+++ b/content/enterprise-tenant/usage-and-billing.md
@@ -130,8 +130,16 @@ The following information is provided for each subtenant (not completely visible
       <td align="left">Number of measurements created</td>
     </tr>
     <tr>
+      <td align="left">Operations created</td>
+      <td align="left">Number of operations created</td>
+    </tr>
+    <tr>
+      <td align="left">Operations updated</td>
+      <td align="left">Number of updates on operations</td>
+    </tr>
+    <tr>
       <td align="left">Total inbound transfer</td>
-      <td align="left">Sum of all inbound transfers (alarms created, alarms updated, events created, events updated, inventories created, inventories updated, measurements created)</td>
+      <td align="left">Sum of all inbound transfers (alarms created, alarms updated, events created, events updated, inventories created, inventories updated, measurements created, operations created, operations updated)</td>
     </tr>
     <tr>
       <td align="left">CPU (M)</td>
@@ -542,6 +550,18 @@ The table below presents which values are used in each model for billing purpose
     <tr>
       <td style="text-align:left"><a href="#to-view-usage-statistics">TenantUsageStatistics</a></td>
       <td style="text-align:left">Measurements created</td>
+      <td style="text-align:left">x</td>
+      <td style="text-align:left"></td>
+    </tr>
+    <tr>
+      <td style="text-align:left"><a href="#to-view-usage-statistics">TenantUsageStatistics</a></td>
+      <td style="text-align:left">Operations created</td>
+      <td style="text-align:left">x</td>
+      <td style="text-align:left"></td>
+    </tr>
+    <tr>
+      <td style="text-align:left"><a href="#to-view-usage-statistics">TenantUsageStatistics</a></td>
+      <td style="text-align:left">Operations updated</td>
       <td style="text-align:left">x</td>
       <td style="text-align:left"></td>
     </tr>


### PR DESCRIPTION
… added to usage statistics.

Preview of new change-log entry (with hardcoded 2024-11-04 date):
![image](https://github.com/user-attachments/assets/1bf6bbad-5306-4fd8-a867-26f3454a7bf2)

Preview from gh-action (change-log not visible, because of no date)
https://cumulocity-iot-c8y-docs-build-pr-2601.surge.sh/enterprise-tenant/usage-and-billing/