### PR TITLE
Kubernetes-native install needs to advise 'helm login'

### DIFF
--- a/content/edge-kubernetes/installing-edge-on-k8-bundle/install-edge-with-edge-operator.md
+++ b/content/edge-kubernetes/installing-edge-on-k8-bundle/install-edge-with-edge-operator.md
@@ -19,8 +19,9 @@ Edge has been tested and officially supported on Kubernetes version 1.32.x, the 
 ### Installing the Edge operator {#installing-edge-operator}
 The Edge operator is available as a Helm chart in the Edge registry, and can be installed like any other chart. You will need your registry credentials, which can be acquired from [product support](/additional-resources/contacting-support/). Assuming you are installing the {{< c8y-edge-current-version >}} release of Edge, and that you wish all Edge workloads to be running in the namespace `c8yedge`, run the following command:
 ```shell
+helm login registry.c8y.io --username="<Edge registry username>" --password="<Edge registry password>"
+
 helm upgrade --install c8yedge-operator oci://registry.c8y.io/edge/helm-charts/cumulocity-iot-edge-operator \
-    --username="<Edge registry username>" --password="<Edge registry password>" \
     --version={{< c8y-edge-current-version >}} \
     --namespace c8yedge \
     --create-namespace \

--- a/content/edge-kubernetes/installing-edge-on-k8-bundle/install-edge-with-edge-operator.md
+++ b/content/edge-kubernetes/installing-edge-on-k8-bundle/install-edge-with-edge-operator.md
@@ -19,7 +19,7 @@ Edge has been tested and officially supported on Kubernetes version 1.32.x, the 
 ### Installing the Edge operator {#installing-edge-operator}
 The Edge operator is available as a Helm chart in the Edge registry, and can be installed like any other chart. You will need your registry credentials, which can be acquired from [product support](/additional-resources/contacting-support/). Assuming you are installing the {{< c8y-edge-current-version >}} release of Edge, and that you wish all Edge workloads to be running in the namespace `c8yedge`, run the following command:
 ```shell
-helm login registry.c8y.io --username="<Edge registry username>" --password="<Edge registry password>"
+helm registry login registry.c8y.io --username="<Edge registry username>" --password="<Edge registry password>"
 
 helm upgrade --install c8yedge-operator oci://registry.c8y.io/edge/helm-charts/cumulocity-iot-edge-operator \
     --version={{< c8y-edge-current-version >}} \


### PR DESCRIPTION
There's a bug in helm where it doesn't pass credentials through in an upgrade/install command - see https://github.com/helm/helm/pull/13483 . Unfortunately it regressed in the latest version (see the latest comments on that PR), so it's safest to just assume it doesn't work.