### PR TITLE
MTM-61949: Remove reference to now removed MQTT_SERVICE_ADMIN role

### DIFF
--- a/content/device-integration/mqtt-service-bundle/implementation.md
+++ b/content/device-integration/mqtt-service-bundle/implementation.md
@@ -126,10 +126,6 @@ Authentication types supported by MQTT Service are:
 *   Username and password: The MQTT username must include the tenant ID and username in the format `<tenantID>/<username>`.
 *   Device certificates: Not yet supported. This will be added in a future release.
 
-{{< c8y-admon-req >}}
-The MQTT user which is used to connect to the MQTT Service must have the `MQTT_SERVICE_ADMIN` role assigned.
-{{< /c8y-admon-req >}}
-
 #### ClientId {#client-id}
 
 The **MQTT ClientID** field identifies the connected client. **ClientID** may consist of up to 128 alphanumeric characters.


### PR DESCRIPTION
As outline here: https://github.com/Cumulocity-IoT/c8y-mqtt-service/blob/develop/adr/0006-mqtt-service-admin-role.md, the `MQTT_SERVICE_ADMIN` role is being removed as the MQTT Service will be adopting the standard microservice subscription model making the role redundant.