### PR TITLE
Migrate Streaming Analytics documentation to Amazon ECR

### DIFF
--- a/content/change-logs/analytics/apama-in-c8y-20241121-Apama-Docker-images-moved-to-Amazon-ECR.md
+++ b/content/change-logs/analytics/apama-in-c8y-20241121-Apama-Docker-images-moved-to-Amazon-ECR.md
@@ -1,5 +1,5 @@
 ---
-date:
+date: 2024-11-21
 title: Apama Docker images moving to Amazon ECR
 change_type:
   - value: change-QHu1GdukP
@@ -12,7 +12,7 @@ build_artifact:
   - value: tc-KXXmo2SUR
     label: apama-in-c8y
 ticket: PAM-35062
-version: 
+version: 25.311.0
 ---
 The Apama Docker images are now available at `public.ecr.aws/apama`, and can be viewed at https://gallery.ecr.aws/apama/. Previously, they were available at `softwareag/`, and viewed at https://hub.docker.com/u/softwareag.
 

--- a/content/change-logs/analytics/apama-in-c8y-20241121-Apama-Docker-images-moved-to-Amazon-ECR.md
+++ b/content/change-logs/analytics/apama-in-c8y-20241121-Apama-Docker-images-moved-to-Amazon-ECR.md
@@ -1,0 +1,21 @@
+---
+date:
+title: Apama Docker images moving to Amazon ECR
+change_type:
+  - value: change-VSkj2iV9m
+    label: Feature
+product_area: Analytics
+component:
+  - value: component-M5-cepIIS
+    label: Streaming Analytics
+build_artifact:
+  - value: tc-KXXmo2SUR
+    label: apama-in-c8y
+ticket: PAM-35062
+version: 
+---
+The Apama Docker images are now available at `public.ecr.aws/apama`, and can be viewed at https://gallery.ecr.aws/apama/. Previously, they were available at `softwareag/`, and viewed at https://hub.docker.com/u/softwareag.
+
+Within any Dockerfiles that use the Apama images, you will need to change `FROM softwareag/<IMAGE>:<TAG>` to `FROM public.ecr.aws/apama/<IMAGE>:<TAG>`. 
+
+The location of Apama within the image has been moved from `/opt/softwareag` to `/opt/cumulocity`. Existing images remain unchanged.

--- a/content/change-logs/analytics/apama-in-c8y-20241121-Apama-Docker-images-moved-to-Amazon-ECR.md
+++ b/content/change-logs/analytics/apama-in-c8y-20241121-Apama-Docker-images-moved-to-Amazon-ECR.md
@@ -2,7 +2,7 @@
 date:
 title: Apama Docker images moving to Amazon ECR
 change_type:
-  - value: change-VSkj2iV9m
+  - value: change-QHu1GdukP
     label: Feature
 product_area: Analytics
 component:

--- a/content/streaming-analytics/epl-apps-bundle/basic-functionality.md
+++ b/content/streaming-analytics/epl-apps-bundle/basic-functionality.md
@@ -275,7 +275,7 @@ If you still use the images from the previous location, you must migrate them.
 {{< /c8y-admon-info >}}
 
 {{< c8y-admon-important >}}
-Apama 10.15.0 introduces several new container images provided via Amazon ECR and some of the existing container images have changed content.
+Apama 10.15.0 introduces several new container images, and some of the existing container images have changed content. As of December 2024, these images are provided via Amazon ECR Public Gallery.
 When building images for use as a {{< product-c8y-iot >}} microservice, this is now different to earlier releases.
 You must now use the
 [public.ecr.aws/apama/apama-cumulocity-jre](https://gallery.ecr.aws/apama/apama-cumulocity-jre) image with the

--- a/content/streaming-analytics/epl-apps-bundle/basic-functionality.md
+++ b/content/streaming-analytics/epl-apps-bundle/basic-functionality.md
@@ -269,24 +269,23 @@ The above is the minimum list of permissions that a custom Apama microservice ne
 5. When you are ready to deploy to {{< product-c8y-iot >}}, upload the application as a microservice. For details, refer to [Managing microservices](/standard-tenant/ecosystem/#managing-microservices).
 
 {{< c8y-admon-info >}}
-After February 2022, the location of the Docker images on Docker Hub has changed for all supported release trains.
-They are now available at *softwareag* instead of within the Docker Hub environment at *store/softwareag*.
+After December 2024, the location of the Docker images has changed for all supported release trains.
+They are now available at *public.ecr.aws/apama* instead of at Docker Hub.
 If you still use the images from the previous location, you must migrate them.
-See also [Apama Docker image availability on Docker Hub]({{< link-sag-tech-forum >}}/t/apama-docker-image-availability-on-docker-hub/260207).
 {{< /c8y-admon-info >}}
 
 {{< c8y-admon-important >}}
-Apama 10.15.0 introduces several new container images provided via Docker Hub and some of the existing container images have changed content.
+Apama 10.15.0 introduces several new container images provided via Amazon ECR and some of the existing container images have changed content.
 When building images for use as a {{< product-c8y-iot >}} microservice, this is now different to earlier releases.
 You must now use the
-[softwareag/apama-cumulocity-jre](https://hub.docker.com/r/softwareag/apama-cumulocity-jre) image with the
-[softwareag/apama-cumulocity-builder](https://hub.docker.com/r/softwareag/apama-cumulocity-builder) image as a builder image.
+[public.ecr.aws/apama/apama-cumulocity-jre](https://gallery.ecr.aws/apama/apama-cumulocity-jre) image with the
+[public.ecr.aws/apama/apama-cumulocity-builder](https://gallery.ecr.aws/apama/apama-cumulocity-builder) image as a builder image.
 To do this with the default project Dockerfile created by {{< sag-designer >}} in 10.15.0 and previous versions,
 you must either change the `FROM` lines in the Dockerfile appropriately
 (you only need to do this once) or build using the following flags (you must do this every time):
 
 ```
---build-arg APAMA_BUILDER=softwareag/apama-cumulocity-builder:10.15 --build-arg APAMA_IMAGE=softwareag/apama-cumulocity-jre:10.15
+--build-arg APAMA_BUILDER=public.ecr.aws/apama/apama-cumulocity-builder:10.15 --build-arg APAMA_IMAGE=public.ecr.aws/apama/apama-cumulocity-jre:10.15
 ```
 {{< /c8y-admon-important >}}
 

--- a/content/streaming-analytics/epl-apps-bundle/basic-functionality.md
+++ b/content/streaming-analytics/epl-apps-bundle/basic-functionality.md
@@ -270,7 +270,7 @@ The above is the minimum list of permissions that a custom Apama microservice ne
 
 {{< c8y-admon-info >}}
 After December 2024, the location of the Docker images has changed for all supported release trains.
-They are now available at *public.ecr.aws/apama* instead of at Docker Hub.
+They are now available at Amazon ECR Public Gallery instead of at Docker Hub.
 If you still use the images from the previous location, you must migrate them.
 {{< /c8y-admon-info >}}
 


### PR DESCRIPTION
We are moving the Docker Images to Amazon ECR. Along with public communication, we are also changing also existing documentation.

I chose to change the existing alert about image change, rather than add a new one, as it felt clunky to have two alerts here.

[PAM-35062]

[PAM-35062]: https://cumulocity.atlassian.net/browse/PAM-35062?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ