### PR TITLE
[MTM-62711] settingsCategory in ms manifest must be unique within the…

### DIFF
--- a/content/microservice-sdk/java-bundle/developing-microservice.md
+++ b/content/microservice-sdk/java-bundle/developing-microservice.md
@@ -253,7 +253,7 @@ The microservice settings module provides two features:
 
 By default the microservice loads the tenant options for the category specified by the microservice context path.
 The custom settings category can be specified by the manifest parameter: `settingsCategory`.
-Note that defined tenant option category must be unique within the tenant.
+Note that the defined tenant option category must be unique within the tenant.
 When neither settings category nor context path is provided in the microservice manifest, the application name is used.
 
 {{< c8y-admon-info >}}

--- a/content/microservice-sdk/java-bundle/developing-microservice.md
+++ b/content/microservice-sdk/java-bundle/developing-microservice.md
@@ -253,6 +253,7 @@ The microservice settings module provides two features:
 
 By default the microservice loads the tenant options for the category specified by the microservice context path.
 The custom settings category can be specified by the manifest parameter: `settingsCategory`.
+Note that defined tenant option category must be unique within the tenant.
 When neither settings category nor context path is provided in the microservice manifest, the application name is used.
 
 {{< c8y-admon-info >}}


### PR DESCRIPTION
For reviewers: Microservice manifest validator, check if settingsCategory is unique. It is necessary for improve the security of encrypted tenant options. A microservice user will be able to encode encrypted tenant options only from ms
Related core changes; https://github.com/Cumulocity-IoT/cumulocity-core/pull/3424