### PR TITLE
Create ui-c8y-1021-3-1-the-correct-icon-is-now-displayed-when-in-root-group-context.md

### DIFF
--- a/content/change-logs/application-enablement/ui-c8y-1021-3-1-the-correct-icon-is-now-displayed-when-in-root-group-context.md
+++ b/content/change-logs/application-enablement/ui-c8y-1021-3-1-the-correct-icon-is-now-displayed-when-in-root-group-context.md
@@ -1,6 +1,6 @@
 ---
 date: ""
-title: The correct icon is now displayed when in root group context. (#6983) [GRAFT][release/cd] (#7571)
+title: Correct icon now displayed in root group context
 product_area: Application enablement & solutions
 change_type:
   - value: change-VSkj2iV9m
@@ -14,4 +14,4 @@ build_artifact:
 ticket: MTM-60388
 version: 1021.3.1
 ---
-The correct icon is now displayed when in root group context. (#6983) [GRAFT][release/cd] (#7571)
+Previously, an incorrect device icon was displayed for the root group, which could lead to confusion for users about their current location within the group hierarchy. With this change, the correct icon is now shown, providing a clear visual indication to users that they are at the root level of the group structure. This improvement enhances the user experience by ensuring the interface accurately reflects the user's position within the group hierarchy.

--- a/content/change-logs/application-enablement/ui-c8y-1021-3-1-the-correct-icon-is-now-displayed-when-in-root-group-context.md
+++ b/content/change-logs/application-enablement/ui-c8y-1021-3-1-the-correct-icon-is-now-displayed-when-in-root-group-context.md
@@ -14,4 +14,4 @@ build_artifact:
 ticket: MTM-60388
 version: 1021.3.1
 ---
-Previously, an incorrect device icon was displayed for the root group, which could lead to confusion for users about their current location within the group hierarchy. With this change, the correct icon is now shown, providing a clear visual indication to users that they are at the root level of the group structure. This improvement enhances the user experience by ensuring the interface accurately reflects the user's position within the group hierarchy.
+Previously, an incorrect device icon was displayed for the root group, which could lead to confusion for users about their current location within the group hierarchy. With this change, the correct icon is now shown, providing a clear visual indication to users that they are at the root level of the group structure.

--- a/content/change-logs/application-enablement/ui-c8y-1021-3-1-the-correct-icon-is-now-displayed-when-in-root-group-context.md
+++ b/content/change-logs/application-enablement/ui-c8y-1021-3-1-the-correct-icon-is-now-displayed-when-in-root-group-context.md
@@ -1,6 +1,6 @@
 ---
 date: ""
-title: Correct icon now displayed in root group context
+title: Correct icon now displayed for root groups
 product_area: Application enablement & solutions
 change_type:
   - value: change-VSkj2iV9m

--- a/content/change-logs/application-enablement/ui-c8y-1021-3-1-the-correct-icon-is-now-displayed-when-in-root-group-context.md
+++ b/content/change-logs/application-enablement/ui-c8y-1021-3-1-the-correct-icon-is-now-displayed-when-in-root-group-context.md
@@ -1,0 +1,17 @@
+---
+date: ""
+title: The correct icon is now displayed when in root group context. (#6983) [GRAFT][release/cd] (#7571)
+product_area: Application enablement & solutions
+change_type:
+  - value: change-VSkj2iV9m
+    label: Fix
+component:
+  - value: component-YbYJ3gLU_
+    label: Web SDK
+build_artifact:
+  - value: tc-pjJiURv9Y
+    label: ui-c8y
+ticket: MTM-60388
+version: 1021.3.1
+---
+The correct icon is now displayed when in root group context. (#6983) [GRAFT][release/cd] (#7571)


### PR DESCRIPTION
Release note created by c8y-ui-automations[bot]

Ticket: [MTM-60388](https://cumulocity.atlassian.net/browse/MTM-60388)
Original PR: [7571](https://github.com/Cumulocity-IoT/cumulocity-ui/pull/7571)

[MTM-60388]: https://cumulocity.atlassian.net/browse/MTM-60388?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ