### PR TITLE
MTM-62395/MSSDK Spring Boot 3.3 update - Fixing version numbers and imports

### DIFF
--- a/content/microservice-sdk/java-bundle/ip-tracker-microservice.md
+++ b/content/microservice-sdk/java-bundle/ip-tracker-microservice.md
@@ -218,7 +218,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import jakarta.annotation.PostConstruct;
-import jakarta.servlet.http.HttpServletRequest;;
+import jakarta.servlet.http.HttpServletRequest;
 
 import org.joda.time.DateTime;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/content/microservice-sdk/java-bundle/ip-tracker-microservice.md
+++ b/content/microservice-sdk/java-bundle/ip-tracker-microservice.md
@@ -33,7 +33,7 @@ Your *pom.xml* file should contain a snippet similar to:
     <java.version>17</java.version>
     <maven.compiler.source>${java.version}</maven.compiler.source>
     <maven.compiler.target>${java.version}</maven.compiler.target>
-    <spring-boot-dependencies.version>2.5.14</spring-boot-dependencies.version>
+    <spring-boot-dependencies.version>3.3.5</spring-boot-dependencies.version>
     <c8y.version>1016.0.117</c8y.version>
     <microservice.name>iptracker-microservice</microservice.name>
 </properties>
@@ -217,8 +217,8 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
 
-import javax.annotation.PostConstruct;
-import javax.servlet.http.HttpServletRequest;
+import jakarta.annotation.PostConstruct;
+import jakarta.servlet.http.HttpServletRequest;;
 
 import org.joda.time.DateTime;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/content/microservice-sdk/java-bundle/java-hello-world-tutorial.md
+++ b/content/microservice-sdk/java-bundle/java-hello-world-tutorial.md
@@ -87,7 +87,7 @@ You will find the _pom.xml_ file inside the *hello-microservice-java* folder. Ed
     <java.version>17</java.version>
     <maven.compiler.source>${java.version}</maven.compiler.source>
     <maven.compiler.target>${java.version}</maven.compiler.target>
-    <spring-boot-dependencies.version>2.5.14</spring-boot-dependencies.version>
+    <spring-boot-dependencies.version>3.3.5</spring-boot-dependencies.version>
 </properties>
 ```
 
@@ -500,7 +500,7 @@ If your Docker image has run successfully, you shall see the output on the conso
  \\/  ___)| |_)| | | | | || (_| |  ) ) ) )
   '  |____| .__|_| |_|_| |_\__, | / / / /
  =========|_|==============|___/=/_/_/_/
- :: Spring Boot ::        (v2.5.14)
+ :: Spring Boot ::        (v3.3.5)
 
 2022-10-21 15:53:07.510  INFO 7 --- [main] c8y.example.App                          : Starting App on dff01acae6d8 with PID 7 (/data/hello-microservice-java.jar started by root in /)
 ...


### PR DESCRIPTION
In MTM-61583 the Microservices SDK dependencies on Spring Boot and Spring Framework have been upgraded to version 3.3 and 6.0 respectively. This PR is fixing outdated references to Spring Boot version 2 and javax-imports in the MS SDK user documentation.