### PR TITLE
[MTM-64334] Document tenant option `sso-redirect-default-application`…

### DIFF
--- a/content/authentication/sso-bundle/sso-troubleshooting.md
+++ b/content/authentication/sso-bundle/sso-troubleshooting.md
@@ -6,10 +6,42 @@ sector:
   - platform_administration
 ---
 
-It can be particularly helpful to inspect the content of the authorization token sent to the platform as some of its fields contain the information required for the correct configuration described above.
+### Inspect token content
 
-In the Administration application, click **Accounts** > **Audit logs** and filter by the category "Single sign-on" and look for entries "Json web token claims".
+It can be particularly helpful to inspect the content of the authorization token sent to the platform as some of its
+fields contain the information required for the correct configuration described above.
+
+In the Administration application, click **Accounts** > **Audit logs** and filter by the category "Single sign-on" and
+look for entries "Json web token claims".
 
 The contexts of the token will be presented in JSON format.
 
 ![Audit token content](/images/users-guide/Administration/admin-sso-audit-token.png)
+
+### Enforce use of tenant domain in SSO login
+
+When a tenant is configured to use the `tenantId` in the `baseUrl` (instead of a tenant domain), users may experience
+unexpected redirect behavior after authenticating via SSO.
+
+If a user opens an application by entering its URL directly and initiates login via SSO, they may not be returned to the
+intended application after authentication. Instead, they may be redirected to the default application configured for the
+tenant.
+
+This can be fixed by setting the following tenant options:
+
+- category: `sso`
+- key: `sso-redirect-default-application`
+- value: `false`
+
+Setting this tenant option to `false` will enforce the use of the tenant domain during SSO login. This results in:
+
+- Correctly scoped cookies being set for the intended application, ensuring the user is redirected back to the original application after successful authentication.
+- Support for SSL certificates using **Subject Alternative Name (SAN)**, eliminating the need for wildcard or tenant-specific certificates.
+
+##### When to use:
+
+Apply this setting when:
+
+- The tenant environment is configured with base URLs that include `{tenantId}` instead of `{tenantDomain}`.
+- Users are redirected to the wrong application after SSO login.
+- You want to use a single SSL certificate with SAN entries instead of maintaining separate certificates for each domain.

--- a/content/authentication/sso-bundle/sso-troubleshooting.md
+++ b/content/authentication/sso-bundle/sso-troubleshooting.md
@@ -6,28 +6,28 @@ sector:
   - platform_administration
 ---
 
-### Inspect token content
+### Inspect token content {#inspect-token-content}
 
 It can be particularly helpful to inspect the content of the authorization token sent to the platform as some of its
 fields contain the information required for the correct configuration described above.
 
-In the Administration application, click **Accounts** > **Audit logs** and filter by the category "Single sign-on" and
-look for entries "Json web token claims".
+In the Administration application, click **Accounts** > **Audit logs**, filter by the type "Single sign-on" and
+look for entries with "JSON web token claims".
 
 The contexts of the token will be presented in JSON format.
 
 ![Audit token content](/images/users-guide/Administration/admin-sso-audit-token.png)
 
-### Enforce use of tenant domain in SSO login
+### Enforce the use of the tenant domain in SSO login {#enforce-use-of-tenant-domain}
 
-When a tenant is configured to use the `tenantId` in the `baseUrl` (instead of a tenant domain), users may experience
+If a tenant is configured to use the `tenantId` in the `baseUrl` (instead of a tenant domain), users may experience
 unexpected redirect behavior after authenticating via SSO.
 
-If a user opens an application by entering its URL directly and initiates login via SSO, they may not be returned to the
+If users opens an application by entering its URL directly and initiates login via SSO, they may not be returned to the
 intended application after authentication. Instead, they may be redirected to the default application configured for the
 tenant.
 
-This can be fixed by setting the following tenant options:
+This can be changed by setting the following tenant options:
 
 - category: `sso`
 - key: `sso-redirect-default-application`
@@ -38,7 +38,7 @@ Setting this tenant option to `false` will enforce the use of the tenant domain 
 - Correctly scoped cookies being set for the intended application, ensuring the user is redirected back to the original application after successful authentication.
 - Support for SSL certificates using **Subject Alternative Name (SAN)**, eliminating the need for wildcard or tenant-specific certificates.
 
-##### When to use:
+**When to use:**
 
 Apply this setting when:
 

--- a/content/authentication/sso-bundle/sso-troubleshooting.md
+++ b/content/authentication/sso-bundle/sso-troubleshooting.md
@@ -23,7 +23,7 @@ The contexts of the token will be presented in JSON format.
 If a tenant is configured to use the `tenantId` in the `baseUrl` (instead of a tenant domain), users may experience
 unexpected redirect behavior after authenticating via SSO.
 
-If users opens an application by entering its URL directly and initiates login via SSO, they may not be returned to the
+If a user opens an application by entering its URL directly and initiates login via SSO, they may not be returned to the
 intended application after authentication. Instead, they may be redirected to the default application configured for the
 tenant.
 


### PR DESCRIPTION
This PR documents the tenant option 'sso-redirect-default-application', which was introduced around 2020.

**Technical background:**
This tenant option was introduced to fix an issue where users logging in via SSO—for example, when accessing the Cockpit application—were incorrectly redirected to the Administration application. The root cause was that the cookie indicating which application should be opened after returning from the authentication server was being set for {tenantID}.domain.com instead of {tenantDomain}, which is not possible (a cookie cannot be set for a different domain than the one making the request).

Later, it was discovered that this option is also required for using SAN certificates, as after returning from the authentication server, there was no valid SSL certificate for {tenantID}.domain.com.