### PR TITLE
Create ui-c8y-1018-503-135-bulk-operation-scheduling-delay-in-milliseconds-not-working-7607-graft-release.md

### DIFF
--- a/content/change-logs/device-management/ui-c8y-1018-503-135-bulk-operation-scheduling-delay-in-milliseconds-not-working-7607-graft-release.md
+++ b/content/change-logs/device-management/ui-c8y-1018-503-135-bulk-operation-scheduling-delay-in-milliseconds-not-working-7607-graft-release.md
@@ -14,4 +14,4 @@ build_artifact:
 ticket: DM-4183
 version: 1018.503.135
 ---
-bulk operation scheduling delay in milliseconds not working (#7607) [GRAFT][release/y2024] (#7678)
+In the {{< product-c8y-iot >}} platform, bulk operations allow performing actions on multiple devices simultaneously. However, scheduling these operations with a delay in milliseconds was not working as expected. This issue has now been resolved. With this fix, bulk operations can now be scheduled with precise delays specified in milliseconds, enhancing the reliability and efficiency of device management tasks.

--- a/content/change-logs/device-management/ui-c8y-1018-503-135-bulk-operation-scheduling-delay-in-milliseconds-not-working-7607-graft-release.md
+++ b/content/change-logs/device-management/ui-c8y-1018-503-135-bulk-operation-scheduling-delay-in-milliseconds-not-working-7607-graft-release.md
@@ -1,0 +1,17 @@
+---
+date: ""
+title: bulk operation scheduling delay in milliseconds not working (#7607) [GRAFT][release/y2024] (#7678)
+product_area: Device management & connectivity
+change_type:
+  - value: change-VSkj2iV9m
+    label: Fix
+component:
+  - value: component--KIsStyzM
+    label: Device Management app
+build_artifact:
+  - value: tc-pjJiURv9Y
+    label: ui-c8y
+ticket: DM-4183
+version: 1018.503.135
+---
+bulk operation scheduling delay in milliseconds not working (#7607) [GRAFT][release/y2024] (#7678)

--- a/content/change-logs/device-management/ui-c8y-1018-503-135-bulk-operation-scheduling-delay-in-milliseconds-not-working-7607-graft-release.md
+++ b/content/change-logs/device-management/ui-c8y-1018-503-135-bulk-operation-scheduling-delay-in-milliseconds-not-working-7607-graft-release.md
@@ -1,6 +1,6 @@
 ---
 date: ""
-title: bulk operation scheduling delay in milliseconds not working (#7607) [GRAFT][release/y2024] (#7678)
+title: Scheduling bulk operations with a precise delay now works properly
 product_area: Device management & connectivity
 change_type:
   - value: change-VSkj2iV9m


### PR DESCRIPTION
Release note created by c8y-ui-automations[bot]

Ticket: [DM-4183](https://cumulocity.atlassian.net/browse/DM-4183)
Original PR: [7678](https://github.com/Cumulocity-IoT/cumulocity-ui/pull/7678)

[DM-4183]: https://cumulocity.atlassian.net/browse/DM-4183?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ