### PR TITLE
Docmentation changes to show up the contextual help for analytics rules plugin [PAB-4811]

### DIFF
--- a/content/streaming-analytics/analytics-rules-plugin-bundle/getting-started.md
+++ b/content/streaming-analytics/analytics-rules-plugin-bundle/getting-started.md
@@ -2,13 +2,6 @@
 weight: 10
 title: Getting started with the Analytics rules plugin
 layout: redirect
-outputs:
-  - html
-  - json
-helpcontent:
-- label: analytics-rules-plugin
-  title: Analytics rules plugin
-  content: "The Analytics rules plugin extends the capabilities of Analytics Builder within Streaming Analytics. It allows users to create, deploy, and manage Analytics Builder models directly from device and group contexts in applications like Device Management and Cockpit."
 ---
 
 ### What is the Analytics rules plugin {#what-is-the-analytics-rules-plugin}

--- a/content/streaming-analytics/analytics-rules-plugin.md
+++ b/content/streaming-analytics/analytics-rules-plugin.md
@@ -2,6 +2,13 @@
 weight: 35
 title: Analytics rules plugin
 layout: bundle
+outputs:
+  - html
+  - json
 sector:
   - data_analytics
+helpcontent:
+- label: analytics-rules-plugin
+  title: Analytics rules plugin
+  content: "The Analytics rules plugin extends the capabilities of Analytics Builder within Streaming Analytics. It allows users to create, deploy, and manage Analytics Builder models directly from device and group contexts in applications like Device Management and Cockpit."
 ---


### PR DESCRIPTION
To show up context help in analytics rules plugin, moved the metadata from **_getting started_** file to **_analytics rules plugin_** file.