### PR TITLE
MTM-62183 sdk env endpoint masks values and trailing slash of endpoints

### DIFF
--- a/content/microservice-sdk/java-bundle/java-troubleshooting.md
+++ b/content/microservice-sdk/java-bundle/java-troubleshooting.md
@@ -85,7 +85,7 @@ This is caused mainly by versions incompatibility between the SDK and Spring Boo
 
 ##### When using the SDK endpoints /env, /configprops, or /quartz I get return values masked with "******" {#when-using-the-sdk-endpoints-env-configprops-or-quartz-i-get-return-values-masked}
 
-This was introduced with Spring version 3. On how to configure or restore the previous behaviour, please refer to the [Spring Boot documentation](https://docs.spring.io/spring-boot/docs/3.2.2/reference/html/actuator.html#actuator.endpoints.sanitization).
+The behavior changed with the update to Spring Boot version 3 in the MS SDK. To configure or restore the previous behavior, please refer to the[Spring Boot documentation](https://docs.spring.io/spring-boot/docs/3.2.2/reference/html/actuator.html#actuator.endpoints.sanitization).
 
 ##### Endpoints with a trailing slash like /some/greeting/ are not accepted any more {#endpoints-with-a-trailng-slash-like-some-greeting-are-not-accepted-any-more}
 

--- a/content/microservice-sdk/java-bundle/java-troubleshooting.md
+++ b/content/microservice-sdk/java-bundle/java-troubleshooting.md
@@ -89,7 +89,7 @@ The behavior changed with the update to Spring Boot version 3 in the MS SDK. To 
 
 ##### Endpoints with a trailing slash like /some/greeting/ are not accepted any more {#endpoints-with-a-trailng-slash-like-some-greeting-are-not-accepted-any-more}
 
-This was introduced with Spring version 3. On how to retain the previous behaviour, please refer to the [Spring Boot migration guide](https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-3.0-Migration-Guide#web-application-changes).
+The behavior changed with the update to Spring Boot version 3 in the MS SDK. To configure the previous behaviour, please refer to the [Spring Boot migration guide](https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-3.0-Migration-Guide#web-application-changes).
 
 ##### Missing Docker permissions in Linux {#missing-docker-permissions-in-linux}
 

--- a/content/microservice-sdk/java-bundle/java-troubleshooting.md
+++ b/content/microservice-sdk/java-bundle/java-troubleshooting.md
@@ -87,7 +87,7 @@ This is caused mainly by versions incompatibility between the SDK and Spring Boo
 
 This was introduced with Spring version 3. On how to configure or restore the previous behaviour, please refer to the [Spring Boot documentation](https://docs.spring.io/spring-boot/docs/3.2.2/reference/html/actuator.html#actuator.endpoints.sanitization).
 
-##### Endpoints with a trailng slash like /some/greeting/ are not accepted any more {#endpoints-with-a-trailng-slash-like-some-greeting-are-not-accepted-any-more}
+##### Endpoints with a trailing slash like /some/greeting/ are not accepted any more {#endpoints-with-a-trailng-slash-like-some-greeting-are-not-accepted-any-more}
 
 This was introduced with Spring version 3. On how to retain the previous behaviour, please refer to the [Spring Boot migration guide](https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-3.0-Migration-Guide#web-application-changes).
 

--- a/content/microservice-sdk/java-bundle/java-troubleshooting.md
+++ b/content/microservice-sdk/java-bundle/java-troubleshooting.md
@@ -89,7 +89,7 @@ This behavior changed with the update to Spring Boot version 3.2 in the Microser
 
 ##### Endpoints with a trailing slash like /some/greeting/ are no longer accepted {#endpoints-with-a-trailng-slash-like-some-greeting-are-not-accepted-any-more}
 
-The behavior changed with the update to Spring Boot version 3.2 in the MS SDK. To configure the previous behaviour, please refer to the [Spring Boot migration guide](https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-3.0-Migration-Guide#web-application-changes).
+This behavior changed with the update to Spring Boot version 3.2 in the Microservice SDK. To configure the previous behaviour, refer to the [Spring Boot Migration guide](https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-3.0-Migration-Guide#web-application-changes).
 
 ##### Missing Docker permissions in Linux {#missing-docker-permissions-in-linux}
 

--- a/content/microservice-sdk/java-bundle/java-troubleshooting.md
+++ b/content/microservice-sdk/java-bundle/java-troubleshooting.md
@@ -85,7 +85,7 @@ This is caused mainly by versions incompatibility between the SDK and Spring Boo
 
 ##### When using the SDK endpoints /env, /configprops, or /quartz I get return values masked with "******" {#when-using-the-sdk-endpoints-env-configprops-or-quartz-i-get-return-values-masked}
 
-The behavior changed with the update to Spring Boot version 3.2 in the MS SDK. To configure or restore the previous behavior, please refer to the[Spring Boot documentation](https://docs.spring.io/spring-boot/docs/3.2.2/reference/html/actuator.html#actuator.endpoints.sanitization).
+This behavior changed with the update to Spring Boot version 3.2 in the Microservice SDK. To configure or restore the previous behavior, refer to the [Spring Boot documentation](https://docs.spring.io/spring-boot/docs/3.2.2/reference/html/actuator.html#actuator.endpoints.sanitization).
 
 ##### Endpoints with a trailing slash like /some/greeting/ are not accepted any more {#endpoints-with-a-trailng-slash-like-some-greeting-are-not-accepted-any-more}
 

--- a/content/microservice-sdk/java-bundle/java-troubleshooting.md
+++ b/content/microservice-sdk/java-bundle/java-troubleshooting.md
@@ -87,7 +87,7 @@ This is caused mainly by versions incompatibility between the SDK and Spring Boo
 
 This behavior changed with the update to Spring Boot version 3.2 in the Microservice SDK. To configure or restore the previous behavior, refer to the [Spring Boot documentation](https://docs.spring.io/spring-boot/docs/3.2.2/reference/html/actuator.html#actuator.endpoints.sanitization).
 
-##### Endpoints with a trailing slash like /some/greeting/ are not accepted any more {#endpoints-with-a-trailng-slash-like-some-greeting-are-not-accepted-any-more}
+##### Endpoints with a trailing slash like /some/greeting/ are no longer accepted {#endpoints-with-a-trailng-slash-like-some-greeting-are-not-accepted-any-more}
 
 The behavior changed with the update to Spring Boot version 3.2 in the MS SDK. To configure the previous behaviour, please refer to the [Spring Boot migration guide](https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-3.0-Migration-Guide#web-application-changes).
 

--- a/content/microservice-sdk/java-bundle/java-troubleshooting.md
+++ b/content/microservice-sdk/java-bundle/java-troubleshooting.md
@@ -83,6 +83,14 @@ This means that the process 12985 is using the 8080 port and it can be killed if
 
 This is caused mainly by versions incompatibility between the SDK and Spring Boot specified in your _pom.xml_ file. If you want to use a recent version of the SDK, for example, 1016.0.0, the version of Spring Boot must be compatible or equal to version 2.5.4.
 
+##### When using the SDK endpoints /env, /configprops, or /quartz I get return values masked with "******" {#when-using-the-sdk-endpoints-env-configprops-or-quartz-i-get-return-values-masked}
+
+This was introduced with Spring version 3. On how to configure or restore the previous behaviour, please refer to the [Spring Boot documentation](https://docs.spring.io/spring-boot/docs/3.2.2/reference/html/actuator.html#actuator.endpoints.sanitization).
+
+##### Endpoints with a trailng slash like /some/greeting/ are not accepted any more {#endpoints-with-a-trailng-slash-like-some-greeting-are-not-accepted-any-more}
+
+This was introduced with Spring version 3. On how to retain the previous behaviour, please refer to the [Spring Boot migration guide](https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-3.0-Migration-Guide#web-application-changes).
+
 ##### Missing Docker permissions in Linux {#missing-docker-permissions-in-linux}
 
 When you build a microservice application via `mvn`, you might get this error:

--- a/content/microservice-sdk/java-bundle/java-troubleshooting.md
+++ b/content/microservice-sdk/java-bundle/java-troubleshooting.md
@@ -85,11 +85,11 @@ This is caused mainly by versions incompatibility between the SDK and Spring Boo
 
 ##### When using the SDK endpoints /env, /configprops, or /quartz I get return values masked with "******" {#when-using-the-sdk-endpoints-env-configprops-or-quartz-i-get-return-values-masked}
 
-The behavior changed with the update to Spring Boot version 3 in the MS SDK. To configure or restore the previous behavior, please refer to the[Spring Boot documentation](https://docs.spring.io/spring-boot/docs/3.2.2/reference/html/actuator.html#actuator.endpoints.sanitization).
+The behavior changed with the update to Spring Boot version 3.2 in the MS SDK. To configure or restore the previous behavior, please refer to the[Spring Boot documentation](https://docs.spring.io/spring-boot/docs/3.2.2/reference/html/actuator.html#actuator.endpoints.sanitization).
 
 ##### Endpoints with a trailing slash like /some/greeting/ are not accepted any more {#endpoints-with-a-trailng-slash-like-some-greeting-are-not-accepted-any-more}
 
-The behavior changed with the update to Spring Boot version 3 in the MS SDK. To configure the previous behaviour, please refer to the [Spring Boot migration guide](https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-3.0-Migration-Guide#web-application-changes).
+The behavior changed with the update to Spring Boot version 3.2 in the MS SDK. To configure the previous behaviour, please refer to the [Spring Boot migration guide](https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-3.0-Migration-Guide#web-application-changes).
 
 ##### Missing Docker permissions in Linux {#missing-docker-permissions-in-linux}
 


### PR DESCRIPTION
This PR contains modifications related to
- MTM-62183 Parmeter values received by microservice /env endpoint are masked with "******"

and (preliminary, depending on the decision whether to keep the current behaviour or not)
- MTM-62154 Trailing slash within REST call paths is rejected

To be discussed, too:
Links are provided for Spring documentation but not (yet) to the Tech Community page which still is in the Softwareag domain (  https://tech.forums.softwareag.com/t/java-microservice-development-preparing-for-spring-boot-3-x/303592 )

