### PR TITLE
Create ui-c8y-1021-22-3-allow-device-type-dashboards-to-work-for-device-types-containing-a.md

### DIFF
--- a/content/change-logs/application-enablement/ui-c8y-1021-22-3-allow-device-type-dashboards-to-work-for-device-types-containing-a.md
+++ b/content/change-logs/application-enablement/ui-c8y-1021-22-3-allow-device-type-dashboards-to-work-for-device-types-containing-a.md
@@ -1,6 +1,6 @@
 ---
 date: ""
-title: allow device type dashboards to work for device types containing a dot (#7876)
+title: Device type dashboards can now be used for device types containing a dot
 product_area: Application enablement & solutions
 change_type:
   - value: change-VSkj2iV9m
@@ -14,4 +14,4 @@ build_artifact:
 ticket: MTM-61863
 version: 1021.22.3
 ---
-allow device type dashboards to work for device types containing a dot (#7876)
+Previously, device type dashboards did not work properly for devices that contained a dot (".") in their type. This has now been fixed. Device type dashboards can be used for all devices, regardless of whether their type includes a dot or not.

--- a/content/change-logs/application-enablement/ui-c8y-1021-22-3-allow-device-type-dashboards-to-work-for-device-types-containing-a.md
+++ b/content/change-logs/application-enablement/ui-c8y-1021-22-3-allow-device-type-dashboards-to-work-for-device-types-containing-a.md
@@ -1,0 +1,17 @@
+---
+date: ""
+title: allow device type dashboards to work for device types containing a dot (#7876)
+product_area: Application enablement & solutions
+change_type:
+  - value: change-VSkj2iV9m
+    label: Fix
+component:
+  - value: component-YdSEScrEC
+    label: Cockpit
+build_artifact:
+  - value: tc-pjJiURv9Y
+    label: ui-c8y
+ticket: MTM-61863
+version: 1021.22.3
+---
+allow device type dashboards to work for device types containing a dot (#7876)


### PR DESCRIPTION
Release note created by c8y-ui-automations[bot]

Ticket: [MTM-61863](https://cumulocity.atlassian.net/browse/MTM-61863)
Original PR: [7876](https://github.com/Cumulocity-IoT/cumulocity-ui/pull/7876)

[MTM-61863]: https://cumulocity.atlassian.net/browse/MTM-61863?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ