### PR TITLE
Add external link icon for external links on page index

### DIFF
--- a/themes/c8ydocs/layouts/index.html
+++ b/themes/c8ydocs/layouts/index.html
@@ -25,7 +25,11 @@
             <h2>{{.Page.Title}}</h2>
           {{end}}
         {{else}}
-          <h2>{{.Page.Title}}</h2>
+          <h2>{{.Page.Title}} 
+            {{if (isset .Page.Params "external") }}
+            <i class="dlt-c8y-icon-external-link" style="font-size: 14px;" title="External website"></i>
+            {{end}}
+          </h2>
         {{end}}
       </div>
         {{.Page.Content}}


### PR DESCRIPTION
This copies the existing logic from https://github.com/Cumulocity-IoT/c8y-docs/blob/aed16f37b201245f3f466203a1f78ad9b6703f2b/themes/c8ydocs/layouts/_default/list.html#L36-L40 to the home page, so external links are properly labelled.