### PR TITLE
Edge installation changes for minor issues found in user testing

### DIFF
--- a/content/edge-kubernetes/installing-edge-on-k8-bundle/prerequisites.md
+++ b/content/edge-kubernetes/installing-edge-on-k8-bundle/prerequisites.md
@@ -17,7 +17,7 @@ layout: redirect
 
 ### Special instructions for K3s {#special-instructions-for-k3s}
 
-To enable the proper functioning of the Edge operator on K3s, you must install K3s with the following configuration options.
+Make configuration changes to your operating system to work with K3S as per [Requirements](https://docs.k3s.io/installation/requirements#operating-systems). To enable the proper functioning of the Edge operator on K3s, you must install K3s with specific configuration options.
 
 Run the command below to install Kubernetes version 1.25.13:
 
@@ -44,9 +44,9 @@ sudo sh -c '
 
     printf "\e[32mSuccessfully installed k3s!\e[0m\n" && \
     
-    k3s crictl pull rancher/klipper-lb:v0.4.4 && \
-    k3s crictl pull rancher/mirrored-metrics-server:v0.6.3 && \
-    k3s crictl pull rancher/local-path-provisioner:v0.0.24
+    /usr/local/bin/k3s crictl pull rancher/klipper-lb:v0.4.4 && \
+    /usr/local/bin/k3s crictl pull rancher/mirrored-metrics-server:v0.6.3 && \
+    /usr/local/bin/k3s crictl pull rancher/local-path-provisioner:v0.0.24
 '
 ```
 

--- a/content/edge-kubernetes/quickstart.md
+++ b/content/edge-kubernetes/quickstart.md
@@ -10,7 +10,9 @@ This section helps you to quickly install Edge on a [Lightweight Kubernetes (K3s
 
 1. Verify that your hardware meets the requirements specified in [Prerequisites](/edge-kubernetes/installing-edge-on-k8/#prerequisites).
 
-2. Run the command below to install K3s.
+2. Make configuration changes to your operating system to work with K3S as per [Requirements](https://docs.k3s.io/installation/requirements#operating-systems). 
+
+3. Run the command below to install K3s.
 
    ```shell
    USER_NAME=$(whoami)
@@ -35,28 +37,28 @@ This section helps you to quickly install Edge on a [Lightweight Kubernetes (K3s
 
       printf "\e[32mSuccessfully installed k3s!\e[0m\n" && \
       
-      k3s crictl pull rancher/klipper-lb:v0.4.4 && \
-      k3s crictl pull rancher/mirrored-metrics-server:v0.6.3 && \
-      k3s crictl pull rancher/local-path-provisioner:v0.0.24
+      /usr/local/bin/k3s crictl pull rancher/klipper-lb:v0.4.4 && \
+      /usr/local/bin/k3s crictl pull rancher/mirrored-metrics-server:v0.6.3 && \
+      /usr/local/bin/k3s crictl pull rancher/local-path-provisioner:v0.0.24
    '
    ```
 
-3. Run the command below to install Helm v3.
+4. Run the command below to install Helm v3.
 
    ```shell
    curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
    ```
 
-4. Run the command below to install the Edge operator and provide the registry credentials when prompted.
+5. Run the command below to install the Edge operator and provide the registry credentials when prompted.
 
    ```shell
    curl -sfL {{< link-c8y-doc-baseurl >}}files/edge-k8s/c8yedge-operator-install.sh -O && bash ./c8yedge-operator-install.sh
    ```
 
-5. Run the command below to apply Edge CR ([c8yedge-sample.yaml](/files/edge-k8s/c8yedge-sample.yaml)) for installing Edge version **{{< c8y-edge-current-version >}}.0.1** named **c8yedge** with the domain **myown.iot.com**.
+6. Run the command below to apply Edge CR ([c8yedge-sample.yaml](/files/edge-k8s/c8yedge-sample.yaml)) for installing Edge version **{{< c8y-edge-current-version >}}.0.1** named **c8yedge** with the domain **myown.iot.com**.
 
    ```shell
    kubectl apply -f {{< link-c8y-doc-baseurl >}}files/edge-k8s/c8yedge-sample.yaml
    ```
 
-6. See [Verifying the Edge installation](/edge-kubernetes/installing-edge-on-k8/#verifying-the-edge-installation) and [Accessing Edge](/edge-kubernetes/installing-edge-on-k8/#accessing-edge) to sign into Edge.
+7. See [Verifying the Edge installation](/edge-kubernetes/installing-edge-on-k8/#verifying-the-edge-installation) and [Accessing Edge](/edge-kubernetes/installing-edge-on-k8/#accessing-edge) to sign into Edge.

--- a/static/files/edge-k8s/c8yedge-operator-install.sh
+++ b/static/files/edge-k8s/c8yedge-operator-install.sh
@@ -136,4 +136,5 @@ helm upgrade --install c8yedge-operator oci://${C8YEDGE_REGISTRY_HOST}/edge/helm
     --set image.pullPolicy="${C8YEDGE_IMAGE_PULL_POLICY}" \
     --set imageCredentials.registry="${C8YEDGE_REGISTRY_HOST}" \
     --set imageCredentials.username="${C8YEDGE_REGISTRY_USERNAME}" \
-    --set imageCredentials.password="${C8YEDGE_REGISTRY_PASSWORD}"
+    --set imageCredentials.password="${C8YEDGE_REGISTRY_PASSWORD}" \
+    --wait


### PR DESCRIPTION
- In some environments, the newly installed k3s wasn't on the path, make the path explicit.
- We found that in some cases, it's really important to follow the k3s OS requirements e.g. the RHEL default firewall settings upsets k3s.
- If you apply an Edge CR immediately after installing the operator, there is a race condition resulting in an error where the webhook can't be reached. Changing the `helm upgrade` command to use `--wait` means that the operator installation waits until all services (including the webhook) are ready.