### PR TITLE
Make rebranding possible for the preview banner [no-issue]

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -39,7 +39,7 @@ relativeURLs = true
 
   oldguides = "//cumulocity.com/guides/welcome/intro-documentation/"
 
-  # Can be a boolean 'false' or a string (example: 'CD' or a release version like '2024'). This flag displays the admonition stating that it is a preview version
+  # Can be a boolean 'false' or a string (example: 'CD' or a release version like '2024'). This flag displays the admonition stating it is a preview version
   docsPreview = false
 
   # Display thumbnail image of each post on index pages (false: disabled, true: enabled)

--- a/config.toml
+++ b/config.toml
@@ -39,7 +39,7 @@ relativeURLs = true
 
   oldguides = "//cumulocity.com/guides/welcome/intro-documentation/"
 
-  # Boolean to display the admonition stating it is a preview version
+  # Can be a boolean 'false' or a string (example: 'CD' or a release version like '2024'). This flag displays the admonition stating that it is a preview version
   docsPreview = false
 
   # Display thumbnail image of each post on index pages (false: disabled, true: enabled)

--- a/themes/c8ydocs/layouts/_default/baseof.html
+++ b/themes/c8ydocs/layouts/_default/baseof.html
@@ -4,6 +4,7 @@
   <body data-spy="scroll" data-target="#main-nav" data-offset="400" {{if .IsHome }} class="isHome" {{end}}>
     <script type="text/javascript">
       const docsPreview = {{.Site.Params.docsPreview}};
+      const docsPreviewString = {{.Site.Params.product_c8y_iot}} + ' ' + docsPreview + ' ' + {{if not site.Data.date_settings.yearly_release}} 'deployments' {{else}} 'release' {{end}};
     </script>
     {{- partial "header.html" . -}}
     {{- partial "to-the-top.html" . -}}

--- a/themes/c8ydocs/static/js/main.js
+++ b/themes/c8ydocs/static/js/main.js
@@ -17,7 +17,7 @@ var main = (function ($) {
         class: 'admonition preview'
       }).insertAfter(elem);
       $('<h4 class="title">Preview</h4>').appendTo('#preview-banner');
-      $('<span>This is a preview of the documentation for the Cumulocity '+ docsPreview +' deployments.</span>').appendTo('#preview-banner');
+      $('<span>This is a preview of the documentation for the '+ docsPreviewString +'.</span>').appendTo('#preview-banner');
    }
 
     //Toggle side navigation


### PR DESCRIPTION
Make product name configurable in the preview banner.

Also there are small differences in the preview banner between 2024 (https://github.com/Cumulocity-IoT/c8y-docs/blob/ce82896d5ecdac9e3f5907025b1015a134f44f45/themes/c8ydocs/static/js/main.js#L20) and CD (https://github.com/Cumulocity-IoT/c8y-docs/blob/develop/themes/c8ydocs/static/js/main.js#L20), so making them configurable.