### PR TITLE
[MTM-62399] RN Enhanced Security for Encrypted Tenant Options

### DIFF
--- a/content/change-logs/platform-services/cumulocity-2025.116.0-Enhanced-security-encrypted-tenant-options.md
+++ b/content/change-logs/platform-services/cumulocity-2025.116.0-Enhanced-security-encrypted-tenant-options.md
@@ -12,7 +12,7 @@ build_artifact:
   - value: tc-QHwMfWtBk7
     label: cumulocity
 ticket: MTM-62399
-version: 2025.tbd.0
+version: 2025.116.0
 ---
 Security improvements have been implemented for decrypting encrypted tenant options with the `credentials.` prefix. Encrypted tenant options with this prefix can only be decrypted by system users (such as bootstrap user and microservice user) if they own those tenant options. This new restriction determines ownership by matching the category of the tenant options in the following order of priority:
 * The category defined in the `settingsCategory` field in the microservice manifest.

--- a/content/change-logs/platform-services/cumulocity-2025.116.0-Enhanced-security-encrypted-tenant-options.md
+++ b/content/change-logs/platform-services/cumulocity-2025.116.0-Enhanced-security-encrypted-tenant-options.md
@@ -19,4 +19,4 @@ Security improvements have been implemented for decrypting encrypted tenant opti
 * The microservice’s context-path.
 * The microservice name.
 
-**Note**: To assist users who may rely on the old behaviour, there is the ability to revert to the previous behaviour using feature toggle api.
+**Note**: To assist users who may rely on the old behaviour, there is the ability to revert to the previous behaviour using a feature toggle via API.

--- a/content/change-logs/platform-services/cumulocity-2025.116.0-Enhanced-security-encrypted-tenant-options.md
+++ b/content/change-logs/platform-services/cumulocity-2025.116.0-Enhanced-security-encrypted-tenant-options.md
@@ -18,3 +18,5 @@ Security improvements have been implemented for decrypting encrypted tenant opti
 * The category defined in the `settingsCategory` field in the microservice manifest.
 * The microservice’s context-path.
 * The microservice name.
+
+**Note**: To assist users who may rely on the old behaviour, there is the ability to revert to the previous behaviour using feature toggle api.

--- a/content/change-logs/platform-services/cumulocity-2025.tbd.0-Enhanced-security-encrypted-tenant-options.md
+++ b/content/change-logs/platform-services/cumulocity-2025.tbd.0-Enhanced-security-encrypted-tenant-options.md
@@ -14,7 +14,7 @@ build_artifact:
 ticket: MTM-62399
 version: 2025.tbd.0
 ---
-Encrypted tenant options with the prefix `credentials.` can only be decrypted by system users (such as bootstrap user and microservice user) if they own those tenant options. This new restriction determines ownership by matching the category of the tenant options in the following order of priority:
+Security improvements have been implemented for decrypting encrypted tenant options with the `credentials.` prefix. Encrypted tenant options with this prefix can only be decrypted by system users (such as bootstrap user and microservice user) if they own those tenant options. This new restriction determines ownership by matching the category of the tenant options in the following order of priority:
 * The category defined in the `settingsCategory` field in the microservice manifest.
 * The microservice’s context-path.
 * The microservice name.

--- a/content/change-logs/platform-services/cumulocity-2025.tbd.0-Enhanced-security-encrypted-tenant-options.md
+++ b/content/change-logs/platform-services/cumulocity-2025.tbd.0-Enhanced-security-encrypted-tenant-options.md
@@ -1,6 +1,6 @@
 ---
-date: '2025-03-31'
-title: Enhanced Security for Encrypted Tenant Options
+date: 
+title: Enhanced security for encrypted tenant options
 product_area: Platform services
 change_type:
   - value: change-VSkj2iV9m
@@ -15,6 +15,6 @@ ticket: MTM-62399
 version: 2025.tbd.0
 ---
 Encrypted tenant options with the prefix `credentials.` can only be decrypted by system users (such as bootstrap user and microservice user) if they own those tenant options. This new restriction determines ownership by matching the category of the tenant options in the following order of priority:
-* The category defined in the settingsCategory field in the microservice manifest.
+* The category defined in the `settingsCategory` field in the microservice manifest.
 * The microservice’s context-path.
 * The microservice name.

--- a/content/change-logs/platform-services/cumulocity-2025.tbd.0-Enhanced-security-encrypted-tenant-options.md
+++ b/content/change-logs/platform-services/cumulocity-2025.tbd.0-Enhanced-security-encrypted-tenant-options.md
@@ -1,0 +1,20 @@
+---
+date: '2025-03-31'
+title: Enhanced Security for Encrypted Tenant Options
+product_area: Platform services
+change_type:
+  - value: change-VSkj2iV9m
+    label: Fix
+component:
+  - value: component-JlFdtOPva
+    label: Rest API
+build_artifact:
+  - value: tc-QHwMfWtBk7
+    label: cumulocity
+ticket: MTM-62399
+version: 2025.tbd.0
+---
+Encrypted tenant options with the prefix `credentials.` can only be decrypted by system users (such as bootstrap user and microservice user) if they own those tenant options. This new restriction determines ownership by matching the category of the tenant options in the following order of priority:
+* The category defined in the settingsCategory field in the microservice manifest.
+* The microservice’s context-path.
+* The microservice name.


### PR DESCRIPTION
RN for core changes: https://github.com/Cumulocity-IoT/cumulocity-core/pull/3479
This is the second step together with https://github.com/Cumulocity-IoT/cumulocity-core/pull/3424/files. (where microservice can not have the same settings category that already exists)
**For reviewers:**
This 'fix' resolves an issue when the microservice service/bootstrap user with OPTION_READ can retrieve all encoded tenant options in decrypted form within a tenant.
Now, the user will be able to decode **only options that match the ms category.** (firstNonBlank(getManifest().getSettingsCategory(), getContextPath(), getName());
The whole change can be rolled back using a feature toogle.

More context: Poposal 3
https://docs.google.com/document/d/1elo9j34yqp5TLFLKdbgBX5LZiq8hP-clfjtVfmnWMlo/edit?tab=t.0