### PR TITLE
[MTM-62399] Enhance security for encrypted tenant options future anno…

### DIFF
--- a/content/change-logs/platform-services/cumulocity-2025-116-0-enhanced-security-for-encrypted-tenant-options.md
+++ b/content/change-logs/platform-services/cumulocity-2025-116-0-enhanced-security-for-encrypted-tenant-options.md
@@ -22,6 +22,6 @@ Ownership is determined based on the category of the tenant option, in the follo
 2. The microservice’s context path.
 3. The microservice name.
 
-This change is currently **disabled by default** and can be **enabled via a feature toggle** "secure-tenant-options" through the [API](https://cumulocity.com/api/core/#operation/setCurrentTenantFeatureToggleValue)
+This change is currently disabled by default and can be enabled via a feature toggle "secure-tenant-options" through the [API](https://cumulocity.com/api/core/#operation/setCurrentTenantFeatureToggleValue).
 
 > ⚠️ **Important:** In Q4 2025 for the SaaS instances and in 2026 for the yearly releases, this restriction will become **mandatory**. We strongly recommend reviewing your microservices now to ensure compatibility with the upcoming enforcement. This gives microservice developers time to adapt, especially if their services depend on reading `credentials.*` options in categories **not owned** by the microservice.

--- a/content/change-logs/platform-services/cumulocity-2025-116-0-enhanced-security-for-encrypted-tenant-options.md
+++ b/content/change-logs/platform-services/cumulocity-2025-116-0-enhanced-security-for-encrypted-tenant-options.md
@@ -24,4 +24,6 @@ Ownership is determined based on the category of the tenant option, in the follo
 
 This change is currently disabled by default and can be enabled via a feature toggle "secure-tenant-options" through the [API](https://cumulocity.com/api/core/#operation/setCurrentTenantFeatureToggleValue).
 
-> ⚠️ **Important:** In Q4 2025 for the SaaS instances and in 2026 for the yearly releases, this restriction will become **mandatory**. We strongly recommend reviewing your microservices now to ensure compatibility with the upcoming enforcement. This gives microservice developers time to adapt, especially if their services depend on reading `credentials.*` options in categories **not owned** by the microservice.
+{{< c8y-admon-important >}}
+In Q4 2025 for the SaaS instances and in 2026 for the yearly releases, this restriction will become **mandatory**. We strongly recommend reviewing your microservices now to ensure compatibility with the upcoming enforcement. This gives microservice developers time to adapt, especially if their services depend on reading `credentials.*` options in categories **not owned** by the microservice.
+{{< /c8y-admon-important >}}

--- a/content/change-logs/platform-services/cumulocity-2025-116-0-enhanced-security-for-encrypted-tenant-options.md
+++ b/content/change-logs/platform-services/cumulocity-2025-116-0-enhanced-security-for-encrypted-tenant-options.md
@@ -1,0 +1,27 @@
+---
+date: 2025-04-28
+title: Enhanced security for encrypted tenant options
+product_area: Platform services
+change_type:
+  - value: change-3BQrQ6adS
+    label: API change
+component:
+  - value: component-JlFdtOPva
+    label: REST API
+build_artifact:
+  - value: tc-QHwMfWtBk7
+    label: cumulocity
+ticket: MTM-62399
+version: 2025.116.0
+---
+A new **security feature** has been introduced to restrict the decryption of encrypted tenant options with the `credentials.` prefix. These options can now **only be decrypted by system users (e.g., bootstrap or microservice users)** **if they own the options**.
+
+Ownership is determined based on the category of the tenant option, in the following priority:
+
+1. The `settingsCategory` defined in the microservice manifest.
+2. The microservice’s context path.
+3. The microservice name.
+
+This change is currently **disabled by default** and can be **enabled via a feature toggle** "secure-tenant-options" through the [API](https://cumulocity.com/api/core/#operation/setCurrentTenantFeatureToggleValue)
+
+> ⚠️ **Important:** In Q4 2025 for the SaaS instances and in 2026 for the yearly releases, this restriction will become **mandatory**. We strongly recommend reviewing your microservices now to ensure compatibility with the upcoming enforcement. This gives microservice developers time to adapt, especially if their services depend on reading `credentials.*` options in categories **not owned** by the microservice.

--- a/content/change-logs/platform-services/cumulocity-2025-116-0-enhanced-security-for-encrypted-tenant-options.md
+++ b/content/change-logs/platform-services/cumulocity-2025-116-0-enhanced-security-for-encrypted-tenant-options.md
@@ -14,7 +14,7 @@ build_artifact:
 ticket: MTM-62399
 version: 2025.116.0
 ---
-A new **security feature** has been introduced to restrict the decryption of encrypted tenant options with the `credentials.` prefix. These options can now **only be decrypted by system users (e.g., bootstrap or microservice users)** **if they own the options**.
+A new security feature has been introduced to restrict the decryption of encrypted tenant options with the `credentials.` prefix. These options can now only be decrypted by system users (such as bootstrap or microservice users) if they own the options.
 
 Ownership is determined based on the category of the tenant option, in the following priority:
 

--- a/content/change-logs/platform-services/cumulocity-2025-116-0-enhanced-security-for-encrypted-tenant-options.md
+++ b/content/change-logs/platform-services/cumulocity-2025-116-0-enhanced-security-for-encrypted-tenant-options.md
@@ -22,7 +22,7 @@ Ownership is determined based on the category of the tenant option, in the follo
 2. The microservice’s context path.
 3. The microservice name.
 
-This change is currently disabled by default and can be enabled via a feature toggle "secure-tenant-options" through the [API](https://cumulocity.com/api/core/#operation/setCurrentTenantFeatureToggleValue).
+This change is currently disabled by default and can be enabled via a feature toggle `secure-tenant-options` through the [API](https://cumulocity.com/api/core/#operation/setCurrentTenantFeatureToggleValue).
 
 {{< c8y-admon-important >}}
 In Q4 2025 for the SaaS instances and in 2026 for the yearly releases, this restriction will become **mandatory**. We strongly recommend reviewing your microservices now to ensure compatibility with the upcoming enforcement. This gives microservice developers time to adapt, especially if their services depend on reading `credentials.*` options in categories **not owned** by the microservice.

--- a/content/change-logs/platform-services/cumulocity-2025-116-0-enhanced-security-for-encrypted-tenant-options.md
+++ b/content/change-logs/platform-services/cumulocity-2025-116-0-enhanced-security-for-encrypted-tenant-options.md
@@ -14,7 +14,7 @@ build_artifact:
 ticket: MTM-62399
 version: 2025.116.0
 ---
-A new security feature has been introduced to restrict the decryption of encrypted tenant options with the `credentials.` prefix. These options can now only be decrypted by system users (such as bootstrap or microservice users) if they own the options.
+A new security feature has been introduced to restrict the decryption of encrypted [tenant options](https://cumulocity.com/api/core/#tag/Options) with the `credentials.` prefix. These options can now only be decrypted by system users (such as bootstrap or microservice users) if they own the options.
 
 Ownership is determined based on the category of the tenant option, in the following priority:
 


### PR DESCRIPTION
Initially, this feature was announced and enabled by default; however, on eu-latest, it turned out that[ it causes many problems and cannot be enabled by default](https://chat.google.com/room/AAAAvnc5o90/CNsW9_pTASY/CNsW9_pTASY?cls=10). That is why this announcement-breaking change was created.

The proposed date for enabling this feature by default is the end of this year.
(Q4 2025 for the SaaS instances and in 2026 for the yearly releases)

Please let me know if anything is missing from this announcement
@Michael-Gesmann
@JanePorter 
@switschel 
@janhommes 