### PR TITLE
[MTM-64368] Add the C8Y_BASEURL_PULSAR environment variable to the Microservices SDK guide

### DIFF
--- a/content/microservice-sdk/general-aspects-bundle/microservice-runtime.md
+++ b/content/microservice-sdk/general-aspects-bundle/microservice-runtime.md
@@ -19,7 +19,7 @@ SERVER_PORT       |  Default open port (80)
 MICROSERVICE_SUBSCRIPTION_ENABLED  |  Default value: true
 C8Y_BASEURL  |  Platform address (contains port number)
 C8Y_BASEURL_MQTT  |  Platform address of the MQTT server (contains port number)
-C8Y_BASEURL_PULSAR  |  Platform address of the Pulsar broker (doesn't contain port number, defaults to `6650`) used to access MQTT Service topics via native Pulsar client libraries
+C8Y_BASEURL_PULSAR  |  Platform address of the Pulsar broker (doesn't contain port number, defaults to `6650`) used to access Messaging Service topics via native Pulsar client libraries
 C8Y_MICROSERVICE_ISOLATION  |  Isolation level (MULTI_TENANT or PER_TENANT)
 C8Y_BOOTSTRAP_REGISTER  |  Indicator whether the microservice should perform self registration or not. <br>Default value: false
 C8Y_BOOTSTRAP_TENANT  |  Bootstrap user tenant, for MULTI_TENANT - microservice owner

--- a/content/microservice-sdk/general-aspects-bundle/microservice-runtime.md
+++ b/content/microservice-sdk/general-aspects-bundle/microservice-runtime.md
@@ -19,7 +19,7 @@ SERVER_PORT       |  Default open port (80)
 MICROSERVICE_SUBSCRIPTION_ENABLED  |  Default value: true
 C8Y_BASEURL  |  Platform address (contains port number)
 C8Y_BASEURL_MQTT  |  Platform address of the MQTT server (contains port number)
-C8Y_BASEURL_PULSAR  |  Platform address of the Pulsar broker (port number default to `6650`) used to access MQTT Service topics via native Pulsar client libraries
+C8Y_BASEURL_PULSAR  |  Platform address of the Pulsar broker (doesn't contain port number, defaults to `6650`) used to access MQTT Service topics via native Pulsar client libraries
 C8Y_MICROSERVICE_ISOLATION  |  Isolation level (MULTI_TENANT or PER_TENANT)
 C8Y_BOOTSTRAP_REGISTER  |  Indicator whether the microservice should perform self registration or not. <br>Default value: false
 C8Y_BOOTSTRAP_TENANT  |  Bootstrap user tenant, for MULTI_TENANT - microservice owner

--- a/content/microservice-sdk/general-aspects-bundle/microservice-runtime.md
+++ b/content/microservice-sdk/general-aspects-bundle/microservice-runtime.md
@@ -19,6 +19,7 @@ SERVER_PORT       |  Default open port (80)
 MICROSERVICE_SUBSCRIPTION_ENABLED  |  Default value: true
 C8Y_BASEURL  |  Platform address (contains port number)
 C8Y_BASEURL_MQTT  |  Platform address of the MQTT server (contains port number)
+C8Y_BASEURL_PULSAR  |  Platform address of the Pulsar broker (port number default to `6650`) used to access MQTT Service topics via native Pulsar client libraries
 C8Y_MICROSERVICE_ISOLATION  |  Isolation level (MULTI_TENANT or PER_TENANT)
 C8Y_BOOTSTRAP_REGISTER  |  Indicator whether the microservice should perform self registration or not. <br>Default value: false
 C8Y_BOOTSTRAP_TENANT  |  Bootstrap user tenant, for MULTI_TENANT - microservice owner

--- a/content/microservice-sdk/http-bundle/python-microservice.md
+++ b/content/microservice-sdk/http-bundle/python-microservice.md
@@ -52,6 +52,7 @@ def environment():
     environment_data = {
         'platformUrl': os.getenv('C8Y_BASEURL'),
         'mqttPlatformUrl': os.getenv('C8Y_BASEURL_MQTT'),
+        'pulsarPlatformUrl': os.getenv('C8Y_BASEURL_PULSAR'),
         'tenant': os.getenv('C8Y_BOOTSTRAP_TENANT'),
         'user': os.getenv('C8Y_BOOTSTRAP_USER'),
         'password': os.getenv('C8Y_BOOTSTRAP_PASSWORD'),
@@ -166,6 +167,7 @@ $ curl -u '<tenantID>/<username>:<password>' https://<URL>/service/hello/environ
     "mqttPlatformUrl": "tcp://cumulocity:1881",
     "password": "...",
     "platformUrl": "https://cumulocity:8111",
+    "pulsarPlatformUrl": "pulsar://pulsar-proxy",
     "tenant": "mytenant",
     "user": "servicebootstrap_hello-microservice"
 }

--- a/content/microservice-sdk/java-bundle/developing-microservice.md
+++ b/content/microservice-sdk/java-bundle/developing-microservice.md
@@ -796,7 +796,7 @@ To deploy the application on a local Docker container, one must inject the envir
 An example execution could be:
 
 ```shell
-$ docker run -e "C8Y_BASEURL=<C8Y_BASEURL>" -e "C8Y_BASEURL_MQTT=<C8Y_BASEURL_MQTT>" <IMAGE_NAME>
+$ docker run -e "C8Y_BASEURL=<C8Y_BASEURL>" -e "C8Y_BASEURL_MQTT=<C8Y_BASEURL_MQTT>" -e "C8Y_BASEURL_PULSAR=<C8Y_BASEURL_PULSAR>" <IMAGE_NAME>
 ```
 
 ### Monitoring {#monitoring}


### PR DESCRIPTION
Add the C8Y_BASEURL_PULSAR environment variable where necessary to the microservice SDK guide. 
More details explanation of when and how to use this property will be included in future stories of the Epic MTM-64302