### PR TITLE
Add a warning about the required microservice

### DIFF
--- a/content/change-logs/platform-services/ui-c8y-1021-73-0-added-messaging-management-as-beta-feature-8891-graft-release-cd-9003.md
+++ b/content/change-logs/platform-services/ui-c8y-1021-73-0-added-messaging-management-as-beta-feature-8891-graft-release-cd-9003.md
@@ -16,4 +16,12 @@ build_artifact:
 ticket: MTM-63290
 version: 1021.73.0
 ---
+{{< c8y-admon-preview >}}
+This feature is in Public Preview, that is, it is not enabled by default and may be subject to change in the future.
+
+To determine whether the feature is available for your tenant, open the Administration application and navigate to **Ecosystem** > **Microservices**.
+If you see the `Messaging-management` microservice subscription for your tenant, the feature is already available to be activated as described below.
+Otherwise, please contact [product support](/additional-resources/contacting-support/) to request the microservice subscription for your tenant.
+{{< /c8y-admon-preview >}}
+
 The Messaging Service, the messaging component embedded in the {{< product-c8y-iot >}} platform, has been enhanced by a new monitoring and management feature which allows users to monitor and manage the usage of the Messaging Service resources. This new feature is currently in Public Preview. You can activate it in the platform UI via the **Manage preview features** option in the user menu. Find out more about the feature in its [user documentation](/standard-tenant/monitoring/#messaging-service).


### PR DESCRIPTION
A customer tried to enable the M&M feature in the UI but was unable to because (as far as I can tell) their tenant was not yet subscribed to the `messaging-management` microservice. Therefore, add a warning to users that they should check for this subscription before trying to enable the beta feature in the UI. Not ideal but I think it's the best we can do until a core updates forces all the tenants to be subscribed?