### PR TITLE
[MTM-62399] Extend documentation for Enhance-security-for-encrypted-t…

### DIFF
--- a/content/microservice-sdk/general-aspects-bundle/security.md
+++ b/content/microservice-sdk/general-aspects-bundle/security.md
@@ -208,6 +208,7 @@ There is a mechanism to encrypt the tenant options that afterwards are automatic
 If a tenant option is created with a key name that starts with "credentials.", it is automatically encrypted and can be fetched as unencrypted only by system users. For instance, when you create a tenant option in a category that matches to the application context path, the value is passed to the microservice by the microservice proxy on the platform as a header (key => value). All encrypted options are decrypted and passed. Note that therefore a space (" ") is not allowed as a tenant option value. 
 
 The options can be fetched via REST using the options endpoint at microservice runtime. Encrypted options are decrypted only if the tenant option category matches the category defined by the microservice. This category is determined based on the first non-blank value from:
+
 1. The manifest settings category
 2. The context path
 3. The service name

--- a/content/microservice-sdk/general-aspects-bundle/security.md
+++ b/content/microservice-sdk/general-aspects-bundle/security.md
@@ -206,7 +206,8 @@ Steps:
 There is a mechanism to encrypt the tenant options that afterwards are automatically decrypted when injecting them into microservices requests.
 
 If a tenant option is created with a key name that starts with "credentials.", it is automatically encrypted and can be fetched as unencrypted only by system users. For instance, when you create a tenant option in a category that matches to the application context path, the value is passed to the microservice by the microservice proxy on the platform as a header (key => value). All encrypted options are decrypted and passed. Note that therefore a space (" ") is not allowed as a tenant option value. 
-Moreover, the options can be fetched via REST using the options endpoint at microservice runtime. Encrypted options are decrypted only if the tenant option category matches the category defined by the microservice. This category is determined based on the first non-blank value from:
+
+The options can be fetched via REST using the options endpoint at microservice runtime. Encrypted options are decrypted only if the tenant option category matches the category defined by the microservice. This category is determined based on the first non-blank value from:
 1. The manifest settings category
 2. The context path
 3. The service name

--- a/content/microservice-sdk/general-aspects-bundle/security.md
+++ b/content/microservice-sdk/general-aspects-bundle/security.md
@@ -205,6 +205,10 @@ Steps:
 
 There is a mechanism to encrypt the tenant options that afterwards are automatically decrypted when injecting them into microservices requests.
 
-If a tenant option is created with a key name that starts with "credentials.", it is automatically encrypted and can be fetched as unencrypted only by system users. For instance, when you create a tenant option in a category that matches to the application context path, the value is passed to the microservice by the microservice proxy on the platform as a header (key => value). Note that therefore a space (" ") is not allowed as a tenant option value. All encrypted options are decrypted and passed. Moreover, the options can be fetched via REST using the options endpoint at microservice runtime.
+If a tenant option is created with a key name that starts with "credentials.", it is automatically encrypted and can be fetched as unencrypted only by system users. For instance, when you create a tenant option in a category that matches to the application context path, the value is passed to the microservice by the microservice proxy on the platform as a header (key => value). All encrypted options are decrypted and passed. Note that therefore a space (" ") is not allowed as a tenant option value. 
+Moreover, the options can be fetched via REST using the options endpoint at microservice runtime. Encrypted options are decrypted only if the tenant option category matches the category defined by the microservice. This category is determined based on the first non-blank value from:
+1. The manifest settings category
+2. The context path
+3. The service name
 
 Refer to tenant options in the [Tenant API](https://{{< domain-c8y >}}/api/core/#tag/Options) in the {{< openapi >}} for more details.


### PR DESCRIPTION
**For reviewers:** reading encoded tenant options has been fixed hence this change in documentation.

Currently a microservice user will not be able to decrypt all tenant options, and will only decrypt tenant options that belong to the microservice category.