### PR TITLE
Update toc grouping logic for change logs/release notes [no-issue]

### DIFF
--- a/themes/c8ydocs/static/js/main.js
+++ b/themes/c8ydocs/static/js/main.js
@@ -166,11 +166,15 @@ function buildToc() {
         let h2 = article.querySelector('h5');
         let target = h2.parentNode.nextElementSibling;
         if (target && h2.textContent.length) {
-          let curMonth = h2.textContent.split(' ')[0];
-          let curYear = h2.textContent.split(' ')[2];
-          if (month !== curMonth) {
-            tocLinks += `<div class="list-group-item p-t-16"><p><strong>${curMonth} ${curYear}</strong></p></div>`;
-            month = curMonth;
+          // Test if the text is a date string used for CD release (example: December 10, 2024) or a version string used for yearly release (example: 2024.12)
+          // Simple check of presence of whitespace in the string can help us check if the string is a date or a version
+          if (/\s/g.test(h2.textContent)) {
+            let curMonth = h2.textContent.split(' ')[0];
+            let curYear = h2.textContent.split(' ')[2];
+            if (month !== curMonth) {
+              tocLinks += `<div class="list-group-item p-t-16"><p><strong>${curMonth} ${curYear}</strong></p></div>`;
+              month = curMonth;
+            }
           }
           tocLinks += `<div class="list-group-item"><a class="toc-link" href="#${target.id}" data-refid="${h2.parentNode.id}" title="${h2.textContent}">${h2.textContent}</a></div>`;
         }


### PR DESCRIPTION
Table of content for CD release (https://cumulocity.com/docs/change-logs/) is grouped differently compared to yearly release (https://cumulocity.com/docs/2024/change-logs/).

For CD release, TOC is grouped by Month + Year whereas for yearly release, TOC is grouped by version number.

The grouping of month + year appears to have been a recent addition (https://github.com/Cumulocity-IoT/c8y-docs/commit/905ccaaa1a9b779257ca7e470861db2485da54dc) and this change enables this to work seamlessly between CD and yearly releases without any changes.