### PR TITLE
MTM-61914 described request counters logic for operationsCreated and …

### DIFF
--- a/content/change-logs/platform-services/cumulocity-10-20-664-0-usage-statistics-counting-operations-implemented.md
+++ b/content/change-logs/platform-services/cumulocity-10-20-664-0-usage-statistics-counting-operations-implemented.md
@@ -14,7 +14,7 @@ build_artifact:
 ticket: MTM-60232
 version: 10.20.664.0
 ---
-Two new request counters for usage statistics `operationsCreatedCount`, `operationsUpdateCount`, introduced for REST endpoints in earlier version (10.20.611.0), are now fully implemented. This means that those counters are incremented 
+Two new request counters for usage statistics `operationsCreatedCount`, `operationsUpdateCount`, introduced for REST endpoints in an earlier version (10.20.611.0), are now fully implemented. This means that these counters are incremented 
 * in case of operationsCreated: when operations are created via REST by POST request on single operation API (`/devicecontrol/opeartions`) or bulk operations API (`/devicecontrol/bulkoperations`).
   * creating bulk operation leads to asynchronously creating individual operations in the background, and {{< product-c8y-iot >}} is counting each created operation individually.
 * in case of operationsUpdated: when single operation is updated via REST, or via MQTT standard smartRest static templates (501-507), or via MQTT custom smartRest templates.

--- a/content/change-logs/platform-services/cumulocity-10-20-664-0-usage-statistics-counting-operations-implemented.md
+++ b/content/change-logs/platform-services/cumulocity-10-20-664-0-usage-statistics-counting-operations-implemented.md
@@ -1,0 +1,21 @@
+---
+date:
+title: Implemented counting operations creation and updates for usage statistics
+product_area: Platform services
+change_type:
+  - value: change-QHu1GdukP
+    label: Feature
+component:
+  - value: component-9vjGQz8Ag
+    label: Core platform
+build_artifact:
+  - value: tc-QHwMfWtBk7
+    label: cumulocity
+ticket: MTM-60232
+version: 10.20.664.0
+---
+Two new request counters for usage statistics `operationsCreatedCount`, `operationsUpdateCount`, introduced for REST endpoints in earlier version (10.20.611.0), are now fully implemented. This means that those counters are incremented 
+* in case of operationsCreated: when operations are created via REST by POST request on single operation API (`/devicecontrol/opeartions`) or bulk operations API (`/devicecontrol/bulkoperations`).
+  * creating bulk operation leads to asynchronously creating individual operations in the background, and {{< product-c8y-iot >}} is counting each created operation individually.
+* in case of operationsUpdated: when single operation is updated via REST, or via MQTT standard smartRest static templates (501-507), or via MQTT custom smartRest templates.
+  * template 507 can cause multiple operations updates, so each updated operation is counted separately.

--- a/content/change-logs/platform-services/cumulocity-10-20-664-0-usage-statistics-counting-operations-implemented.md
+++ b/content/change-logs/platform-services/cumulocity-10-20-664-0-usage-statistics-counting-operations-implemented.md
@@ -14,7 +14,7 @@ build_artifact:
 ticket: MTM-60232
 version: 10.20.664.0
 ---
-Two new request counters for usage statistics `operationsCreatedCount`, `operationsUpdateCount`, introduced for REST endpoints in an earlier version (10.20.611.0), are now fully implemented. This means that these counters are incremented 
+Two new request counters for usage statistics `operationsCreatedCount`, `operationsUpdateCount`, introduced for REST endpoints in an earlier version (10.20.611.0), are now fully implemented. These counters are incremented in the following way:
 * in case of operationsCreated: when operations are created via REST by POST request on single operation API (`/devicecontrol/opeartions`) or bulk operations API (`/devicecontrol/bulkoperations`).
   * creating bulk operation leads to asynchronously creating individual operations in the background, and {{< product-c8y-iot >}} is counting each created operation individually.
 * in case of operationsUpdated: when single operation is updated via REST, or via MQTT standard smartRest static templates (501-507), or via MQTT custom smartRest templates.

--- a/content/change-logs/platform-services/cumulocity-10-20-664-0-usage-statistics-counting-operations-implemented.md
+++ b/content/change-logs/platform-services/cumulocity-10-20-664-0-usage-statistics-counting-operations-implemented.md
@@ -1,6 +1,6 @@
 ---
 date:
-title: Implemented counting operations creation and updates for usage statistics
+title: Implemented operation creation and update counters for usage statistics
 product_area: Platform services
 change_type:
   - value: change-QHu1GdukP
@@ -15,7 +15,7 @@ ticket: MTM-60232
 version: 10.20.664.0
 ---
 Two new request counters for usage statistics `operationsCreatedCount`, `operationsUpdateCount`, introduced for REST endpoints in an earlier version (10.20.611.0), are now fully implemented. These counters are incremented in the following way:
-* in case of operationsCreated: when operations are created via REST by POST request on single operation API (`/devicecontrol/opeartions`) or bulk operations API (`/devicecontrol/bulkoperations`).
-  * creating bulk operation leads to asynchronously creating individual operations in the background, and {{< product-c8y-iot >}} is counting each created operation individually.
-* in case of operationsUpdated: when single operation is updated via REST, or via MQTT standard smartRest static templates (501-507), or via MQTT custom smartRest templates.
-  * template 507 can cause multiple operations updates, so each updated operation is counted separately.
+* operationsCreated: When operations are created via REST by POST request on a single operations API (`/devicecontrol/operations`) or the bulk operations API (`/devicecontrol/bulkoperations`).
+  * Creating bulk operations leads to asynchronously creating individual operations in the background, and {{< product-c8y-iot >}} is counting each created operation individually.
+* operationsUpdated: When a single operation is updated via REST, or via MQTT standard SmartREST static templates (501-507), or via MQTT custom SmartREST templates.
+  * Template 507 can cause multiple operations updates, so each updated operation is counted separately.


### PR DESCRIPTION
…operationsUpdated

Preview is not visible on build (maybe because of no date parameter). Locally with today's date it looks like:
![image](https://github.com/user-attachments/assets/d5f564c6-f58c-4c5d-909d-6ed0d401514c)

What can be changed:
* mentioned earlier version bolded, or removed, or maybe link to previous change-log
* we can link operations static templates 501-507 in our documentation https://cumulocity.com/docs/smartrest/mqtt-static-templates/#operation-templates
* reformat pointing. I like this form, but this is personal preference