### PR TITLE
MTM-64421 Requirement for max header size

### DIFF
--- a/content/change-logs/application-enablement/cumulocity-2025-62-0-microservices-sdk-allowing-bigger-headers-in-request.md
+++ b/content/change-logs/application-enablement/cumulocity-2025-62-0-microservices-sdk-allowing-bigger-headers-in-request.md
@@ -1,10 +1,10 @@
 ---
-date: 2025-10-09
+date: 2025-15-09
 title: Increase of max request header size
 product_area: Application enablement & solutions
 change_type:
-  - value: change-inv-3bw8e
-    label: Announcement
+  - value: change-2c7RdTdXo4
+    label: Improvement
 component:
   - value: component-Sv2buFZ5I
     label: Microservice SDK

--- a/content/change-logs/application-enablement/cumulocity-2025-62-0-microservices-sdk-allowing-bigger-headers-in-request.md
+++ b/content/change-logs/application-enablement/cumulocity-2025-62-0-microservices-sdk-allowing-bigger-headers-in-request.md
@@ -14,4 +14,4 @@ build_artifact:
 ticket: MTM-64421
 version: 2025.62.0
 ---
-To allow the usage of larger headers in the requests, in microservices SDK we have set the property server.max-http-request-header-size to 24KB. Previous value was 8KB.
+To allow the usage of larger headers in requests, the property `server.max-http-request-header-size` has been increased to 24KB in the Microservice SDK. Previously, the value was 8KB.

--- a/content/change-logs/application-enablement/cumulocity-2025-62-0-microservices-sdk-allowing-bigger-headers-in-request.md
+++ b/content/change-logs/application-enablement/cumulocity-2025-62-0-microservices-sdk-allowing-bigger-headers-in-request.md
@@ -1,0 +1,17 @@
+---
+date: 2025-10-09
+title: Increase of max request header size
+product_area: Application enablement & solutions
+change_type:
+  - value: change-inv-3bw8e
+    label: Announcement
+component:
+  - value: component-Sv2buFZ5I
+    label: Microservice SDK
+build_artifact:
+  - value: tc-QHwMfWtBk7
+    label: cumulocity
+ticket: MTM-64421
+version: 2025.62.0
+---
+To allow the usage of larger headers in the requests, in microservices SDK we have set the property *server.max-http-request-header-size* to 24KB. Previous default value was 8KB.

--- a/content/change-logs/application-enablement/cumulocity-2025-62-0-microservices-sdk-allowing-bigger-headers-in-request.md
+++ b/content/change-logs/application-enablement/cumulocity-2025-62-0-microservices-sdk-allowing-bigger-headers-in-request.md
@@ -14,4 +14,4 @@ build_artifact:
 ticket: MTM-64421
 version: 2025.62.0
 ---
-To allow the usage of larger headers in the requests, in microservices SDK we have set the property server.max-http-request-header-size to 24KB. Previous default value was 8KB.
+To allow the usage of larger headers in the requests, in microservices SDK we have set the property server.max-http-request-header-size to 24KB. Previous value was 8KB.

--- a/content/change-logs/application-enablement/cumulocity-2025-62-0-microservices-sdk-allowing-bigger-headers-in-request.md
+++ b/content/change-logs/application-enablement/cumulocity-2025-62-0-microservices-sdk-allowing-bigger-headers-in-request.md
@@ -1,5 +1,5 @@
 ---
-date: 2025-15-09
+date:
 title: Increase of max request header size
 product_area: Application enablement & solutions
 change_type:

--- a/content/change-logs/application-enablement/cumulocity-2025-62-0-microservices-sdk-allowing-bigger-headers-in-request.md
+++ b/content/change-logs/application-enablement/cumulocity-2025-62-0-microservices-sdk-allowing-bigger-headers-in-request.md
@@ -14,4 +14,4 @@ build_artifact:
 ticket: MTM-64421
 version: 2025.62.0
 ---
-To allow the usage of larger headers in the requests, in microservices SDK we have set the property *server.max-http-request-header-size* to 24KB. Previous default value was 8KB.
+To allow the usage of larger headers in the requests, in microservices SDK we have set the property server.max-http-request-header-size to 24KB. Previous default value was 8KB.

--- a/content/microservice-sdk/general-aspects-bundle/requirements-interactions.md
+++ b/content/microservice-sdk/general-aspects-bundle/requirements-interactions.md
@@ -13,6 +13,7 @@ The following requirements towards {{< product-c8y-iot >}} microservices must be
 * A microservice cannot access the database directly and must use the {{< product-c8y-iot >}} API.
 * A microservice must provide one inbound REST API. Additional inbound ports are not supported.
 * A microservice can use multiple outbound ports.
+* Requests to microservices may include HTTP headers of up to 24 KB in size. Requests that exceed this limit may be rejected by the infrastructure. 
 * The request lifetime must have the maximum. The infrastructure might terminate too long running requests.
 * All log information must be sent to the standard output in order to be captured and persisted by the infrastructure.
 

--- a/content/microservice-sdk/general-aspects-bundle/requirements-interactions.md
+++ b/content/microservice-sdk/general-aspects-bundle/requirements-interactions.md
@@ -13,7 +13,7 @@ The following requirements towards {{< product-c8y-iot >}} microservices must be
 * A microservice cannot access the database directly and must use the {{< product-c8y-iot >}} API.
 * A microservice must provide one inbound REST API. Additional inbound ports are not supported.
 * A microservice can use multiple outbound ports.
-* Requests to microservices may include HTTP headers of up to 24 KB in size. Requests that exceed this limit may be rejected by the infrastructure. 
+* Requests to microservices can include HTTP headers of up to 24 KB in size. Requests that exceed this limit may be rejected by the infrastructure. 
 * The request lifetime must have the maximum. The infrastructure might terminate too long running requests.
 * All log information must be sent to the standard output in order to be captured and persisted by the infrastructure.
 


### PR DESCRIPTION
This PR is in the context of https://cumulocity.atlassian.net/browse/MTM-64421, and documents the requirement for the microservices not to reject requests with headers up to 24KB