### PR TITLE
Fix copyright message in repo readme [no-issue]

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,4 +193,4 @@ This is not going to influence the other release branches as long as they do not
 
 
 ---
-© Cumulocity GmbH  2025 + All rights reserved.
+Copyright © 2018-present Cumulocity GmbH. All rights reserved.


### PR DESCRIPTION
"2025 +" isn't a standard way to represent copyright, and also isn't explicit about the longer copyright history we own for cumulocity's documentation since 2018. 

This PR adds the correct copyright message from https://cumulocity.com/docs/legal-notices/copyright/