### PR TITLE
Create ui-c8y-1021-0-8-emit-move-event-only-when-dragstart-event-emits-7376-7507.md

### DIFF
--- a/content/change-logs/application-enablement/ui-c8y-1021-0-8-emit-move-event-only-when-dragstart-event-emits-7376-7507.md
+++ b/content/change-logs/application-enablement/ui-c8y-1021-0-8-emit-move-event-only-when-dragstart-event-emits-7376-7507.md
@@ -1,6 +1,6 @@
 ---
 date: ""
-title: The map widget's center coordinate inputs in the configuration should work consistently
+title: Map widget's center coordinate inputs work consistently
 product_area: Application enablement & solutions
 change_type:
   - value: change-VSkj2iV9m
@@ -14,4 +14,4 @@ build_artifact:
 ticket: MTM-58182
 version: 1021.0.8
 ---
-The map widget's center coordinate inputs in the configuration had issues setting the right coordinates by user input. The fix ensures that the user can set the right coordinates also via text input and not only by dragging the map.
+In the configuration of the "Map widget" the center coordinates provided by the user via text input were not set correctly. This change ensures that the user can set the right coordinates also via text input and not only by dragging the map.

--- a/content/change-logs/application-enablement/ui-c8y-1021-0-8-emit-move-event-only-when-dragstart-event-emits-7376-7507.md
+++ b/content/change-logs/application-enablement/ui-c8y-1021-0-8-emit-move-event-only-when-dragstart-event-emits-7376-7507.md
@@ -1,6 +1,6 @@
 ---
 date: ""
-title: emit move event only when dragstart event emits (#7376) (#7507)
+title: The map widget's center coordinate inputs in the configuration should not trigger move events when modified
 product_area: Application enablement & solutions
 change_type:
   - value: change-VSkj2iV9m
@@ -14,4 +14,4 @@ build_artifact:
 ticket: MTM-58182
 version: 1021.0.8
 ---
-emit move event only when dragstart event emits (#7376) (#7507)
+The map widget's center coordinate inputs in the configuration should not trigger move events when modified. This issue was leading to a situation where a move event was emitted, which resulted in updates to the center coordinate inputs.

--- a/content/change-logs/application-enablement/ui-c8y-1021-0-8-emit-move-event-only-when-dragstart-event-emits-7376-7507.md
+++ b/content/change-logs/application-enablement/ui-c8y-1021-0-8-emit-move-event-only-when-dragstart-event-emits-7376-7507.md
@@ -1,0 +1,17 @@
+---
+date: ""
+title: emit move event only when dragstart event emits (#7376) (#7507)
+product_area: Application enablement & solutions
+change_type:
+  - value: change-VSkj2iV9m
+    label: Fix
+component:
+  - value: component-YdSEScrEC
+    label: Cockpit
+build_artifact:
+  - value: tc-pjJiURv9Y
+    label: ui-c8y
+ticket: MTM-58182
+version: 1021.0.8
+---
+emit move event only when dragstart event emits (#7376) (#7507)

--- a/content/change-logs/application-enablement/ui-c8y-1021-0-8-emit-move-event-only-when-dragstart-event-emits-7376-7507.md
+++ b/content/change-logs/application-enablement/ui-c8y-1021-0-8-emit-move-event-only-when-dragstart-event-emits-7376-7507.md
@@ -1,6 +1,6 @@
 ---
 date: ""
-title: The map widget's center coordinate inputs in the configuration should not trigger move events when modified
+title: The map widget's center coordinate inputs in the configuration should work consistently
 product_area: Application enablement & solutions
 change_type:
   - value: change-VSkj2iV9m
@@ -14,4 +14,4 @@ build_artifact:
 ticket: MTM-58182
 version: 1021.0.8
 ---
-The map widget's center coordinate inputs in the configuration should not trigger move events when modified. This issue was leading to a situation where a move event was emitted, which resulted in updates to the center coordinate inputs.
+The map widget's center coordinate inputs in the configuration had issues setting the right coordinates by user input. The fix ensures that the user can set the right coordinates also via text input and not only by dragging the map.


### PR DESCRIPTION
Release note created by c8y-ui-automations[bot]

Ticket: [MTM-58182](https://cumulocity.atlassian.net/browse/MTM-58182)
Original PR: [7507](https://github.com/Cumulocity-IoT/cumulocity-ui/pull/7507)

[MTM-58182]: https://cumulocity.atlassian.net/browse/MTM-58182?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ