### PR TITLE
sections-selector: support external links

### DIFF
--- a/themes/c8ydocs/layouts/partials/sections-selector.html
+++ b/themes/c8ydocs/layouts/partials/sections-selector.html
@@ -13,3 +13,4 @@
   href='{{ if eq .Page.Params.type "change-log"}}/change-logs{{else if .Page.Params.external}}{{.Page.Params.external}}{{else}}{{.Page.Permalink}}{{end}}' 
   <i class="c8y-icon-duocolor {{.Page.Params.icon}} icon-20 m-r-8"></i>{{.Page.Title}}</a></li>
 {{ end }}
+

--- a/themes/c8ydocs/layouts/partials/sections-selector.html
+++ b/themes/c8ydocs/layouts/partials/sections-selector.html
@@ -8,9 +8,9 @@
 {{ $sortedsections := sort $sections ".Page.Params.weight" }}
 {{ range $sortedsections }}
 {{ $pages := where .Pages "Type" "!=" "page" }}
-{{ if $pages }}
 {{ $page := index $pages 0 }}
 <li><a class='{{if or (eq $currentSection .Page.Data.Term) (eq $current_dataTerm .Page.Data.Term)  }} active {{ end}}'
-  href='{{.Page.Permalink}}'><i class="c8y-icon-duocolor {{.Page.Params.icon}} icon-20 m-r-8"></i>{{.Page.Title}}</a></li>
-{{ end }}
+  href='{{ if eq $page.Type "external" }}{{ $page.Params.external }}{{ else }}{{.Page.Permalink}}{{ end }}'
+  {{ if eq $page.Type "external" }}target="_blank" rel="noopener"{{ end }}>
+  <i class="c8y-icon-duocolor {{.Page.Params.icon}} icon-20 m-r-8"></i>{{.Page.Title}}</a></li>
 {{ end }}

--- a/themes/c8ydocs/layouts/partials/sections-selector.html
+++ b/themes/c8ydocs/layouts/partials/sections-selector.html
@@ -1,4 +1,3 @@
-
 {{ $currentSection := "" }}
 {{ with .Params.sector }}
   {{ $currentSection = index . 0 }}
@@ -8,8 +7,9 @@
 {{ $sortedsections := sort $sections ".Page.Params.weight" }}
 {{ range $sortedsections }}
 {{ $pages := where .Pages "Type" "!=" "page" }}
+{{ if $pages }}
 {{ $page := index $pages 0 }}
 <li><a class='{{if or (eq $currentSection .Page.Data.Term) (eq $current_dataTerm .Page.Data.Term)  }} active {{ end}}'
   href='{{.Page.Permalink}}'><i class="c8y-icon-duocolor {{.Page.Params.icon}} icon-20 m-r-8"></i>{{.Page.Title}}</a></li>
 {{ end }}
-  
+{{ end }}

--- a/themes/c8ydocs/layouts/partials/sections-selector.html
+++ b/themes/c8ydocs/layouts/partials/sections-selector.html
@@ -1,3 +1,4 @@
+
 {{ $currentSection := "" }}
 {{ with .Params.sector }}
   {{ $currentSection = index . 0 }}

--- a/themes/c8ydocs/layouts/partials/sections-selector.html
+++ b/themes/c8ydocs/layouts/partials/sections-selector.html
@@ -10,7 +10,7 @@
 {{ $pages := where .Pages "Type" "!=" "page" }}
 {{ $page := index $pages 0 }}
 <li><a class='{{if or (eq $currentSection .Page.Data.Term) (eq $current_dataTerm .Page.Data.Term)  }} active {{ end}}'
-  href='{{ if eq $page.Type "external" }}{{ $page.Params.external }}{{ else }}{{.Page.Permalink}}{{ end }}'
+  href='{{ if eq .Page.Params.type "change-log"}}/change-logs{{else if .Page.Params.external}}{{.Page.Params.external}}{{else}}{{.Page.Permalink}}{{end}}' 
   {{ if eq $page.Type "external" }}target="_blank" rel="noopener"{{ end }}>
   <i class="c8y-icon-duocolor {{.Page.Params.icon}} icon-20 m-r-8"></i>{{.Page.Title}}</a></li>
 {{ end }}

--- a/themes/c8ydocs/layouts/partials/sections-selector.html
+++ b/themes/c8ydocs/layouts/partials/sections-selector.html
@@ -11,6 +11,5 @@
 {{ $page := index $pages 0 }}
 <li><a class='{{if or (eq $currentSection .Page.Data.Term) (eq $current_dataTerm .Page.Data.Term)  }} active {{ end}}'
   href='{{ if eq .Page.Params.type "change-log"}}/change-logs{{else if .Page.Params.external}}{{.Page.Params.external}}{{else}}{{.Page.Permalink}}{{end}}' 
-  {{ if eq $page.Type "external" }}target="_blank" rel="noopener"{{ end }}>
   <i class="c8y-icon-duocolor {{.Page.Params.icon}} icon-20 m-r-8"></i>{{.Page.Title}}</a></li>
 {{ end }}

--- a/themes/c8ydocs/layouts/partials/sections-selector.html
+++ b/themes/c8ydocs/layouts/partials/sections-selector.html
@@ -10,6 +10,6 @@
 {{ $pages := where .Pages "Type" "!=" "page" }}
 {{ $page := index $pages 0 }}
 <li><a class='{{if or (eq $currentSection .Page.Data.Term) (eq $current_dataTerm .Page.Data.Term)  }} active {{ end}}'
-  href='{{ if eq .Page.Params.type "change-log"}}/change-logs{{else if .Page.Params.external}}{{.Page.Params.external}}{{else}}{{.Page.Permalink}}{{end}}' 
+  href='{{ if eq .Page.Params.type "change-log"}}/change-logs{{else if .Page.Params.external}}{{.Page.Params.external}}{{else}}{{.Page.Permalink}}{{end}}'> 
   <i class="c8y-icon-duocolor {{.Page.Params.icon}} icon-20 m-r-8"></i>{{.Page.Title}}</a></li>
 {{ end }}

--- a/themes/c8ydocs/layouts/partials/sections-selector.html
+++ b/themes/c8ydocs/layouts/partials/sections-selector.html
@@ -13,4 +13,3 @@
   href='{{ if eq .Page.Params.type "change-log"}}/change-logs{{else if .Page.Params.external}}{{.Page.Params.external}}{{else}}{{.Page.Permalink}}{{end}}' 
   <i class="c8y-icon-duocolor {{.Page.Params.icon}} icon-20 m-r-8"></i>{{.Page.Title}}</a></li>
 {{ end }}
-


### PR DESCRIPTION
This copies the existing `href` logic from https://github.com/Cumulocity-IoT/c8y-docs/blob/aed16f37b201245f3f466203a1f78ad9b6703f2b/themes/c8ydocs/layouts/index.html#L17 to fix external links in the top-right section selector.

(It's related to #2764, but fixes the underlying cause, which is useful for the Apama doc :))