### PR TITLE
Match terminology used in contract templates

### DIFF
--- a/content/service-terms/releases.md
+++ b/content/service-terms/releases.md
@@ -23,13 +23,13 @@ To address these considerations, this document outlines the various upgrade mode
 
 {{< company-c8y >}}’s continuous deployment model enables cloud software upgrades to occur automatically, at any time, ensuring that customers receive the latest features, enhancements, and security improvements promptly. All cloud instances are under full support of {{< company-c8y >}}’s support services at any time according to the support service-level purchased by the customer.
 
-Cloud instances are separated into *preproduction* and *production* cloud instances to streamline upgrades and testing.
- * Preproduction instances include customer development instances and the public instance at eu-latest.cumulocity.com.
+Cloud instances are separated into *non-production* and *production* cloud instances to streamline upgrades and testing.
+ * Non-production instances include customer development and test instances, and the public instance at eu-latest.cumulocity.com.
  * Production instances cover both customer production environments and other public cloud production instances.
 
 The upgrade process for instances follows a staged approach.
- * After an upgrade has passed {{< product-c8y-iot >}}’s internal quality assurance, it is first deployed to preproduction instances.
- * Following this initial deployment and based on the scope and complexity of the upgrade, production instances are then upgraded, typically two to three weeks after preproduction.
+ * After an upgrade has passed {{< product-c8y-iot >}}’s internal quality assurance, it is first deployed to non-production instances.
+ * Following this initial deployment and based on the scope and complexity of the upgrade, production instances are then upgraded, typically two to three weeks after non-production deployment.
 
 In rare circumstances, upgrades may be rolled back if significant issues are detected post-deployment.
 
@@ -49,7 +49,7 @@ To help ensure that applications built on {{< product-c8y-iot >}}  continue to f
 For customers in particularly sensitive industries, {{< company-c8y >}} offers an annual deployment model, designed to provide a predictable, stable upgrade cycle. Each year, {{< company-c8y >}} designates one release as the annual release, which is deployed to customers following a carefully coordinated schedule, as outlined in the example below.
 
 In the annual deployment model:
-* A release candidate is made available on preproduction instances for a two-month period, during which customers are required to perform thorough testing. As rollbacks are not available once the release is deployed, this testing period is essential.
+* A release candidate is made available on non-production instances for a two-month period, during which customers are required to perform thorough testing. As rollbacks are not available once the release is deployed, this testing period is essential.
 * Maintenance for each annual release ends three months after the next annual release becomes generally available (End of Maintenance, or EOM).
 * After EOM, support will continue for up to three additional months (End of Sustained Support, or EOSS); however, no further fixes will be issued during this period. Customers are expected to complete upgrades within this timeframe and will receive dedicated support to facilitate this process.
 

--- a/content/service-terms/service-level-bundle/datahub-sla.md
+++ b/content/service-terms/service-level-bundle/datahub-sla.md
@@ -49,7 +49,7 @@ Customer acknowledges the following limitations and constraints in using Service
 {{< company-c8y >}} is committed to providing reliable service. The specific service availability targets for {{< product-c8y-iot >}} DataHub are as follows:
 
 * **Production environments:** 99.00% availability
-* **Preproduction environments:** 95.00% availability
+* **Non-production environments:** 95.00% availability
 
 Service availability for [{{< product-c8y-iot >}} DataHub APIs](https://cumulocity.com/api/datahub/#tag/Standard-API) is calculated as outlined in the [platform's service availability section](/service-terms/service-level/#service-availability).
 

--- a/content/service-terms/service-level-bundle/platform-sla.md
+++ b/content/service-terms/service-level-bundle/platform-sla.md
@@ -23,7 +23,7 @@ The {{< product-c8y-iot >}} platform offers a comprehensive set of features desi
 * **Real-time and batch data processing and storage:** {{< product-c8y-iot >}} supports both real-time and batch processing of IoT data, enabling users to efficiently manage and analyze large volumes of data as it is generated. Data storage is Customer-configurable, allowing you to define retention periods according to your specific requirements.
 * **Flexible deployment options:**
     * The platform is deployed using shared ("{{< product-c8y-iot >}}") or dedicated cloud instances ("{{< product-c8y-iot >}} Enterprise Dedicated"), tailored to meet the needs of your organization.
-    * Optionally, separate environments for pre-production (non-production) activities can be purchased to ensure smooth development and testing processes.
+    * Optionally, separate environments for non-production activities can be purchased to ensure smooth development and testing processes.
     * {{< product-c8y-iot >}} is hosted in Customer-selected regions (EMEA, APAC, Japan, and the US).
 * **Support services:**
     * The platform offers tiered product support to meet varying operational needs as outlined in the [support agreement](/service-terms/service-level/#support-sla).
@@ -78,7 +78,7 @@ In the interest of transparency and to ensure a mutual understanding of the serv
 {{< company-c8y >}} is committed to providing reliable service. The specific service availability targets are as follows:
 
 * **Production environments:** 99.90% availability
-* **Preproduction environments:** 95.00% availability
+* **Non-production environments:** 95.00% availability
 
 Service availability for {{< product-c8y-iot >}} is calculated as follows:
 
@@ -164,7 +164,7 @@ service availability requirements are set forth in this service credit commitmen
 #### **Support**
 
 * **Customer support:** Support is provided in accordance with Customer’s selected support plan, as detailed in the [support agreement](/service-terms/service-level/#support-sla).
-* **Pre-production environments:** For pre-production environments, Starter-level support is generally provided, with support tickets handled at standard priority.
+* **Non-production environments:** For non-production environments, Starter-level support is generally provided, with support tickets handled at standard priority.
 
 #### **Maintenance**
 


### PR DESCRIPTION
Small request from Jürgen to rename pre-production/preproduction to non-production as used in the current contract templates.

![unnamed](https://github.com/user-attachments/assets/2a458b94-cfbd-4094-9f7b-c4dcf60f45b3)
