### PR TITLE
Links to point to cumulocity.com instead of www.cumulocity.com

### DIFF
--- a/content/device-integration/device-integration-rest-bundle/integration-life-cycle.md
+++ b/content/device-integration/device-integration-rest-bundle/integration-life-cycle.md
@@ -245,7 +245,7 @@ For example, the hardware information of a device will usually not change, but t
             "pi-driver": "pi-driver-3.4.6.jar",
             "pi4j-gpio-extension": "pi4j-gpio-extension-0.0.5.jar"
         }
-    }   
+    }
 
     HTTP/1.1 200 OK
 

--- a/content/legal-notices/imprint.md
+++ b/content/legal-notices/imprint.md
@@ -17,7 +17,7 @@ Cumulocity GmbH, Toulouser Allee 25, 40211 Düsseldorf, Germany
 
 **Email:** info@cumulocity.com
 
-**Internet:** www.cumulocity.com
+**Internet:** cumulocity.com
 
 Cumulocity GmbH is entered in the Register of Companies of Düsseldorf Local Court under the No. **HRB 68832**.
 

--- a/content/legal-notices/imprint.md
+++ b/content/legal-notices/imprint.md
@@ -17,7 +17,7 @@ Cumulocity GmbH, Toulouser Allee 25, 40211 Düsseldorf, Germany
 
 **Email:** info@cumulocity.com
 
-**Internet:** cumulocity.com
+**Internet:** www.cumulocity.com
 
 Cumulocity GmbH is entered in the Register of Companies of Düsseldorf Local Court under the No. **HRB 68832**.
 

--- a/content/rest_api/rest_api.md
+++ b/content/rest_api/rest_api.md
@@ -2,7 +2,7 @@
 title: "Rest API"
 icon: "dlt-c8y-icon-rest-api"
 type: external
-external: https://www.cumulocity.com/api/
+external: https://cumulocity.com/api/
 weight: 55
 sector:
   - rest_api

--- a/content/sector/rest_api/_index.md
+++ b/content/sector/rest_api/_index.md
@@ -2,7 +2,7 @@
 title: "Rest API"
 icon: "dlt-c8y-icon-rest-api"
 type: external
-external: https://www.cumulocity.com/api/
+external: https://cumulocity.com/api/
 weight: 45
 
 ---

--- a/content/service-terms/quotas.md
+++ b/content/service-terms/quotas.md
@@ -87,8 +87,8 @@ The quotas listed here reflect the maximum values for the cloud subscriptions un
 | [Offloaded leaf properties](https://docs.dremio.com/current/sonar/query-manage/querying-data/wide-tables/)[^1] | Soft |    6400 |
 | Query time out                                                                                                 | Soft |   4 min |
 | Query job retention                                                                                            | Hard |   1 day |
-| [Rows in a query job](https://www.cumulocity.com/api/datahub/#operation/getJobResultsApiResource)              | Hard | 1000000 |
-| [Rows in a high performance query](https://www.cumulocity.com/api/datahub/#tag/High-performance-API)           | Soft | 1000000 |
+| [Rows in a query job](https://cumulocity.com/api/datahub/#operation/getJobResultsApiResource)                  | Hard | 1000000 |
+| [Rows in a high performance query](https://cumulocity.com/api/datahub/#tag/High-performance-API)               | Soft | 1000000 |
 
 Additional [quotas from the Dremio engine](https://docs.dremio.com/current/get-started/cluster-deployments/architecture/limits/#catalog) may apply.
 

--- a/content/service-terms/service-level-bundle/datahub-sla.md
+++ b/content/service-terms/service-level-bundle/datahub-sla.md
@@ -51,7 +51,7 @@ Customer acknowledges the following limitations and constraints in using Service
 * **Production environments:** 99.00% availability
 * **Preproduction environments:** 95.00% availability
 
-Service availability for [{{< product-c8y-iot >}} DataHub APIs](https://www.cumulocity.com/api/datahub/#tag/Standard-API) is calculated as outlined in the [platform's service availability section](/service-terms/service-level/#service-availability).
+Service availability for [{{< product-c8y-iot >}} DataHub APIs](https://cumulocity.com/api/datahub/#tag/Standard-API) is calculated as outlined in the [platform's service availability section](/service-terms/service-level/#service-availability).
 
 Offloading jobs may not run at a scheduled time if a previous offloading job is still in progress (for example, due to an initial larger volume upload or after a longer period of inactivity) or during scheduled maintenance. Subsequent offloading jobs will eventually catch up with remaining data.
 

--- a/content/web/introduction.md
+++ b/content/web/introduction.md
@@ -52,7 +52,7 @@ Following is a list which explains the use cases of each package.
 
 #### @c8y/client: Accessing data
 
-The @c8y/client is an isomorphic (node and browser) Javascript client library for the [{{< product-c8y-iot >}}](http://www.cumulocity.com) REST API. It can be used for getting data from the platform. In an Angular application you will mostly use the injected services from `@c8y/ngx-components`.
+The @c8y/client is an isomorphic (node and browser) Javascript client library for the [{{< product-c8y-iot >}}](http://cumulocity.com) REST API. It can be used for getting data from the platform. In an Angular application you will mostly use the injected services from `@c8y/ngx-components`.
 
 #### @c8y/ngx-components: The component library
 
@@ -110,7 +110,7 @@ As our releases are bound to the Angular versioning, you must to ensure that you
 
 {{< c8y-admon-info >}}
 If you want to use an older version then `1019.x.x` you must to use our old tooling based on the `c8ycli` tool-set. For more information see [C8Y Command Line Tool (CLI)](/web/upgrade/#c8y-cli).
-{{< /c8y-admon-info >}}  
+{{< /c8y-admon-info >}}
 
 
 ### Next steps

--- a/content/web/introduction.md
+++ b/content/web/introduction.md
@@ -52,7 +52,7 @@ Following is a list which explains the use cases of each package.
 
 #### @c8y/client: Accessing data
 
-The @c8y/client is an isomorphic (node and browser) Javascript client library for the [{{< product-c8y-iot >}}](http://cumulocity.com) REST API. It can be used for getting data from the platform. In an Angular application you will mostly use the injected services from `@c8y/ngx-components`.
+The @c8y/client is an isomorphic (node and browser) Javascript client library for the [{{< product-c8y-iot >}} REST API](http://cumulocity.com/api/). It can be used for getting data from the platform. In an Angular application you will mostly use the injected services from `@c8y/ngx-components`.
 
 #### @c8y/ngx-components: The component library
 

--- a/themes/c8ydocs/layouts/partials/header.html
+++ b/themes/c8ydocs/layouts/partials/header.html
@@ -39,7 +39,7 @@
       <a
         class="dropdown-toggle version"
         title="REST API documentation"
-        href="https://www.cumulocity.com/api/"
+        href="https://cumulocity.com/api/"
       >
         <i class="dlt-c8y-icon-rest-api"></i> <span>REST API</span></a>
     </div>
@@ -140,7 +140,7 @@
         <li class="text-normal">
           <a class="dd-link"
             title="REST API documentation"
-            href="https://www.cumulocity.com/api/"
+            href="https://cumulocity.com/api/"
           >
             <i class="dlt-c8y-icon-rest-api"></i> <span>REST API &nbsp;</span>
           </a>


### PR DESCRIPTION
@BeateRixen @MWindel  This is a "just in case" PR. If the www links are intended to not come back, please merge it. If the www links are coming back, feel free to close it.