### PR TITLE
MTM-63034 remove karaf from documentation

### DIFF
--- a/content/streaming-analytics/troubleshooting-bundle/alarms.md
+++ b/content/streaming-analytics/troubleshooting-bundle/alarms.md
@@ -373,7 +373,7 @@ A problem is likely to trigger these alarms, followed by this alarm:
 This alarm is raised whenever the CEP queue for the respective tenant is full.
 It is coming from {{< product-c8y-iot >}} Core, but concerns Apama-ctrl.
 
-Karaf nodes that send events to the CEP engine maintain per-tenant queues for the incoming events. This data gets processed by the CEP engine for the hosted CEP rules. For various reasons, these queues can become full and cannot accommodate newly arriving data. In such cases, an alarm is sent to the platform so that the end users are notified about the situation.
+Core java application nodes that send events to the CEP engine maintain per-tenant queues for the incoming events. This data gets processed by the CEP engine for the hosted CEP rules. For various reasons, these queues can become full and cannot accommodate newly arriving data. In such cases, an alarm is sent to the platform so that the end users are notified about the situation.
 
 If the CEP queue is full, older events are removed to handle new incoming events. To avoid this, you must diagnose the cause of the queue being full and resolve it as soon as possible.
 


### PR DESCRIPTION
Caused by:
 - https://cumulocity.atlassian.net/browse/MTM-63034
 
 Since the removal of karaf we are replacing reference to it by `java application` that more accurately describe the component. 