### PR TITLE
[MTM-62765] Certificate authority feature preview

### DIFF
--- a/content/change-logs/platform-services/cumulocity-undefined-certificate-authority-feature-preview.md
+++ b/content/change-logs/platform-services/cumulocity-undefined-certificate-authority-feature-preview.md
@@ -1,5 +1,5 @@
 ---
-date: '2025-04-01'
+date: '2025-04-17'
 title: Enhanced certificate management with ability to sign and issue certificates
 product_area: Platform services
 change_type:
@@ -15,6 +15,8 @@ ticket: MTM-62765
 ---
 {{< c8y-admon-preview >}}
 This feature is in Public Preview, that is, it is not enabled by default and may be subject to change in the future.
+
+In order to determine if the feature is enabled go to the Device Management app and look at the Management/Trusted Certificates page. If on the top right of the page you see `Add CA Certificate` then the feature is enabled. If it is not enabled please contact Global Support to request the feature to be enabled.
 {{< /c8y-admon-preview >}}
 
 {{< product-c8y-iot >}} has has been enhanced to function as a Certificate Authority (CA), providing the following capabilities:

--- a/content/change-logs/platform-services/cumulocity-undefined-certificate-authority-feature-preview.md
+++ b/content/change-logs/platform-services/cumulocity-undefined-certificate-authority-feature-preview.md
@@ -16,7 +16,7 @@ ticket: MTM-62765
 {{< c8y-admon-preview >}}
 This feature is in Public Preview, that is, it is not enabled by default and may be subject to change in the future.
 
-In order to determine if the feature is enabled go to the Device Management app and look at the Management/Trusted Certificates page. If on the top right of the page you see `Add CA Certificate` then the feature is enabled. If it is not enabled please contact Global Support to request the feature to be enabled.
+To determine whether the feature is enabled, go to the Device Management application and navigate to Management → Trusted Certificates. If you see Add CA Certificate in the top-right corner of the page, the feature is enabled. If it is not enabled, please use the Feature Toggles REST endpoints or contact Global Support to enable the feature.
 {{< /c8y-admon-preview >}}
 
 {{< product-c8y-iot >}} has has been enhanced to function as a Certificate Authority (CA), providing the following capabilities:

--- a/content/change-logs/platform-services/cumulocity-undefined-certificate-authority-feature-preview.md
+++ b/content/change-logs/platform-services/cumulocity-undefined-certificate-authority-feature-preview.md
@@ -23,4 +23,4 @@ This feature is in Public Preview, that is, it is not enabled by default and may
 - Perform legitimacy checks, as defined by each tenant
 - Issue signed X.509 certificates trusted by the device tenant
 
-For more details about this feature refer to [Certificate Authority (CA)](/device-integration/certificate-authority-bundle/create-certificate-authority.md)
+For more details about this feature refer to [Certificate Authority (CA)](/device-integration/certificate-authority-bundle/create-certificate-authority.md).

--- a/content/change-logs/platform-services/cumulocity-undefined-certificate-authority-feature-preview.md
+++ b/content/change-logs/platform-services/cumulocity-undefined-certificate-authority-feature-preview.md
@@ -14,7 +14,13 @@ build_artifact:
 ticket: MTM-62765
 ---
 {{< c8y-admon-preview >}}
-This feature is in Public Preview, that is, it is not enabled by default and maybe subject to change in the future.
+This feature is in Public Preview, that is, it is not enabled by default and may be subject to change in the future.
 {{< /c8y-admon-preview >}}
 
-{{< product-c8y-iot >}} has enhanced the certificate management with the ability for {{< product-c8y-iot >}} to sign and issue certificates. This means that the list of certificates in a tenant, which previously only contained the  trust anchor certificates, does now also include the {{< product-c8y-iot >}} signed certificates. The latter are identifiable by the words TENANT CA.
+{{< product-c8y-iot >}} has has been enhanced to function as a Certificate Authority (CA), providing the following capabilities:
+- Manage signing certificates
+- Accept Certificate Signing Requests (CSR)
+- Perform legitimacy checks, as defined by each tenant
+- Issue signed X.509 certificates trusted by the device tenant
+
+For more details about this feature refer to [Certificate Authority (CA)](/device-integration/certificate-authority-bundle/create-certificate-authority.md)

--- a/content/change-logs/platform-services/cumulocity-undefined-certificate-authority-feature-preview.md
+++ b/content/change-logs/platform-services/cumulocity-undefined-certificate-authority-feature-preview.md
@@ -1,0 +1,20 @@
+---
+date: '2025-04-01'
+title: Enhanced certificate management with ability to sign and issue certificates
+product_area: Platform services
+change_type:
+  - value: change-pXAlHAWka
+    label: Preview
+component:
+  - value: q3kclF6pO
+    label: Authentication
+build_artifact:
+  - value: tc-QHwMfWtBk7
+    label: cumulocity
+ticket: MTM-62765
+---
+{{< c8y-admon-preview >}}
+This feature is in Public Preview, that is, it is not enabled by default and maybe subject to change in the future.
+{{< /c8y-admon-preview >}}
+
+{{< product-c8y-iot >}} has enhanced the certificate management with the ability for {{< product-c8y-iot >}} to sign and issue certificates. This means that the list of certificates in a tenant, which previously only contained the  trust anchor certificates, does now also include the {{< product-c8y-iot >}} signed certificates. The latter are identifiable by the words TENANT CA.


### PR DESCRIPTION
Feature preview for Certificate Management System (CMS) a.k.a Certificate Authority

- Category: We need to announce this under Preview, not Feature (at least initially).
- Date: The public preview is set to start in April. Currently this feature is not available.