### PR TITLE
[CIA-946] Remove reference to Barista.io demo.

### DIFF
--- a/content/sensor-app/sensorapp-introduction.md
+++ b/content/sensor-app/sensorapp-introduction.md
@@ -41,10 +41,6 @@ The latest list of supported Bluetooth devices is provided in the app. A button 
 
 More devices will be supported in the future and made available in the app.
 
-{{< c8y-admon-info >}}
-The Barista.io demo demonstrates the use of connected weight and pressure sensors to brew the perfect coffee. The demo sends measurements from up to 4 connected Bluetooth devices to {{< product-c8y-iot >}} in real time.
-{{< /c8y-admon-info >}}
-
 Reading vehicle sensors comes with the use of an additional OBD dongle, which exposes the vehicles sensors to the phone via WiFi or Bluetooth (Note: iOS is WiFi only). There are two supported diagnostic connectors, both based on the ELM327 microcontroller:
 
 *	Kungfuren OBD2 Diagnostic Device Bluetooth 4.0 Adapter


### PR DESCRIPTION
Since the barista.io demo is no longer hosted anywhere, this should be removed from all versions of docs. 