### PR TITLE
MTM-64344 document removing attachment references fix

### DIFF
--- a/content/change-logs/platform-services/cumulocity-2025-284-0-remove-child-references-from-parents-of-deleted-attachement.md
+++ b/content/change-logs/platform-services/cumulocity-2025-284-0-remove-child-references-from-parents-of-deleted-attachement.md
@@ -1,0 +1,18 @@
+---
+date: 
+title: Delete child references from parents of deleted attachment
+change_type:
+  - value: change-2c7RdTdXo4
+    label: Improvement
+product_area: Platform services
+component:
+  - value: component-JlFdtOPva
+    label: REST API
+build_artifact:
+  - value: tc-QHwMfWtBk7
+    label: cumulocity
+ticket: MTM-64344
+version: 2025.284.0
+---
+
+When an attachment is deleted, the references to this attachment are now also removed from the parent managed objects. This ensures that no leftover references are pointing to non-existent managed objects.


### PR DESCRIPTION
Caused by:
 - https://cumulocity.atlassian.net/browse/MTM-64344
 - https://github.com/Cumulocity-IoT/cumulocity-core/pull/3911
 
 Document fix for removing references of deleted attachment.