### PR TITLE
Create ui-c8y-1018-503-131-the-correct-icon-is-now-displayed-when-in-root-group-context.md

### DIFF
--- a/content/change-logs/application-enablement/ui-c8y-1018-503-131-the-correct-icon-is-now-displayed-when-in-root-group-context.md
+++ b/content/change-logs/application-enablement/ui-c8y-1018-503-131-the-correct-icon-is-now-displayed-when-in-root-group-context.md
@@ -14,4 +14,4 @@ build_artifact:
 ticket: MTM-60388
 version: 1018.503.131
 ---
-The correct icon is now displayed when in root group context. (#6983) [GRAFT][release/y2024] (#7572)
+Previously, an incorrect device icon was displayed for the root group, which could lead to confusion for users about their current location within the group hierarchy. With this change, the correct icon is now shown, providing a clear visual indication to users that they are at the root level of the group structure.

--- a/content/change-logs/application-enablement/ui-c8y-1018-503-131-the-correct-icon-is-now-displayed-when-in-root-group-context.md
+++ b/content/change-logs/application-enablement/ui-c8y-1018-503-131-the-correct-icon-is-now-displayed-when-in-root-group-context.md
@@ -1,6 +1,6 @@
 ---
 date: ""
-title: The correct icon is now displayed when in root group context. (#6983) [GRAFT][release/y2024] (#7572)
+title: Correct icon displayed for root groups
 product_area: Application enablement & solutions
 change_type:
   - value: change-VSkj2iV9m

--- a/content/change-logs/application-enablement/ui-c8y-1018-503-131-the-correct-icon-is-now-displayed-when-in-root-group-context.md
+++ b/content/change-logs/application-enablement/ui-c8y-1018-503-131-the-correct-icon-is-now-displayed-when-in-root-group-context.md
@@ -14,4 +14,4 @@ build_artifact:
 ticket: MTM-60388
 version: 1018.503.131
 ---
-Previously, an incorrect device icon was displayed for the root group, which could lead to confusion for users about their current location within the group hierarchy. With this change, the correct icon is now shown, providing a clear visual indication to users that they are at the root level of the group structure.
+Previously, an incorrect device icon was displayed for root groups, which could lead to confusion for users about their current location within the group hierarchy. With this change, the correct icon is now shown, providing a clear visual indication to users that they are at the root level of the group structure.

--- a/content/change-logs/application-enablement/ui-c8y-1018-503-131-the-correct-icon-is-now-displayed-when-in-root-group-context.md
+++ b/content/change-logs/application-enablement/ui-c8y-1018-503-131-the-correct-icon-is-now-displayed-when-in-root-group-context.md
@@ -1,0 +1,17 @@
+---
+date: ""
+title: The correct icon is now displayed when in root group context. (#6983) [GRAFT][release/y2024] (#7572)
+product_area: Application enablement & solutions
+change_type:
+  - value: change-VSkj2iV9m
+    label: Fix
+component:
+  - value: component-YbYJ3gLU_
+    label: Web SDK
+build_artifact:
+  - value: tc-pjJiURv9Y
+    label: ui-c8y
+ticket: MTM-60388
+version: 1018.503.131
+---
+The correct icon is now displayed when in root group context. (#6983) [GRAFT][release/y2024] (#7572)


### PR DESCRIPTION
Release note created by c8y-ui-automations[bot]

Ticket: [MTM-60388](https://cumulocity.atlassian.net/browse/MTM-60388)
Original PR: [7572](https://github.com/Cumulocity-IoT/cumulocity-ui/pull/7572)

[MTM-60388]: https://cumulocity.atlassian.net/browse/MTM-60388?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ