### PR TITLE
Create ui-c8y-1021-2-1-fix-add-type-validator-to-the-alarm-event-selector-7423-graft.md

### DIFF
--- a/content/change-logs/application-enablement/ui-c8y-1021-2-1-fix-add-type-validator-to-the-alarm-event-selector-7423-graft.md
+++ b/content/change-logs/application-enablement/ui-c8y-1021-2-1-fix-add-type-validator-to-the-alarm-event-selector-7423-graft.md
@@ -1,0 +1,17 @@
+---
+date: ""
+title: fix: add type validator to the alarm/event selector (#7423) [GRAFT][release/cd] (#7558)
+product_area: Application enablement & solutions
+change_type:
+  - value: change-VSkj2iV9m
+    label: Fix
+component:
+  - value: component-YdSEScrEC
+    label: Cockpit
+build_artifact:
+  - value: tc-pjJiURv9Y
+    label: ui-c8y
+ticket: MTM-61126
+version: 1021.2.1
+---
+fix: add type validator to the alarm/event selector (#7423) [GRAFT][release/cd] (#7558)

--- a/content/change-logs/application-enablement/ui-c8y-1021-2-1-fix-add-type-validator-to-the-alarm-event-selector-7423-graft.md
+++ b/content/change-logs/application-enablement/ui-c8y-1021-2-1-fix-add-type-validator-to-the-alarm-event-selector-7423-graft.md
@@ -14,4 +14,4 @@ build_artifact:
 ticket: MTM-61126
 version: 1021.2.1
 ---
-The alarm and event selector in the Cumulocity IoT user interface previously allowed invalid input to be entered. With this fix, input validation has been added to the alarm and event selector to ensure only valid input is accepted. This change improves the user experience and prevents potential errors or unexpected behavior when using the alarm and event selector.
+The alarm and event selector in the {{< product-c8y-iot >}} UI previously allowed to enter invalid input. With this fix, input validation has been added to the alarm and event selector to ensure that only valid input is accepted. This change improves the user experience and prevents potential errors or unexpected behavior when using the alarm and event selector.

--- a/content/change-logs/application-enablement/ui-c8y-1021-2-1-fix-add-type-validator-to-the-alarm-event-selector-7423-graft.md
+++ b/content/change-logs/application-enablement/ui-c8y-1021-2-1-fix-add-type-validator-to-the-alarm-event-selector-7423-graft.md
@@ -1,6 +1,6 @@
 ---
 date: ""
-title: fix: add type validator to the alarm/event selector (#7423) [GRAFT][release/cd] (#7558)
+title: Alarm and event selector input validation added
 product_area: Application enablement & solutions
 change_type:
   - value: change-VSkj2iV9m
@@ -14,4 +14,4 @@ build_artifact:
 ticket: MTM-61126
 version: 1021.2.1
 ---
-fix: add type validator to the alarm/event selector (#7423) [GRAFT][release/cd] (#7558)
+The alarm and event selector in the Cumulocity IoT user interface previously allowed invalid input to be entered. With this fix, input validation has been added to the alarm and event selector to ensure only valid input is accepted. This change improves the user experience and prevents potential errors or unexpected behavior when using the alarm and event selector.


### PR DESCRIPTION
Release note created by c8y-ui-automations[bot]

Ticket: [MTM-61126](https://cumulocity.atlassian.net/browse/MTM-61126)
Original PR: [7558](https://github.com/Cumulocity-IoT/cumulocity-ui/pull/7558)

[MTM-61126]: https://cumulocity.atlassian.net/browse/MTM-61126?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ