### PR TITLE
Create ui-c8y-1021-0-9-nightly-failure-data-and-control-team-device-protocol-loriot-7512.md

### DIFF
--- a/content/change-logs/device-management/ui-c8y-1021-0-9-nightly-failure-data-and-control-team-device-protocol-loriot-7512.md
+++ b/content/change-logs/device-management/ui-c8y-1021-0-9-nightly-failure-data-and-control-team-device-protocol-loriot-7512.md
@@ -1,0 +1,17 @@
+---
+date: ""
+title: Nightly failure dataAndControlTeam deviceProtocolLoriot (#7512)
+product_area: Device management & connectivity
+change_type:
+  - value: change-VSkj2iV9m
+    label: Fix
+component:
+  - value: component--KIsStyzM
+    label: Device Management app
+build_artifact:
+  - value: tc-pjJiURv9Y
+    label: ui-c8y
+ticket: DM-4173
+version: 1021.0.9
+---
+Nightly failure dataAndControlTeam deviceProtocolLoriot (#7512)


### PR DESCRIPTION
Release note created by c8y-ui-automations[bot]

Ticket: [DM-4173](https://cumulocity.atlassian.net/browse/DM-4173)
Original PR: [7512](https://github.com/Cumulocity-IoT/cumulocity-ui/pull/7512)

[DM-4173]: https://cumulocity.atlassian.net/browse/DM-4173?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ