### PR TITLE
[MTM 62462] vulnerabilities identified in microservice sdk 2025

### DIFF
--- a/content/change-logs/application-enablement/cumulocity-2025-18-0-microservices-sdk-spring-boot-34.md
+++ b/content/change-logs/application-enablement/cumulocity-2025-18-0-microservices-sdk-spring-boot-34.md
@@ -11,14 +11,14 @@ component:
 build_artifact:
   - value: tc-QHwMfWtBk7
     label: cumulocity
-version: 2025.18.0
+version: 2025.0.12
 ticket: MTM-62462
 ---
-Starting from version **2025.18.0**, the Microservice SDK is now using Spring Boot 3.4.2. 
+Starting from version **2025.0.12**, the Microservice SDK is now using Spring Boot 3.4.2. 
 Notice that along with Spring Boot, most other dependencies were also updated to be consistent to 
 the dependencies which Spring Boot uses.
 
-The version 2025.18.0 will also bring along updates to several third-party libraries and frameworks.
+The version 2025.0.12 will also bring along updates to several third-party libraries and frameworks.
 These changes will be included in the org.springframework.boot:spring-boot-dependencies:3.4.2 dependency 
 which comes with Microservice SDK.
 


### PR DESCRIPTION
Updated the version of the backport pull request to 2025.0.12.
relates to 
* https://github.com/Cumulocity-IoT/c8y-docs/pull/3112
(version not updated from original PR which is for develop)
*  - [Merge pull request #3080 from Cumulocity-IoT/bugfix/MTM-62462/vulnerabilities-identified-in-Mmcroservice-sdk](https://github.com/Cumulocity-IoT/c8y-docs/pull/3080)
