### PR TITLE
MTM-62950 - Binary Search returns wrong results - update release notes

### DIFF
--- a/content/change-logs/platform-services/cumulocity-20-25-100-0-binaries-api-ids-filter-fix.md
+++ b/content/change-logs/platform-services/cumulocity-20-25-100-0-binaries-api-ids-filter-fix.md
@@ -1,6 +1,6 @@
 ---
 date:
-title: Fixed an issue with retrieving stored files metadata by ids
+title: Correct data returned when retrieving stored file metadata by ID
 product_area: Platform services
 change_type:
   - value: change-VSkj2iV9m
@@ -14,5 +14,4 @@ build_artifact:
 ticket: MTM-62950
 version: 2025.100.0
 ---
-Fixed an issue with the endpoint for retrieving [stored files metadata](https://{{< domain-c8y >}}/api/core/#operation/getBinariesCollectionResource) 
-not returning any results when `ids` filter is used.
+Previously, the endpoint for retrieving [stored files metadata](https://{{< domain-c8y >}}/api/core/#operation/getBinariesCollectionResource) did not return the correct data when filtering by ID. This issue has been fixed and the correct data is now returned.


### PR DESCRIPTION
This PR aligns release notes in develop with changes done in y2025 branch: https://github.com/Cumulocity-IoT/c8y-docs/pull/3129