### PR TITLE
[EDGE] CIE-5382 Correct operator clusterrole patch command 

### DIFF
--- a/content/edge-kubernetes/manage-edge-bundle/version-upgrade.md
+++ b/content/edge-kubernetes/manage-edge-bundle/version-upgrade.md
@@ -12,7 +12,7 @@ For this example, assume that Edge is deployed using the [c8yedge-sample.yaml](/
 
 ### Upgrading from Edge version 10.18
 
-Before upgrading Edge to `{{< c8y-edge-version-major >}}`, run the following command to patch the `c8yedge-operator-manager-role` ClusterRole with the necessary permissions:
+Before upgrading Edge to `{{< c8y-edge-version-major >}}`, run the following command to patch the [`c8yedge-operator-manager-role`]({{< link-c8y-doc-baseurl >}}files/edge-k8s/c8yedge-operator-cluster-role-patch-1018.yaml) ClusterRole with the necessary permissions:
 
 ```bash
 kubectl patch clusterrole c8yedge-operator-manager-role --patch --type='json' "$(curl -s {{< link-c8y-doc-baseurl >}}files/edge-k8s/c8yedge-operator-cluster-role-patch-1018.yaml)"

--- a/content/edge-kubernetes/manage-edge-bundle/version-upgrade.md
+++ b/content/edge-kubernetes/manage-edge-bundle/version-upgrade.md
@@ -15,7 +15,7 @@ For this example, assume that Edge is deployed using the [c8yedge-sample.yaml](/
 Before upgrading Edge to `{{< c8y-edge-version-major >}}`, run the following command to patch the `c8yedge-operator-manager-role` ClusterRole with the necessary permissions:
 
 ```bash
-kubectl patch clusterrole c8yedge-operator-manager-role --type='json' --patch-file {{< link-c8y-doc-baseurl >}}files/edge-k8s/c8yedge-operator-cluster-role-patch-1018.yaml
+kubectl patch clusterrole c8yedge-operator-manager-role --patch --type='json' "$(curl -s {{< link-c8y-doc-baseurl >}}files/edge-k8s/c8yedge-operator-cluster-role-patch-1018.yaml)"
 ```
 This step is required to ensure the Edge operator can properly enforce validation and mutation rules when updating the Edge CR.
 

--- a/content/edge-kubernetes/manage-edge-bundle/version-upgrade.md
+++ b/content/edge-kubernetes/manage-edge-bundle/version-upgrade.md
@@ -15,7 +15,7 @@ For this example, assume that Edge is deployed using the [c8yedge-sample.yaml](/
 Before upgrading Edge to `{{< c8y-edge-version-major >}}`, run the following command to patch the [`c8yedge-operator-manager-role`]({{< link-c8y-doc-baseurl >}}files/edge-k8s/c8yedge-operator-cluster-role-patch-1018.yaml) ClusterRole with the necessary permissions:
 
 ```bash
-kubectl patch clusterrole c8yedge-operator-manager-role --patch --type='json' "$(curl -s {{< link-c8y-doc-baseurl >}}files/edge-k8s/c8yedge-operator-cluster-role-patch-1018.yaml)"
+kubectl patch clusterrole c8yedge-operator-manager-role --type='json' --patch "$(curl -s {{< link-c8y-doc-baseurl >}}files/edge-k8s/c8yedge-operator-cluster-role-patch-1018.yaml)"
 ```
 This step is required to ensure the Edge operator can properly enforce validation and mutation rules when updating the Edge CR.
 


### PR DESCRIPTION
Current operator cluster role patch command, which needs to be executed before upgrading 1018.0.1 to 2025.0.0 is incorrect. The --patch-file flag in kubectl expects a local file, not a URL.