### PR TITLE
[MTM-62790] password must not have been used previously by user.

### DIFF
--- a/content/get-familiar-with-the-ui/user-settings.md
+++ b/content/get-familiar-with-the-ui/user-settings.md
@@ -98,7 +98,7 @@ Make sure to select a strong password. To support you in doing so, a password st
 By default, the password must meet the following conditions:
 
 * Consist of at least eight characters (this parameter can be configured by the {{< management-tenant >}}. Contact your Operations team on how to configure this setting according to your needs.
-* It must not have been used previously by the user.
+* Must not have been used previously by the user.
 * Include each of the following character types:
   * uppercase letters: `[A-Z]`, for example `ABCDEF`.
   * lowercase letters: `[a-z]`, for example `abcdef`.

--- a/content/get-familiar-with-the-ui/user-settings.md
+++ b/content/get-familiar-with-the-ui/user-settings.md
@@ -98,7 +98,7 @@ Make sure to select a strong password. To support you in doing so, a password st
 By default, the password must meet the following conditions:
 
 * Consist of at least eight characters (this parameter can be configured by the {{< management-tenant >}}. Contact your Operations team on how to configure this setting according to your needs.
-* It must not have been used previously by user.
+* It must not have been used previously by the user.
 * Include each of the following character types:
   * uppercase letters: `[A-Z]`, for example `ABCDEF`.
   * lowercase letters: `[a-z]`, for example `abcdef`.

--- a/content/get-familiar-with-the-ui/user-settings.md
+++ b/content/get-familiar-with-the-ui/user-settings.md
@@ -98,6 +98,7 @@ Make sure to select a strong password. To support you in doing so, a password st
 By default, the password must meet the following conditions:
 
 * Consist of at least eight characters (this parameter can be configured by the {{< management-tenant >}}. Contact your Operations team on how to configure this setting according to your needs.
+* It must not have been used previously by user.
 * Include each of the following character types:
   * uppercase letters: `[A-Z]`, for example `ABCDEF`.
   * lowercase letters: `[a-z]`, for example `abcdef`.


### PR DESCRIPTION
A password used once in the past cannot be assigned again.
This behavior was implemented long ago ~2016y,

but there is no documentation about it.
This should be described so that the user knows where this limit comes from.
