### PR TITLE
[MTM-63990] Removed a confusing deprecation note about "Web SDK for Angular JS" from docs

### DIFF
--- a/content/web/introduction.md
+++ b/content/web/introduction.md
@@ -15,12 +15,6 @@ This guide provides information on the Web SDK which enables you to:
 * Communicate authenticated with our API.
 * Apply default or branded UI components to your custom application.
 
-{{< c8y-admon-important >}}
- Web SDK for Angular JS is deprecated. Therefore, its documentation is no longer provided here.  As all {{< product-c8y-iot >}} REST APIs are backward compatible, Angular JS applications will still continue to work.
-
-Web SDK for plugins is based on Angular JS and is also deprecated. For Angular-based development, we recommend you to implement native Angular modules. For more information, refer to the [{{< c8y-tech-community >}}]({{< c8y-tech-community-link >}}).
-{{< /c8y-admon-important >}}
-
 ### When can I use the Web SDK?
 
 The Web SDK is designed to extend default application or build new IoT solutions. It provides many default components to compose such applications. However, if one of our default applications already fits your usecase, you should think about extending it via the less-code approach and install plugins to them. If you simply have very special needs or can't find the right plugin for you use-case, consider building a custom application with the help of the Web SDK. There you basically have three options:


### PR DESCRIPTION
From Andre's feedback:
> The "Web SDK for Angular JS" disclaimer can probably by now be removed; it's likely more confusing than helping here.