### PR TITLE
Expose more detail when monitoring an update

### DIFF
--- a/content/edge-kubernetes/manage-edge-bundle/monitoring-changes.md
+++ b/content/edge-kubernetes/manage-edge-bundle/monitoring-changes.md
@@ -4,13 +4,15 @@ title: Monitoring changes
 layout: redirect
 ---
 
-Any change that involves an update to the custom resource via `kubectl` will run and complete in the background. Whether it's a configuration change or an upgrade, you can use `kubectl` to wait for the custom resource to advertise itself as `Ready` after a change.
-```bash
-kubectl wait --timeout=1800s --namespace=c8yedge --for='jsonpath={.status.state}=Ready' edge/c8yedge
-```
-This command will exit when the change completes.
-
-Or you can monitor the progress of the changes in more detail:
+Any change that involves an update to the custom resource via `kubectl` will run and complete in the background. Whether it's a configuration change or an upgrade, you can use `kubectl` to monitor the progress of the changes in detail:
 ```bash
 kubectl get events --namespace=c8yedge --sort-by=.metadata.creationTimestamp --watch
 ```
+When it completes successfully, you will see a message of the form `{{< product-c8y-iot >}} Edge installation is complete...`.
+
+If you are making an update through automated scripting, you can also just wait for the custom resource to advertise itself as `Ready` after the change:
+```bash
+kubectl wait --timeout=1800s --namespace=c8yedge --for='jsonpath={.status.state}=Ready' edge/c8yedge
+```
+This command will exit when the change completes successfully.
+

--- a/content/edge-kubernetes/manage-edge-bundle/monitoring-changes.md
+++ b/content/edge-kubernetes/manage-edge-bundle/monitoring-changes.md
@@ -12,5 +12,5 @@ This command will exit when the change completes.
 
 Or you can monitor the progress of the changes in more detail:
 ```bash
-kubectl get events --namespace=c8yedge --field-selector involvedObject.name=c8yedge --sort-by=.metadata.creationTimestamp
+kubectl get events --namespace=c8yedge --sort-by=.metadata.creationTimestamp --watch
 ```

--- a/content/edge-kubernetes/manage-edge-bundle/monitoring-changes.md
+++ b/content/edge-kubernetes/manage-edge-bundle/monitoring-changes.md
@@ -14,5 +14,5 @@ If you are making an update through automated scripting, you can also just wait 
 ```bash
 kubectl wait --timeout=1800s --namespace=c8yedge --for='jsonpath={.status.state}=Ready' edge/c8yedge
 ```
-This command will exit when the change completes successfully.
+This command will return with exit code 0 when the change completes successfully, or a non-zero exit code if it does not complete after the timeout.
 


### PR DESCRIPTION
Saw a customer ticket where seeing other events such as insufficient CPU would have been very helpful for them.

I'm also prioritising the `kubectl get events` approach, because that's more helpful to an interactive user.