### PR TITLE
Document analytics builder support in the multi-tenant microservice

### DIFF
--- a/content/change-logs/analytics/apama-in-c8y-20250206-The-Apama-ctrl-mt-4c-16g-microservice-now-supports-analytic-models.md
+++ b/content/change-logs/analytics/apama-in-c8y-20250206-The-Apama-ctrl-mt-4c-16g-microservice-now-supports-analytic-models.md
@@ -12,6 +12,6 @@ build_artifact:
   - value: tc-KXXmo2SUR
     label: apama-in-c8y
 ticket: PAB-4623
-version: 26.16.0
+version: 25.331.0
 ---
 The **Apama-ctrl-mt-4c-16g** now supports Analytic models. The **Analytics Builder** page is shown for tenants subscribed to the microservice, allowing users to create, deploy and manage analytic models.

--- a/content/change-logs/analytics/apama-in-c8y-20250206-The-Apama-ctrl-mt-4c-16g-microservice-now-supports-analytic-models.md
+++ b/content/change-logs/analytics/apama-in-c8y-20250206-The-Apama-ctrl-mt-4c-16g-microservice-now-supports-analytic-models.md
@@ -1,0 +1,17 @@
+---
+date:
+title: The Apama-ctrl-mt-4c-16g microservice now supports analytic models
+change_type:
+  - value: change-2c7RdTdXo4
+    label: Improvement
+product_area: Analytics
+component:
+  - value: component-M5-cepIIS
+    label: Streaming Analytics
+build_artifact:
+  - value: tc-KXXmo2SUR
+    label: apama-in-c8y
+ticket: PAB-4623
+version: 26.16.0
+---
+The **Apama-ctrl-mt-4c-16g** now supports Analytic models. The **Analytics Builder** page is shown for tenants subscribed to the microservice, allowing users to create, deploy and manage analytic models.

--- a/content/change-logs/analytics/apama-in-c8y-20250206-The-Apama-ctrl-mt-4c-16g-microservice-now-supports-analytic-models.md
+++ b/content/change-logs/analytics/apama-in-c8y-20250206-The-Apama-ctrl-mt-4c-16g-microservice-now-supports-analytic-models.md
@@ -1,6 +1,6 @@
 ---
 date:
-title: The Apama-ctrl-mt-4c-16g microservice now supports analytic models
+title: The multi-tenant apama-ctrl-mt-4c-16g microservice now supports analytic models
 change_type:
   - value: change-2c7RdTdXo4
     label: Improvement
@@ -14,4 +14,4 @@ build_artifact:
 ticket: PAB-4623
 version: 25.331.0
 ---
-The **Apama-ctrl-mt-4c-16g** now supports Analytic models. The **Analytics Builder** page is shown for tenants subscribed to the microservice, allowing users to create, deploy and manage analytic models.
+The multi-tenant **Apama-ctrl-mt-4c-16g** microservice now supports Analytic models. The **Analytics Builder** page is shown for tenants subscribed to the microservice, allowing users to create, deploy and manage analytic models.

--- a/content/streaming-analytics/analytics-builder-bundle/model-simulation.md
+++ b/content/streaming-analytics/analytics-builder-bundle/model-simulation.md
@@ -55,4 +55,4 @@ See also [Configuration](/streaming-analytics/analytics-builder/#configuration).
 
 ### Monitoring dropped inputs {#monitoring-dropped-inputs}
 
-The simulated model may drop delayed input events in exceptional cases. The number of input events dropped across all the models is exposed as a user-defined status with the name `user-analytics-oldEventsDropped`. See also [Monitoring dropped events](/streaming-analytics/analytics-builder/#monitoring-dropped-events).
+The simulated model may drop delayed input events in exceptional cases. Alarms are periodically raised with the number of input events dropped across all the models. See also [Monitoring dropped events](/streaming-analytics/analytics-builder/#monitoring-dropped-events).

--- a/content/streaming-analytics/analytics-builder-bundle/models-and-devices.md
+++ b/content/streaming-analytics/analytics-builder-bundle/models-and-devices.md
@@ -51,6 +51,10 @@ With the concurrency level set to 1, it is still possible to create models which
 Using multiple specific devices in a model with the concurrency level set to more than 1 can lead to connections between models which are deployed across multiple workers. Chains of models using multiple specific devices with high throughput usually scale less well than chains of models all using a single specific device.
 {{< /c8y-admon-info>}}
 
+{{< c8y-admon-info>}}
+The concurrency level has a fixed value of 1 for microservices with multi-tenant support.
+{{< /c8y-admon-info>}}
+
 ### Broadcast devices {#broadcast-devices}
 
 It is sometimes useful to have signals that can apply to all models. These may be signals from devices, or from other systems that are presented as if they were signals from a device. Analytics Builder thus supports devices that are referred to as broadcast devices and signals from these devices are available to all models across all devices.

--- a/content/streaming-analytics/analytics-builder-bundle/models-and-devices.md
+++ b/content/streaming-analytics/analytics-builder-bundle/models-and-devices.md
@@ -52,7 +52,7 @@ Using multiple specific devices in a model with the concurrency level set to mor
 {{< /c8y-admon-info>}}
 
 {{< c8y-admon-info>}}
-The concurrency level has a fixed value of 1 for microservices with multi-tenant support.
+The concurrency level has a fix value of 1 for microservices with multi-tenant support.
 {{< /c8y-admon-info>}}
 
 ### Broadcast devices {#broadcast-devices}

--- a/content/streaming-analytics/analytics-builder-bundle/monitoring-and-configuration.md
+++ b/content/streaming-analytics/analytics-builder-bundle/monitoring-and-configuration.md
@@ -246,7 +246,6 @@ The following is an example of the status operation data that is published by {{
     "apama_status": {
         "user-analyticsbuilder.slowestChain.models": "\"Model 1\", \"Model 2\", \"Model 3\"",
         "user-analyticsbuilder.slowestChain.delaySec": "3",
-        "user-analytics-oldEventsDropped": "1",
         "numJavaApplications": "1",
         "numMonitors": "27",
         "user-httpServer.eventsTowardsHost": "1646",
@@ -286,9 +285,7 @@ The following is an example of the status operation data that is published by {{
 
 #### Monitoring dropped events {#monitoring-dropped-events}
 
-When a model receives an event, it may be dropped if the correlator delivers or processes it too late. See [Input blocks and event timing](/streaming-analytics/analytics-builder/#input-blocks-and-event-timing).
-
-The total number of dropped events across all models is periodically published as part of the status operation. The count of the number of dropped events is available as a user-defined status value with the name `user-analytics-oldEventsDropped` in the `apama_status` parameter of the status operation. See also [Monitoring periodic status](/streaming-analytics/analytics-builder/#monitoring-periodic-status) for details about the operation.
+When a model receives an event, it may be dropped if the correlator delivers or processes it too late. See [Input blocks and event timing](/streaming-analytics/analytics-builder/#input-blocks-and-event-timing). Alarms are periodically raised with total number of dropped events and sample of the last dropped event.
 
 All dropped input events are also sent to channel `AnalyticsDroppedEvents`, allowing you to implement your own monitoring of the dropped events. A dropped input event sent to the channel `AnalyticsDroppedEvents` is packaged inside an event of type `apama.analyticsbuilder.DroppedEvent`. This allows you to extract the original dropped event and perform any analysis on it, for example, categorizing the number of dropped events per device. This can be achieved by writing EPL that listens for the `DroppedEvent` events, aggregates by device identifier and/or time, and sends measurements to {{< product-c8y-iot >}} that can be monitored. See also [Deploying apps](/streaming-analytics/epl-apps/#deploying-apps).
 
@@ -441,7 +438,7 @@ After you have changed a tenant option using a REST request, the correlator will
 <tbody>
   <tr>
     <td><code>numWorkerThreads</code></td>
-    <td>The number of worker threads. The default value is 1. See also <a href="/streaming-analytics/analytics-builder/#configuring-the-concurrency-level">Configuring the concurrency level</a>.</td>
+    <td>The number of worker threads. The default value is 1. See also <a href="/streaming-analytics/analytics-builder/#configuring-the-concurrency-level">Configuring the concurrency level</a>. Note that the number of worker threads cannot be changed for the microservice with multi-tenant support.</td>
   </tr>
   <tr>
     <td><code>retention.virtualDevicesMaxDays</code></td>

--- a/content/streaming-analytics/analytics-builder-bundle/monitoring-and-configuration.md
+++ b/content/streaming-analytics/analytics-builder-bundle/monitoring-and-configuration.md
@@ -285,7 +285,7 @@ The following is an example of the status operation data that is published by {{
 
 #### Monitoring dropped events {#monitoring-dropped-events}
 
-When a model receives an event, it may be dropped if the correlator delivers or processes it too late. See [Input blocks and event timing](/streaming-analytics/analytics-builder/#input-blocks-and-event-timing). Alarms are periodically raised with total number of dropped events and sample of the last dropped event.
+When a model receives an event, it may be dropped if the correlator delivers or processes it too late. See [Input blocks and event timing](/streaming-analytics/analytics-builder/#input-blocks-and-event-timing). Alarms are periodically raised with total number of dropped events and sample of the last dropped event. See [Analytics Builder dropped events](/streaming-analytics/troubleshooting/#analytics-builder-dropped-events) for information on alarms.
 
 All dropped input events are also sent to channel `AnalyticsDroppedEvents`, allowing you to implement your own monitoring of the dropped events. A dropped input event sent to the channel `AnalyticsDroppedEvents` is packaged inside an event of type `apama.analyticsbuilder.DroppedEvent`. This allows you to extract the original dropped event and perform any analysis on it, for example, categorizing the number of dropped events per device. This can be achieved by writing EPL that listens for the `DroppedEvent` events, aggregates by device identifier and/or time, and sends measurements to {{< product-c8y-iot >}} that can be monitored. See also [Deploying apps](/streaming-analytics/epl-apps/#deploying-apps).
 

--- a/content/streaming-analytics/analytics-builder-bundle/monitoring-and-configuration.md
+++ b/content/streaming-analytics/analytics-builder-bundle/monitoring-and-configuration.md
@@ -285,7 +285,7 @@ The following is an example of the status operation data that is published by {{
 
 #### Monitoring dropped events {#monitoring-dropped-events}
 
-When a model receives an event, it may be dropped if the correlator delivers or processes it too late. See [Input blocks and event timing](/streaming-analytics/analytics-builder/#input-blocks-and-event-timing). Alarms are periodically raised with total number of dropped events and sample of the last dropped event. See [Analytics Builder dropped events](/streaming-analytics/troubleshooting/#analytics-builder-dropped-events) for information on alarms.
+When a model receives an event, it may be dropped if the correlator delivers or processes it too late. See [Input blocks and event timing](/streaming-analytics/analytics-builder/#input-blocks-and-event-timing). Alarms are periodically raised with the total number of dropped events and a sample of the last dropped event. See [Analytics Builder dropped events](/streaming-analytics/troubleshooting/#analytics-builder-dropped-events) for information on alarms.
 
 All dropped input events are also sent to channel `AnalyticsDroppedEvents`, allowing you to implement your own monitoring of the dropped events. A dropped input event sent to the channel `AnalyticsDroppedEvents` is packaged inside an event of type `apama.analyticsbuilder.DroppedEvent`. This allows you to extract the original dropped event and perform any analysis on it, for example, categorizing the number of dropped events per device. This can be achieved by writing EPL that listens for the `DroppedEvent` events, aggregates by device identifier and/or time, and sends measurements to {{< product-c8y-iot >}} that can be monitored. See also [Deploying apps](/streaming-analytics/epl-apps/#deploying-apps).
 

--- a/content/streaming-analytics/analytics-builder-bundle/understanding-models.md
+++ b/content/streaming-analytics/analytics-builder-bundle/understanding-models.md
@@ -143,6 +143,10 @@ To upload an extension, the user specified in the `--username` argument must hav
 
 The Apama-ctrl microservice is restarted after running the above command. The user must have the ADMIN permission for "CEP management" to request a restart.
 
+{{< c8y-admon-info>}}
+When using the multi-tenant Apama-ctrl-mt-4c-16g microservice, only extensions uploaded to the tenant that owns the microservice will be used.
+{{< /c8y-admon-info>}}
+
 ### Wires {#wires}
 
 One block is connected to another block with the help of wires. All data transfer between the output port of one block and the input port of another block is done using wires. All connections must be made between compatible types. See [Wires and blocks](/streaming-analytics/analytics-builder/#wires-and-blocks) for detailed information.

--- a/content/streaming-analytics/analytics-customization-bundle/control-access.md
+++ b/content/streaming-analytics/analytics-customization-bundle/control-access.md
@@ -14,8 +14,8 @@ Which pages are available also depends on the variant of the Apama-ctrl microser
 and only a card with information about smart rules is shown on the home screen.
 - If the Apama-ctrl-starter microservice is running, the **EPL Apps** page is not shown (and cannot be enabled)
 as the EPL apps functionality is not available in Apama-ctrl-starter.
-- If the Apama-ctrl-mt-4c-16g microservice is running, the **Analytics Builder** page is not shown (and cannot be enabled).
-In this case, only the **EPL Apps** page is shown.
+- If the Apama-ctrl-mt-4c-16g microservice is running, the **Analytics Builder** page is shown. The **EPL Apps** is shown 
+on the tenant that owns the microservice, but not shown (and cannot be enabled) on the subtenants.
 - If the Apama-ctrl-smartrules or Apama-ctrl-smartrulesmt microservice is running, neither the **Analytics Builder** nor the **EPL Apps** page is shown (and cannot be enabled).
 In this case, only the card with information about smart rules is shown on the home screen.
 - For other variants of the Apama-ctrl microservice, both the **Analytics Builder** and **EPL Apps** pages are shown by default.

--- a/content/streaming-analytics/analytics-customization-bundle/control-access.md
+++ b/content/streaming-analytics/analytics-customization-bundle/control-access.md
@@ -14,7 +14,7 @@ Which pages are available also depends on the variant of the Apama-ctrl microser
 and only a card with information about smart rules is shown on the home screen.
 - If the Apama-ctrl-starter microservice is running, the **EPL Apps** page is not shown (and cannot be enabled)
 as the EPL apps functionality is not available in Apama-ctrl-starter.
-- If the Apama-ctrl-mt-4c-16g microservice is running, the **Analytics Builder** page is shown. The **EPL Apps** is shown 
+- If the Apama-ctrl-mt-4c-16g microservice is running, the **Analytics Builder** page is shown for all subscribed tenants. The **EPL Apps** is shown 
 on the tenant that owns the microservice, but not shown (and cannot be enabled) on the subtenants.
 - If the Apama-ctrl-smartrules or Apama-ctrl-smartrulesmt microservice is running, neither the **Analytics Builder** nor the **EPL Apps** page is shown (and cannot be enabled).
 In this case, only the card with information about smart rules is shown on the home screen.

--- a/content/streaming-analytics/analytics-customization-bundle/control-access.md
+++ b/content/streaming-analytics/analytics-customization-bundle/control-access.md
@@ -14,7 +14,7 @@ Which pages are available also depends on the variant of the Apama-ctrl microser
 and only a card with information about smart rules is shown on the home screen.
 - If the Apama-ctrl-starter microservice is running, the **EPL Apps** page is not shown (and cannot be enabled)
 as the EPL apps functionality is not available in Apama-ctrl-starter.
-- If the Apama-ctrl-mt-4c-16g microservice is running, the **Analytics Builder** page is shown for all subscribed tenants. The **EPL Apps** is shown 
+- If the Apama-ctrl-mt-4c-16g microservice is running, the **Analytics Builder** page is shown for all subscribed tenants. The **EPL Apps** page is shown 
 on the tenant that owns the microservice, but not shown (and cannot be enabled) on the subtenants.
 - If the Apama-ctrl-smartrules or Apama-ctrl-smartrulesmt microservice is running, neither the **Analytics Builder** nor the **EPL Apps** page is shown (and cannot be enabled).
 In this case, only the card with information about smart rules is shown on the home screen.

--- a/content/streaming-analytics/analytics-customization-bundle/optimize-requests.md
+++ b/content/streaming-analytics/analytics-customization-bundle/optimize-requests.md
@@ -23,5 +23,5 @@ You can adjust the default number of client connections with the `client.numClie
 If you require a fully serial transport, set the value of `client.numClients` to 1.
 
 {{< c8y-admon-info >}}
-This does not apply to the Apama-ctrl-smartrules, Apama-ctrl-smartrulesmt, and Apama-ctrl-mt-4c-16g microservices. They have a fixed value of 1 (that is, fully serial) for this option, which is not configurable.
+This does not apply to the Apama-ctrl-smartrules, Apama-ctrl-smartrulesmt, and Apama-ctrl-mt-4c-16g microservices. They have a fix value of 1 (that is, fully serial) for this option, which is not configurable.
 {{< /c8y-admon-info >}}

--- a/content/streaming-analytics/analytics-customization-bundle/optimize-requests.md
+++ b/content/streaming-analytics/analytics-customization-bundle/optimize-requests.md
@@ -23,5 +23,5 @@ You can adjust the default number of client connections with the `client.numClie
 If you require a fully serial transport, set the value of `client.numClients` to 1.
 
 {{< c8y-admon-info >}}
-This does not apply to the Apama-ctrl-smartrules and Apama-ctrl-smartrulesmt microservices. They have a fixed value of 1 (that is, fully serial) for this option, which is not configurable.
+This does not apply to the Apama-ctrl-smartrules, Apama-ctrl-smartrulesmt, and Apama-ctrl-mt-4c-16g microservice microservices. They have a fixed value of 1 (that is, fully serial) for this option, which is not configurable.
 {{< /c8y-admon-info >}}

--- a/content/streaming-analytics/analytics-customization-bundle/optimize-requests.md
+++ b/content/streaming-analytics/analytics-customization-bundle/optimize-requests.md
@@ -23,5 +23,5 @@ You can adjust the default number of client connections with the `client.numClie
 If you require a fully serial transport, set the value of `client.numClients` to 1.
 
 {{< c8y-admon-info >}}
-This does not apply to the Apama-ctrl-smartrules, Apama-ctrl-smartrulesmt, and Apama-ctrl-mt-4c-16g microservice microservices. They have a fixed value of 1 (that is, fully serial) for this option, which is not configurable.
+This does not apply to the Apama-ctrl-smartrules, Apama-ctrl-smartrulesmt, and Apama-ctrl-mt-4c-16g microservices. They have a fixed value of 1 (that is, fully serial) for this option, which is not configurable.
 {{< /c8y-admon-info >}}

--- a/content/streaming-analytics/introduction-analytics-bundle/microservice-and-applications.md
+++ b/content/streaming-analytics/introduction-analytics-bundle/microservice-and-applications.md
@@ -29,7 +29,7 @@ If your tenant is subscribed to the Apama-ctrl-250mc-1g microservice (or one of 
 If your tenant is subscribed to the Apama-ctrl-mt-4c-16g microservice, then the following applies:
 - Multi-tenant support.
 - EPL apps are only enabled on the tenant that owns the microservice, but disabled on the subtenants.
-- The **Analytics Builder** page is currently not available in the Streaming Analytics application.
+- Analytic models are supported.
 - Smart rules are supported.
 
 If your tenant is subscribed to the Apama-ctrl-smartrules or Apama-ctrl-smartrulesmt microservice, then the following applies:

--- a/content/streaming-analytics/introduction-analytics-bundle/microservice-and-applications.md
+++ b/content/streaming-analytics/introduction-analytics-bundle/microservice-and-applications.md
@@ -29,8 +29,7 @@ If your tenant is subscribed to the Apama-ctrl-250mc-1g microservice (or one of 
 If your tenant is subscribed to the Apama-ctrl-mt-4c-16g microservice, then the following applies:
 - Multi-tenant support.
 - EPL apps are only enabled on the tenant that owns the microservice, but disabled on the subtenants.
-- Analytic models are supported.
-- Smart rules are supported.
+- Analytic models and smart rules are supported.
 
 If your tenant is subscribed to the Apama-ctrl-smartrules or Apama-ctrl-smartrulesmt microservice, then the following applies:
 - Smart rules are supported.


### PR DESCRIPTION
Update doc and add change log to mention that analytic models are now supported in the Apama-ctrl-mt-4c-16g microservice.