### PR TITLE
MTM-62228 Clean up user documentation for the data broker microservice

### DIFF
--- a/content/data-broker/ms-data-broker-bundle/ms-troubleshooting.md
+++ b/content/data-broker/ms-data-broker-bundle/ms-troubleshooting.md
@@ -29,7 +29,3 @@ This alarm is raised when latency for message delivery crosses a specified thres
 The data broker monitors the data rate at which events are being forwarded. If this rate is lower than a pre-configured threshold, a slow processing alert will be raised. This can occur due to a slow network.
 
 ![New Data-Broker Alarms](/images/users-guide/enterprise-tenant/et-new-data-broker-alarms.png)
-
-{{< c8y-admon-info >}}
-Refer to the *Messaging Service Installation & operations guide* to find out more about how these parameters can be configured.
-{{< /c8y-admon-info >}}

--- a/content/data-broker/ms-data-broker-bundle/using-ms-data-broker.md
+++ b/content/data-broker/ms-data-broker-bundle/using-ms-data-broker.md
@@ -6,22 +6,6 @@ sector:
   - platform_administration
 ---
 
-### Notice of current storage limits and message TTL for the microservice-based data broker
-
-{{< c8y-admon-important >}}
-
-The microservice-based data broker stores messages persistently until they are successfully delivered to the destination tenant. To optimize resource usage, the storage limits for the microservice-based data broker have been adjusted as follows:
-
-**Message backlog quota**:
-- Each data broker connector can store a maximum of **50 MiB** of unacknowledged messages in its backlog. This is equivalent to approximately 260,000 messages, assuming an average message size of 200 bytes.
-
-**Message time-to-live (TTL)**:
-- A default message TTL of **36 hours** has been introduced. Any unacknowledged messages remaining in the backlog for more than 36 hours will be automatically deleted.
-
-These limits are configurable on a per-tenant basis. If your use case requires a different configuration, or if you have any concerns, please contact [product support](https://cumulocity.com/docs/additional-resources/contacting-support/).
-
-{{< /c8y-admon-important >}}
-
 The microservice-based data broker is powered by the {{< product-c8y-iot >}} Messaging Service that enables reliable, scalable and high-performance movement of IoT data. The microservice-based data broker is similar to the existing data broker in its functionality, except that a microservice, the `databroker-agent-server`, must be enabled to make use of it.
 
 {{< c8y-admon-req >}}
@@ -32,7 +16,7 @@ For the shared public cloud instances of the {{< product-c8y-iot >}} platform, t
 For dedicated and self-hosted instances, the Messaging Service and microservice-based data broker are available for release 10.10 and above, but will need to be explicitly enabled.
 
 Please [contact product support](/additional-resources/contacting-support/) to inquire about using the Messaging Service and microservice-based data broker capabilities in your {{< product-c8y-iot >}} environment.
-See the *Messaging Service - Installation & operations guide* for further technical details of the configuration required, but note that these tasks can only be performed by a {{< product-c8y-iot >}} platform operator, not by a normal user.
+See the *Messaging Service Installation & operations guide* for further technical details of the configuration required, but note that these tasks can only be performed by a {{< product-c8y-iot >}} platform operator, not by a normal user.
 
 In summary, to work with the microservice-based data broker, the following requirements must be met:
   * The {{< product-c8y-iot >}} Messaging Service should be available on your {{< product-c8y-iot >}} platform.
@@ -57,6 +41,16 @@ See [Data connectors](/data-broker/data-broker-application/#data-connectors) for
 See [Data subscriptions](/data-broker/data-broker-application/#data-subscriptions) for details on how to manage data subscriptions.
 
 
-###  Migrating existing data connectors to the microservice-based data broker {#-migrating-existing-data-connectors-to-the-microservice-based-data-broker}
+### Migrating existing data connectors to the microservice-based data broker {#migrating-existing-data-connectors-to-the-microservice-based-data-broker}
 
 After enabling the microservice-based data broker, your existing data connectors should continue to work without any additional configuration.
+
+
+### Service quotas for the microservice-based data broker {#microservice-based-data-broker-service-quotas}
+
+The microservice-based data broker stores messages persistently using the {{< product-c8y-iot >}} Messaging Service until they are successfully delivered to the destination tenant.
+To optimize resource usage, the Messaging Service imposes storage limits and a message time-to-live (TTL) on persistently stored messages.
+See [service quotas](/service-terms/quotas/#realtime-apis) for details of the default quotas used by the microservice-based data broker.
+
+These limits are configurable on a per-tenant basis.
+If your use case requires a different configuration, or if you have any concerns, please contact [product support](https://cumulocity.com/docs/additional-resources/contacting-support/).


### PR DESCRIPTION
While working on MTM-62228 I thought I had better review the user doc for the microservice-based data broker to make sure there were no references to operation documentation that was about to be deleted. I didn't find any of that but I did:
1. Remove the scary warning about limits and replace this with a link to the central list of service quotas.
2. Remove a reference to some microservice configuration doc that doesn't actually exist.

This change will be back-ported to 2025.