### PR TITLE
Create ui-c8y-1021-25-3-done-steps-in-stepper-are-not-properly-marked-when-user-navigates.md

### DIFF
--- a/content/change-logs/application-enablement/ui-c8y-1021-25-3-done-steps-in-stepper-are-not-properly-marked-when-user-navigates.md
+++ b/content/change-logs/application-enablement/ui-c8y-1021-25-3-done-steps-in-stepper-are-not-properly-marked-when-user-navigates.md
@@ -1,6 +1,6 @@
 ---
 date: ""
-title: Done steps in stepper are not properly marked when user navigates back and forward (#7762) [GRAFT][release/cd] (#7787)
+title: Stepper navigation marks steps incorrectly when navigating back and forth
 product_area: Application enablement & solutions
 change_type:
   - value: change-VSkj2iV9m

--- a/content/change-logs/application-enablement/ui-c8y-1021-25-3-done-steps-in-stepper-are-not-properly-marked-when-user-navigates.md
+++ b/content/change-logs/application-enablement/ui-c8y-1021-25-3-done-steps-in-stepper-are-not-properly-marked-when-user-navigates.md
@@ -1,0 +1,17 @@
+---
+date: ""
+title: Done steps in stepper are not properly marked when user navigates back and forward (#7762) [GRAFT][release/cd] (#7787)
+product_area: Application enablement & solutions
+change_type:
+  - value: change-VSkj2iV9m
+    label: Fix
+component:
+  - value: component-YbYJ3gLU_
+    label: Web SDK
+build_artifact:
+  - value: tc-pjJiURv9Y
+    label: ui-c8y
+ticket: MTM-60759
+version: 1021.25.3
+---
+Done steps in stepper are not properly marked when user navigates back and forward (#7762) [GRAFT][release/cd] (#7787)

--- a/content/change-logs/application-enablement/ui-c8y-1021-25-3-done-steps-in-stepper-are-not-properly-marked-when-user-navigates.md
+++ b/content/change-logs/application-enablement/ui-c8y-1021-25-3-done-steps-in-stepper-are-not-properly-marked-when-user-navigates.md
@@ -1,6 +1,6 @@
 ---
 date: ""
-title: Stepper navigation marks steps incorrectly when navigating back and forth
+title: Stepper navigation marks steps correctly when navigating back and forth
 product_area: Application enablement & solutions
 change_type:
   - value: change-VSkj2iV9m

--- a/content/change-logs/application-enablement/ui-c8y-1021-25-3-done-steps-in-stepper-are-not-properly-marked-when-user-navigates.md
+++ b/content/change-logs/application-enablement/ui-c8y-1021-25-3-done-steps-in-stepper-are-not-properly-marked-when-user-navigates.md
@@ -14,4 +14,4 @@ build_artifact:
 ticket: MTM-60759
 version: 1021.25.3
 ---
-In some scenarios, users may navigate back and forth between steps in a stepper component. Previously, when navigating this way, the stepper incorrectly marked and displayed completed steps as incomplete. This has now been fixed so that the stepper component correctly reflects the done steps when the user navigates backwards and forwards through the steps.
+In some scenarios, users may navigate back and forth between steps in a stepper component. Previously, when navigating this way, the stepper incorrectly marked and displayed completed steps as incomplete. This has now been fixed so that the stepper component correctly reflects the completed steps when the user navigates backwards and forwards through the steps.

--- a/content/change-logs/application-enablement/ui-c8y-1021-25-3-done-steps-in-stepper-are-not-properly-marked-when-user-navigates.md
+++ b/content/change-logs/application-enablement/ui-c8y-1021-25-3-done-steps-in-stepper-are-not-properly-marked-when-user-navigates.md
@@ -14,4 +14,4 @@ build_artifact:
 ticket: MTM-60759
 version: 1021.25.3
 ---
-Done steps in stepper are not properly marked when user navigates back and forward (#7762) [GRAFT][release/cd] (#7787)
+In some scenarios, users may navigate back and forth between steps in a stepper component. Previously, when navigating this way, the stepper incorrectly marked and displayed completed steps as incomplete. This has now been fixed so that the stepper component correctly reflects the done steps when the user navigates backwards and forwards through the steps.


### PR DESCRIPTION
Release note created by c8y-ui-automations[bot]

Ticket: [MTM-60759](https://cumulocity.atlassian.net/browse/MTM-60759)
Original PR: [7787](https://github.com/Cumulocity-IoT/cumulocity-ui/pull/7787)

[MTM-60759]: https://cumulocity.atlassian.net/browse/MTM-60759?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ