### PR TITLE
[no-issue] Fix invalid json issue with monitoring.

### DIFF
--- a/content/standard-tenant/monitoring.md
+++ b/content/standard-tenant/monitoring.md
@@ -7,5 +7,6 @@ outputs:
   - json
 sector:
   - platform_administration
+bundlefolder: monitoring
 ---
 Monitoring covers operational health and user activity tracking. This helps administrators to proactively manage the system, ensure stability, maintain security, and diagnose issues efficiently across different components.

--- a/content/standard-tenant/monitoring.md
+++ b/content/standard-tenant/monitoring.md
@@ -7,8 +7,5 @@ outputs:
   - json
 sector:
   - platform_administration
-helpcontent:
-  - label: monitoring
-    title: Monitoring
-    content: "Monitoring covers operational health and user activity tracking. This helps administrators to proactively manage the system, ensure stability, maintain security, and diagnose issues efficiently across different components."
+bundlefolder: monitoring
 ---

--- a/content/standard-tenant/monitoring.md
+++ b/content/standard-tenant/monitoring.md
@@ -7,6 +7,5 @@ outputs:
   - json
 sector:
   - platform_administration
-bundlefolder: monitoring
 ---
 Monitoring covers operational health and user activity tracking. This helps administrators to proactively manage the system, ensure stability, maintain security, and diagnose issues efficiently across different components.

--- a/content/standard-tenant/monitoring.md
+++ b/content/standard-tenant/monitoring.md
@@ -9,3 +9,4 @@ sector:
   - platform_administration
 bundlefolder: monitoring
 ---
+Monitoring covers operational health and user activity tracking. This helps administrators to proactively manage the system, ensure stability, maintain security, and diagnose issues efficiently across different components.


### PR DESCRIPTION
there is a problem on UI with docs. When we try to get audit logs docs, we make call to `https://cumulocity.com/docs/standard-tenant/monitoring/index.json` but we get invalid json
![image](https://github.com/user-attachments/assets/f58aa8a8-15a9-4e6a-b457-8156cfdfa73f)
there should be `,` before "audit-logs" but there isn't. 
I investigateg the issue and it turns out that helpcontent from bundle file cause the issue. Now returned json is valid:
```json
{
  "audit-logs": {
    "helpcontent": "\u003Cp\u003EAudit logs show the operations that users have carried out.\u003C/p\u003E\n\u003Cp\u003EIn order to easily search through logs, specify filter criteria in the top bar for type, date range or user and apply them.\u003C/p\u003E\n",
    "title": "Audit logs",
    "url": "http://localhost:1313/docs/standard-tenant/monitoring/#audit-logs"
  },
  "messaging-service": {
    "helpcontent": "Monitor the Messaging Service resources. Track resource usage like topics, subscribers, and backlogs for features such as Notifications 2.0 and the MQTT Service. Select features and topics to view detailed statistics, check limits, and identify potential bottlenecks or inactive consumers.",
    "title": "Messaging Service",
    "url": "http://localhost:1313/docs/standard-tenant/monitoring/#messaging-service"
  }
}
```