### PR TITLE
[MTM-61989] Adapt docu for customized log configuration file handling

### DIFF
--- a/content/microservice-sdk/java-bundle/developing-microservice.md
+++ b/content/microservice-sdk/java-bundle/developing-microservice.md
@@ -331,7 +331,7 @@ You cannot override a property injected by Spring `@Value("${property.name}")`.
 
 ### Logging {#logging}
 
-The standard output should be used for hosted deployment.
+The standard output should be used for hosted deployments.
 For more details on how to use your own log configuration file refer to [Logging](/microservice-sdk/java/#legacy-logging).
 
 ### Maven plugin {#maven-plugin}

--- a/content/microservice-sdk/java-bundle/developing-microservice.md
+++ b/content/microservice-sdk/java-bundle/developing-microservice.md
@@ -332,7 +332,7 @@ You cannot override a property injected by Spring `@Value("${property.name}")`.
 ### Logging {#logging}
 
 The standard output should be used for hosted deployment.
-(For more details about how to use your own log configuration file please refer to [Logging](/microservice-sdk/java/#legacy-logging))
+For more details on how to use your own log configuration file refer to [Logging](/microservice-sdk/java/#legacy-logging).
 
 ### Maven plugin {#maven-plugin}
 

--- a/content/microservice-sdk/java-bundle/developing-microservice.md
+++ b/content/microservice-sdk/java-bundle/developing-microservice.md
@@ -662,7 +662,7 @@ For external/legacy deployment, the following paths will be searched in order to
 
 * To customize the logging configuration for your microservice instead of using the default configuration, create a log
 configuration file in the _configuration_ folder of your microservice project.
-* The file must adhere to the naming convention \<application-name\>-logging.xml. 
+* The file must adhere to the naming convention *\<application-name\>-logging.xml*. 
 This ensures that your custom log configuration replaces the default configuration file 
 with the same name in the resulting Docker image.
 * Once deployed, the customized log configuration file will be located in the /etc/\<artifactId\> 

--- a/content/microservice-sdk/java-bundle/developing-microservice.md
+++ b/content/microservice-sdk/java-bundle/developing-microservice.md
@@ -665,7 +665,7 @@ configuration file in the _configuration_ folder of your microservice project.
 * The file must adhere to the naming convention *\<application-name\>-logging.xml*. 
 This ensures that your custom log configuration replaces the default configuration file 
 with the same name in the resulting Docker image.
-* Once deployed, the customized log configuration file will be located in the /etc/\<artifactId\> 
+* Once deployed, the customized log configuration file will be located in the */etc/\<artifactId\>*
 directory within the microservice pod.
 
 ##### Locations to be searched for log configuration file

--- a/content/microservice-sdk/java-bundle/developing-microservice.md
+++ b/content/microservice-sdk/java-bundle/developing-microservice.md
@@ -670,7 +670,7 @@ directory within the microservice pod.
 
 ##### Locations to be searched for log configuration file
 
-For external/legacy deployment, logging into the application implies using [Spring Logging](https://docs.spring.io/spring-boot/docs/current/reference/html/howto-logging.html).
+For external/legacy deployments, logging into the application implies using [Spring Logging](https://docs.spring.io/spring-boot/docs/current/reference/html/howto-logging.html).
 The following locations are searched for the logback configuration file:
 
 * {UPPERCASE(application_name)}_CONF_DIR/.{application_name}/*-logging.xml

--- a/content/microservice-sdk/java-bundle/developing-microservice.md
+++ b/content/microservice-sdk/java-bundle/developing-microservice.md
@@ -665,7 +665,7 @@ configuration file in the _configuration_ folder of your microservice project.
 * The file must adhere to the naming convention \<application-name\>-logging.xml. 
 This ensures that your custom log configuration replaces the default configuration file 
 with the same name in the resulting Docker image.
-* Once deployed, the customized log configuration file will be located in the /etc/\<application_name\> 
+* Once deployed, the customized log configuration file will be located in the /etc/\<artifactId\> 
 directory within the microservice pod.
 
 ##### Locations to be searched for log configuration file

--- a/content/microservice-sdk/java-bundle/developing-microservice.md
+++ b/content/microservice-sdk/java-bundle/developing-microservice.md
@@ -332,6 +332,7 @@ You cannot override a property injected by Spring `@Value("${property.name}")`.
 ### Logging {#logging}
 
 The standard output should be used for hosted deployment.
+(For more details about how to use your own log configuration file please refer to [Logging](/microservice-sdk/java/#legacy-logging))
 
 ### Maven plugin {#maven-plugin}
 
@@ -655,18 +656,30 @@ For external/legacy deployment, the following paths will be searched in order to
 * {CONF_DIR}/{application_name}
 * /etc/{application_name}
 
-#### Logging {#logging}
+#### Logging {#legacy-logging}
+
+##### Add your own log configuration file
+
+* To customize the logging configuration for your microservice instead of using the default configuration, create a log
+configuration file in the _configuration_ folder of your microservice project.
+* The file must adhere to the naming convention \<application-name\>-logging.xml. 
+This ensures that your custom log configuration replaces the default configuration file 
+with the same name in the resulting Docker image.
+* Once deployed, the customized log configuration file will be located in the /etc/\<application_name\> 
+directory within the microservice pod.
+
+##### Locations to be searched for log configuration file
 
 For external/legacy deployment, logging into the application implies using [Spring Logging](https://docs.spring.io/spring-boot/docs/current/reference/html/howto-logging.html).
 The following locations are searched for the Logback configuration file:
 
-* {UPPERCASE(application_name)}_CONF_DIR/.{application_name}/logging.xml
-* {UPPERCASE(application_name)}_CONF_DIR/{application_name}/logging.xml
-* {user/home}/.{application_name}/logging.xml
-* {user/home}/{application_name}/logging.xml
-* {CONF_DIR}/.{application_name}/logging.xml
-* {CONF_DIR}/{application_name}/logging.xml
-* /etc/{application_name}/logging.xml
+* {UPPERCASE(application_name)}_CONF_DIR/.{application_name}/*-logging.xml
+* {UPPERCASE(application_name)}_CONF_DIR/{application_name}/*-logging.xml
+* {user/home}/.{application_name}/*-logging.xml
+* {user/home}/{application_name}/*-logging.xml
+* {CONF_DIR}/.{application_name}/*-logging.xml
+* {CONF_DIR}/{application_name}/*-logging.xml
+* /etc/{application_name}/*-logging.xml
 
 ### Upgrade to Microservice SDK 10.13+ {#upgrade-to-microservice-sdk-1013}
 

--- a/content/microservice-sdk/java-bundle/developing-microservice.md
+++ b/content/microservice-sdk/java-bundle/developing-microservice.md
@@ -671,7 +671,7 @@ directory within the microservice pod.
 ##### Locations to be searched for log configuration file
 
 For external/legacy deployment, logging into the application implies using [Spring Logging](https://docs.spring.io/spring-boot/docs/current/reference/html/howto-logging.html).
-The following locations are searched for the Logback configuration file:
+The following locations are searched for the logback configuration file:
 
 * {UPPERCASE(application_name)}_CONF_DIR/.{application_name}/*-logging.xml
 * {UPPERCASE(application_name)}_CONF_DIR/{application_name}/*-logging.xml


### PR DESCRIPTION
There was some information missing in the public documentation of microservice sdk how to handle a customized log configuration file. This has been added now.