### PR TITLE
Add Jane Porter to platform services change logs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,7 +8,7 @@
 
 /content/change-logs/application-enablement/ @rahultc8y @janhommes @BeateRixen @MWindel
 /content/change-logs/device-management/ @Oezge-Akin @aaronraab @l2p- @BeateRixen @MWindel
-/content/change-logs/platform-services/ @iiar-c8y @martin-c8y @mgrumann @saran-govindarajan @scmi-c8y @JanePorter @BeateRixen @MWindel
+/content/change-logs/platform-services/ @iiar-c8y @martin-c8y @mgrumann @saran-govindarajan @scmi-c8y @JanePorter @BeateRixen @MWindel @JanePorter
 /content/change-logs/application-enablement/dtm* @rahultc8y @pavanshivajirao @lara-c8y @BeateRixen @MWindel
 /content/change-logs/analytics/apama-in-c8y* @kailol-sag @Rob-J-SAG @BeateRixen @MWindel @skom-c8y
 /content/change-logs/analytics/cdh* @cheinz-sag @ChrisFurlong @BeateRixen @MWindel


### PR DESCRIPTION
@JanePorter often rewrites the release notes to be presented to the customers, so by adding here to `CODEOWNERS` he can get notified and possibly improve the message before it's published.