### PR TITLE
Create ui-c8y-1021-4-3-only-error-from-auth-external-server-are-shown-in-additional-modal.md

### DIFF
--- a/content/change-logs/platform-services/ui-c8y-1021-4-3-only-error-from-auth-external-server-are-shown-in-additional-modal.md
+++ b/content/change-logs/platform-services/ui-c8y-1021-4-3-only-error-from-auth-external-server-are-shown-in-additional-modal.md
@@ -1,0 +1,17 @@
+---
+date: ""
+title: only error from auth external server are shown in additional modal (#6937) [GRAFT][release/cd] (#7594)
+product_area: Platform services
+change_type:
+  - value: change-VSkj2iV9m
+    label: Fix
+component:
+  - value: q3kclF6pO
+    label: Authentication
+build_artifact:
+  - value: tc-pjJiURv9Y
+    label: ui-c8y
+ticket: MTM-60547
+version: 1021.4.3
+---
+only error from auth external server are shown in additional modal (#6937) [GRAFT][release/cd] (#7594)

--- a/content/change-logs/platform-services/ui-c8y-1021-4-3-only-error-from-auth-external-server-are-shown-in-additional-modal.md
+++ b/content/change-logs/platform-services/ui-c8y-1021-4-3-only-error-from-auth-external-server-are-shown-in-additional-modal.md
@@ -1,6 +1,6 @@
 ---
 date: ""
-title: only error from auth external server are shown in additional modal (#6937) [GRAFT][release/cd] (#7594)
+title: Enhanced display of error messages for external authentication and platform permissions
 product_area: Platform services
 change_type:
   - value: change-VSkj2iV9m

--- a/content/change-logs/platform-services/ui-c8y-1021-4-3-only-error-from-auth-external-server-are-shown-in-additional-modal.md
+++ b/content/change-logs/platform-services/ui-c8y-1021-4-3-only-error-from-auth-external-server-are-shown-in-additional-modal.md
@@ -14,4 +14,4 @@ build_artifact:
 ticket: MTM-60547
 version: 1021.4.3
 ---
-Previously, errors from external authentication servers were not always displayed to the user, causing confusion when authentication failed without any visible indication. With this update, all errors originating from external authentication servers are now consistently shown in a dedicated error modal dialog. Additionally, errors resulting from insufficient permissions within the platform are now presented clearly and in a user-friendly manner on the login page.
+Previously, errors from external authentication servers were not always displayed to the user, causing confusion when authentication failed without any visible indication. With this update, all errors originating from external authentication servers are now consistently shown in a dedicated error dialog. Additionally, errors resulting from insufficient permissions within the platform are now presented clearly and in a user-friendly manner on the login page.

--- a/content/change-logs/platform-services/ui-c8y-1021-4-3-only-error-from-auth-external-server-are-shown-in-additional-modal.md
+++ b/content/change-logs/platform-services/ui-c8y-1021-4-3-only-error-from-auth-external-server-are-shown-in-additional-modal.md
@@ -14,4 +14,4 @@ build_artifact:
 ticket: MTM-60547
 version: 1021.4.3
 ---
-only error from auth external server are shown in additional modal (#6937) [GRAFT][release/cd] (#7594)
+Enhanced display of error messages for external authentication and platform permissions

--- a/content/change-logs/platform-services/ui-c8y-1021-4-3-only-error-from-auth-external-server-are-shown-in-additional-modal.md
+++ b/content/change-logs/platform-services/ui-c8y-1021-4-3-only-error-from-auth-external-server-are-shown-in-additional-modal.md
@@ -14,4 +14,4 @@ build_artifact:
 ticket: MTM-60547
 version: 1021.4.3
 ---
-Enhanced display of error messages for external authentication and platform permissions
+Previously, errors from external authentication servers were not always displayed to the user, causing confusion when authentication failed without any visible indication. With this update, all errors originating from external authentication servers are now consistently shown in a dedicated error modal dialog. Additionally, errors resulting from insufficient permissions within the platform are now presented clearly and in a user-friendly manner on the login page.


### PR DESCRIPTION
Release note created by c8y-ui-automations[bot]

Ticket: [MTM-60547](https://cumulocity.atlassian.net/browse/MTM-60547)
Original PR: [7594](https://github.com/Cumulocity-IoT/cumulocity-ui/pull/7594)

[MTM-60547]: https://cumulocity.atlassian.net/browse/MTM-60547?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ