### PR TITLE
Create ui-c8y-1021-4-1-fix-duplicate-navigation-entries-when-configuring-cockpit-root-nodes-7412-graft.md

### DIFF
--- a/content/change-logs/application-enablement/ui-c8y-1021-4-1-fix-duplicate-navigation-entries-when-configuring-cockpit-root-nodes-7412-graft.md
+++ b/content/change-logs/application-enablement/ui-c8y-1021-4-1-fix-duplicate-navigation-entries-when-configuring-cockpit-root-nodes-7412-graft.md
@@ -14,4 +14,4 @@ build_artifact:
 ticket: MTM-61026
 version: 1021.4.1
 ---
-Fixed an issue where editing top level nodes in the "Application configuration" would create duplicate entries of assets in the main navigation menu. The navigator now properly updates without creating redundant menu items.
+Fixed an issue where editing top level nodes in the **Application configuration** page created duplicate entries of assets in the navigator. Now the navigator updates properly without creating redundant menu items.

--- a/content/change-logs/application-enablement/ui-c8y-1021-4-1-fix-duplicate-navigation-entries-when-configuring-cockpit-root-nodes-7412-graft.md
+++ b/content/change-logs/application-enablement/ui-c8y-1021-4-1-fix-duplicate-navigation-entries-when-configuring-cockpit-root-nodes-7412-graft.md
@@ -1,6 +1,6 @@
 ---
 date: ""
-title: Prevented duplicate entries in the navigator when configuring top level nodes
+title: Prevented duplicate asset entries in the navigator when configuring top level nodes
 product_area: Application enablement & solutions
 change_type:
   - value: change-VSkj2iV9m

--- a/content/change-logs/application-enablement/ui-c8y-1021-4-1-fix-duplicate-navigation-entries-when-configuring-cockpit-root-nodes-7412-graft.md
+++ b/content/change-logs/application-enablement/ui-c8y-1021-4-1-fix-duplicate-navigation-entries-when-configuring-cockpit-root-nodes-7412-graft.md
@@ -1,6 +1,6 @@
 ---
 date: ""
-title: Prevent duplicate entries in navigation when configuring top level nodes
+title: Prevented duplicate entries in the navigator when configuring top level nodes
 product_area: Application enablement & solutions
 change_type:
   - value: change-VSkj2iV9m

--- a/content/change-logs/application-enablement/ui-c8y-1021-4-1-fix-duplicate-navigation-entries-when-configuring-cockpit-root-nodes-7412-graft.md
+++ b/content/change-logs/application-enablement/ui-c8y-1021-4-1-fix-duplicate-navigation-entries-when-configuring-cockpit-root-nodes-7412-graft.md
@@ -1,0 +1,17 @@
+---
+date: ""
+title: Fix duplicate navigation entries when configuring cockpit root nodes (#7412) [GRAFT][release/cd] (#7584)
+product_area: Application enablement & solutions
+change_type:
+  - value: change-VSkj2iV9m
+    label: Fix
+component:
+  - value: component-YbYJ3gLU_
+    label: Web SDK
+build_artifact:
+  - value: tc-pjJiURv9Y
+    label: ui-c8y
+ticket: MTM-61026
+version: 1021.4.1
+---
+Fix duplicate navigation entries when configuring cockpit root nodes (#7412) [GRAFT][release/cd] (#7584)

--- a/content/change-logs/application-enablement/ui-c8y-1021-4-1-fix-duplicate-navigation-entries-when-configuring-cockpit-root-nodes-7412-graft.md
+++ b/content/change-logs/application-enablement/ui-c8y-1021-4-1-fix-duplicate-navigation-entries-when-configuring-cockpit-root-nodes-7412-graft.md
@@ -1,6 +1,6 @@
 ---
 date: ""
-title: Fix duplicate navigation entries when configuring cockpit root nodes (#7412) [GRAFT][release/cd] (#7584)
+title: Prevent duplicate entries in navigation when configuring top level nodes
 product_area: Application enablement & solutions
 change_type:
   - value: change-VSkj2iV9m
@@ -14,4 +14,4 @@ build_artifact:
 ticket: MTM-61026
 version: 1021.4.1
 ---
-Fix duplicate navigation entries when configuring cockpit root nodes (#7412) [GRAFT][release/cd] (#7584)
+Fixed an issue where editing top level nodes in the "Application configuration" would create duplicate entries in the main navigation menu. The navigator now properly updates without creating redundant menu items.

--- a/content/change-logs/application-enablement/ui-c8y-1021-4-1-fix-duplicate-navigation-entries-when-configuring-cockpit-root-nodes-7412-graft.md
+++ b/content/change-logs/application-enablement/ui-c8y-1021-4-1-fix-duplicate-navigation-entries-when-configuring-cockpit-root-nodes-7412-graft.md
@@ -14,4 +14,4 @@ build_artifact:
 ticket: MTM-61026
 version: 1021.4.1
 ---
-Fixed an issue where editing top level nodes in the "Application configuration" would create duplicate entries in the main navigation menu. The navigator now properly updates without creating redundant menu items.
+Fixed an issue where editing top level nodes in the "Application configuration" would create duplicate entries of assets in the main navigation menu. The navigator now properly updates without creating redundant menu items.

--- a/content/change-logs/application-enablement/ui-c8y-1021-4-1-fix-duplicate-navigation-entries-when-configuring-cockpit-root-nodes-7412-graft.md
+++ b/content/change-logs/application-enablement/ui-c8y-1021-4-1-fix-duplicate-navigation-entries-when-configuring-cockpit-root-nodes-7412-graft.md
@@ -7,7 +7,7 @@ change_type:
     label: Fix
 component:
   - value: component-YbYJ3gLU_
-    label: Web SDK
+    label: Cockpit
 build_artifact:
   - value: tc-pjJiURv9Y
     label: ui-c8y

--- a/content/change-logs/application-enablement/ui-c8y-1021-4-1-fix-duplicate-navigation-entries-when-configuring-cockpit-root-nodes-7412-graft.md
+++ b/content/change-logs/application-enablement/ui-c8y-1021-4-1-fix-duplicate-navigation-entries-when-configuring-cockpit-root-nodes-7412-graft.md
@@ -6,7 +6,7 @@ change_type:
   - value: change-VSkj2iV9m
     label: Fix
 component:
-  - value: component-YbYJ3gLU_
+  - value: component-YdSEScrEC
     label: Cockpit
 build_artifact:
   - value: tc-pjJiURv9Y

--- a/content/change-logs/application-enablement/ui-c8y-1021-4-1-fix-duplicate-navigation-entries-when-configuring-cockpit-root-nodes-7412-graft.md
+++ b/content/change-logs/application-enablement/ui-c8y-1021-4-1-fix-duplicate-navigation-entries-when-configuring-cockpit-root-nodes-7412-graft.md
@@ -14,4 +14,4 @@ build_artifact:
 ticket: MTM-61026
 version: 1021.4.1
 ---
-Fixed an issue where editing top level nodes in the **Application configuration** page created duplicate entries of assets in the navigator. Now the navigator updates properly without creating redundant menu items.
+Fixed an issue where editing top level nodes in the **Application configuration** page in the Cockpit application created duplicate entries of assets in the navigator. Now the navigator updates properly without creating redundant menu items.


### PR DESCRIPTION
Release note created by c8y-ui-automations[bot]

Ticket: [MTM-61026](https://cumulocity.atlassian.net/browse/MTM-61026)
Original PR: [7584](https://github.com/Cumulocity-IoT/cumulocity-ui/pull/7584)

[MTM-61026]: https://cumulocity.atlassian.net/browse/MTM-61026?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ