### PR TITLE
Create ui-c8y-1021-25-1-hide-context-indicators-in-untranslated-strings-in-runtime-7679-graft-release.md

### DIFF
--- a/content/change-logs/application-enablement/ui-c8y-1021-25-1-hide-context-indicators-in-untranslated-strings-in-runtime-7679-graft-release.md
+++ b/content/change-logs/application-enablement/ui-c8y-1021-25-1-hide-context-indicators-in-untranslated-strings-in-runtime-7679-graft-release.md
@@ -14,4 +14,4 @@ build_artifact:
 ticket: MTM-61194
 version: 1021.25.1
 ---
-Hide context indicators in untranslated strings in runtime (#7679) [GRAFT][release/cd] (#7770)
+In the past, untranslated strings shown in applications might have included additional context indicators which were confusing for end users and not intended. With this change, context indicators are now hidden for untranslated strings at runtime. This improves the user experience when the strings are not yet translated, as end users will no longer see technical details not relevant to them.

--- a/content/change-logs/application-enablement/ui-c8y-1021-25-1-hide-context-indicators-in-untranslated-strings-in-runtime-7679-graft-release.md
+++ b/content/change-logs/application-enablement/ui-c8y-1021-25-1-hide-context-indicators-in-untranslated-strings-in-runtime-7679-graft-release.md
@@ -1,0 +1,17 @@
+---
+date: ""
+title: Hide context indicators in untranslated strings in runtime (#7679) [GRAFT][release/cd] (#7770)
+product_area: Application enablement & solutions
+change_type:
+  - value: change-VSkj2iV9m
+    label: Fix
+component:
+  - value: component-YbYJ3gLU_
+    label: Web SDK
+build_artifact:
+  - value: tc-pjJiURv9Y
+    label: ui-c8y
+ticket: MTM-61194
+version: 1021.25.1
+---
+Hide context indicators in untranslated strings in runtime (#7679) [GRAFT][release/cd] (#7770)

--- a/content/change-logs/application-enablement/ui-c8y-1021-25-1-hide-context-indicators-in-untranslated-strings-in-runtime-7679-graft-release.md
+++ b/content/change-logs/application-enablement/ui-c8y-1021-25-1-hide-context-indicators-in-untranslated-strings-in-runtime-7679-graft-release.md
@@ -1,6 +1,6 @@
 ---
 date: ""
-title: Hide context indicators in untranslated strings in runtime (#7679) [GRAFT][release/cd] (#7770)
+title: Hide context indicators in untranslated strings at runtime
 product_area: Application enablement & solutions
 change_type:
   - value: change-VSkj2iV9m


### PR DESCRIPTION
Release note created by pawel-rynarzewski-sag

Ticket: [MTM-61194](https://cumulocity.atlassian.net/browse/MTM-61194)
Original PR: [7770](https://github.com/Cumulocity-IoT/cumulocity-ui/pull/7770)

[MTM-61194]: https://cumulocity.atlassian.net/browse/MTM-61194?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ