### PR TITLE
move extensible device registration

### DIFF
--- a/content/device-management-application/registering-devices-bundle/extensible-device-registration.md
+++ b/content/device-management-application/registering-devices-bundle/extensible-device-registration.md
@@ -4,16 +4,16 @@ title: Extensible device registration
 layout: bundle
 ---
 
-To address the growing number of IoT protocols and certain restrictions in the general single or bulk device registration, an extensible device registration is available with release 10.15.
+To address the growing number of IoT protocols and certain restrictions in the general single or bulk device registration, {{< product-c8y-iot >}} provides an extensible device registration feature.
 
 The general concept is based on extending the device registration using a metadata-based approach. Microservices and agents that implement current device registrations can add custom forms to the device registration wizard by providing simple descriptions of the required registration attributes. The metadata is then used by the UI to render a corresponding device registration wizard.
 
 There are two possible ways to extend the UI:
-- with a [single device registration](/concepts/applications/#single-device-registration) form
-- with a [bulk device registration](/concepts/applications/#bulk-device-registration) form
+- with a [single device registration](#single-device-registration) form
+- with a [bulk device registration](#bulk-device-registration) form
 
 {{< c8y-admon-req >}}
-Extensible device registration requires [application extensions](/concepts/applications/#extension-enabling) to be defined, and the microservice to implement the predefined endpoints used for getting device registration metadata and creating the device.
+Extensible device registration requires [application extensions](#extension-enabling) to be defined, and the microservice to implement the predefined endpoints used for getting device registration metadata and creating the device.
 {{< /c8y-admon-req >}}
 
 ### Advantages of extended device registration {#advantages-of-extended-device-registration}
@@ -68,7 +68,7 @@ From now on, everything will be rendered based on data provided via the custom m
 
 `GET /service/<contextPath>/deviceRegistration/metadata&lang=<user-language>`
 
-Make use of the `lang` query parameter in your microservice to respond with the already translated JSON Schema metadata. See also [Limitations](/concepts/applications/#limitations).
+Make use of the `lang` query parameter in your microservice to respond with the already translated JSON Schema metadata. See also [Limitations](#limitations).
 
 
 The UI automatically takes the contextPath for the GET request from the application definition of the microservice:
@@ -126,7 +126,7 @@ The important part is the `pages` array which contains steps of the wizard that 
 
 As a result the following wizard will be displayed:
 
-![Select guide](/images/concepts-guide/extensible-device-registration/extensible-single-device-reg.png)
+![example-wizard-single](/images/concepts-guide/extensible-device-registration/extensible-single-device-reg.png)
 
 In the final step all data collected via the wizard will be sent back to the microservice using the following REST endpoint:
 
@@ -192,7 +192,7 @@ Additionally, the microservice provides the title of the wizard step and example
 
 As a result the following wizard will be displayed:
 
-![Select guide](/images/concepts-guide/extensible-device-registration/extensible-bulk-device-reg.png)
+![example-wizard-bulk](/images/concepts-guide/extensible-device-registration/extensible-bulk-device-reg.png)
 
 #### API specification {#api-specification}
 

--- a/content/device-management-application/registering-devices.md
+++ b/content/device-management-application/registering-devices.md
@@ -38,12 +38,7 @@ helpcontent:
     To register a device, click **Register device** at the right of the top bar, select an option from the dropdown list and follow the instructions in the device registration wizard."
 ---
 
-{{< c8y-admon-related >}}
-* [Device management & connectivity > Protocol integration](/protocol-integration/) for details on registering devices using various standard protocol types.
-* [Device management & connectivity > Device integration](/device-integration/device-integration-introduction/) for step-by-step instructions on registering devices.
-* [Device management & connectivity > Device integration > Device integration using REST](/device-integration/device-integration-rest/) for a detailed descriptions on device integration via REST.
-* The [New device requests API](https://{{< domain-c8y >}}/api/core/#tag/New-device-requests) for REST API methods concerning the creation of new devices.
-{{< /c8y-admon-related >}}
+### Overview
 
 In the **Device registration** page all devices are displayed which are currently in the registration process.
 
@@ -74,8 +69,15 @@ To register devices, you can select one of the following options:
 * **[Single device registration](#single-device-registration)** - to manually connect one device or several devices one by one.
 * **[Bulk device registration](#bulk-device-registration)** - to register larger amounts of devices in one step.
 
-Microservice developers can also use the [Extensible device registration](/concepts/applications/#extensible-device-registration) and implement a custom registration form that blends seamlessly into the UI.
+Microservice developers can also use the [Extensible device registration](#extensible-device-registration) and implement a custom registration form that blends seamlessly into the UI.
 
 {{< c8y-admon-info >}}
 The following descriptions apply to the general device registration processes. If you subscribe to specific protocol integrations, you will see additional protocol-specific options (for example, for LWM2M or OPC UA). A full list of supported protocols can be found in [Protocol integration](/protocol-integration/). It also contains descriptions for the protocol specific registration processes.
 {{< /c8y-admon-info >}}
+
+{{< c8y-admon-related >}}
+* [Device management & connectivity > Protocol integration](/protocol-integration/) for details on registering devices using various standard protocol types.
+* [Device management & connectivity > Device integration](/device-integration/device-integration-introduction/) for step-by-step instructions on registering devices.
+* [Device management & connectivity > Device integration > Device integration using REST](/device-integration/device-integration-rest/) for a detailed descriptions on device integration via REST.
+* The [New device requests API](https://{{< domain-c8y >}}/api/core/#tag/New-device-requests) for REST API methods concerning the creation of new devices.
+{{< /c8y-admon-related >}}

--- a/content/protocol-integration/lwm2m-bundle/registering-lwm2m-devices.md
+++ b/content/protocol-integration/lwm2m-bundle/registering-lwm2m-devices.md
@@ -437,7 +437,7 @@ The value must not exceed the maximum request timeout limit given in the LWM2M m
 <td style="text-align: left">Event log level</td>
 <td style="text-align: left">logLevel</td>
 <td style="text-align: left">String</td>
-<td style="text-align: left">{{< product-c8y-iot >}} can output detailed logs to the event stream. This field configures a log level. Allowed values are: 
+<td style="text-align: left">{{< product-c8y-iot >}} can output detailed logs to the event stream. This field configures a log level. Allowed values are:
 <b>NONE</b> (nothing will be logged as events), <b>LIFECYCLE</b> (only registration, de-registration and registration update events),
 <b>TRAFFIC</b> (LIFECYCLE + sent/received data), <b>FIRMWARE</b> (LIFECYCLE + detailed firmware update information),
 <b>VERBOSE</b> (all of the above will be logged).
@@ -499,7 +499,7 @@ Allowed values are PACKAGE or PACKAGE_URI. Depending on the value, the LWM2M age
 <td style="text-align: left">Firmware update URL (DEPRECATED)</td>
 <td style="text-align: left">fwUpdateURL</td>
 <td style="text-align: left">String</td>
-<td style="text-align: left"><b>DEPRECATED</b>: Use the regular firmware repository to specify the firmware version that links to an external URL. This field will be removed in a future update. 
+<td style="text-align: left"><b>DEPRECATED</b>: Use the regular firmware repository to specify the firmware version that links to an external URL. This field will be removed in a future update.
 
 Indicates the firmware update URL from where the LWM2M device can download the firmware package.</td>
 <td style="text-align: left">Optional</td>
@@ -522,7 +522,7 @@ Firmware updates are also supported for the registration of unsecured devices as
 
 #### Registering LWM2M devices using the REST API {#registering-lwm2m-devices-using-restapi}
 
-LWM2M internally uses our [Extensible Device Registration](/concepts/applications/#extensible-device-registration) feature. It provides an API based on JSON Schema and REST to extend {{< company-c8y >}} with arbitrary wizards for device registration.
+LWM2M internally uses our [Extensible device registration](/device-management-application/registering-devices/#extensible-device-registration) feature. It provides an API based on JSON Schema and REST to extend {{< company-c8y >}} with arbitrary wizards for device registration.
 
 #### REST-based single LWM2M device registration {#rest-lwm2m-single-registration}
 


### PR DESCRIPTION
Moved the content from https://cumulocity.com/docs/concepts/applications/#extensible-device-registration to the Device Management documentation.