### PR TITLE
CIE-5447 - Document online upgrade with c8yedge

### DIFF
--- a/content/change-logs/edge/edge-2025.0.5-c8yedge-online-upgrade.md
+++ b/content/change-logs/edge/edge-2025.0.5-c8yedge-online-upgrade.md
@@ -1,0 +1,19 @@
+---
+date: 2024-01-06
+title: c8yedge supports online upgrade
+change_type:
+  - value: change-2c7RdTdXo4
+    label: Feature
+product_area: Edge
+component:
+  - value: component-g7hnfbu4J
+    label: Edge
+build_artifact:
+  - value: tc-nJH2U7g3u
+    label: edge
+ticket: CIE-5447
+version: 2025.0.5
+---
+The `c8yedge` tool now supports upgrade in an online environment. After installing Edge with the `c8yedge` tool, you can also use this tool to upgrade Edge to the latest version, or a version of you choice.
+
+For more details, see [Upgrading with the c8yedge tool](/edge-kubernetes/manage-edge/#upgrade-with-c8yedge).

--- a/content/change-logs/edge/edge-2025.0.5-c8yedge-online-upgrade.md
+++ b/content/change-logs/edge/edge-2025.0.5-c8yedge-online-upgrade.md
@@ -14,6 +14,6 @@ build_artifact:
 ticket: CIE-5447
 version: 2025.0.5
 ---
-The `c8yedge` tool now supports upgrade in an online environment. After installing Edge with the `c8yedge` tool, you can also use this tool to upgrade Edge to the latest version, or a version of you choice.
+The `c8yedge` tool now supports upgrade in an online environment. After installing Edge with the `c8yedge` tool, you can also use this tool to upgrade Edge to the latest version, or a version of your choice.
 
 For more details, see [Upgrading with the c8yedge tool](/edge-kubernetes/manage-edge/#upgrade-with-c8yedge).

--- a/content/edge-kubernetes/installing-edge-on-k8-bundle/accessing-edge.md
+++ b/content/edge-kubernetes/installing-edge-on-k8-bundle/accessing-edge.md
@@ -7,7 +7,7 @@ layout: redirect
 If you have installed Edge on your local machine, then you should be able to immediately access Edge in your browser with the URL `http://localhost`. If it is on a remote machine or a VM with a simple network setup and no firewall in the way, you can use `http://<IP of remote machine or VM>`.
 
 {{< c8y-admon-info >}}
-If you have performed the install on a self-managed Kubernetes cluster rather than installing with the `c8yedge` tool, it is sometimes the case that Edge is not accessible via either URL. This depends on the Kubernetes distribution you have used. See [Accessing Edge via an external IP](/edge-kubernetes/manage-edge/#external-ip)
+If you have performed the install on a self-managed Kubernetes cluster rather than installing with the `c8yedge` tool, it is sometimes the case that Edge is not accessible via either URL. This depends on the Kubernetes distribution you have used. See [Accessing Edge via an external IP](/edge-kubernetes/manage-edge/#external-ip).
 {{< /c8y-admon-info >}}
 
 When signing into Edge this way, you will be prompted for the Cumulocity tenant id you are signing into. Edge has two tenants, `management` and `edge`. When signing in for the first time, use the default credentials username “**admin**” and password “**admin-pass**”. If you have installed using the `c8yedge` tool, the email address will have been initially configured to `company@edgebootstrap.example` which you will also need when signing in for the first time. These credentials are set for both Cumulocity tenants, and should be changed on both even if you do not intend to use the `management` tenant.

--- a/content/edge-kubernetes/installing-edge-on-k8-bundle/accessing-edge.md
+++ b/content/edge-kubernetes/installing-edge-on-k8-bundle/accessing-edge.md
@@ -7,7 +7,7 @@ layout: redirect
 If you have installed Edge on your local machine, then you should be able to immediately access Edge in your browser with the URL `http://localhost`. If it is on a remote machine or a VM with a simple network setup and no firewall in the way, you can use `http://<IP of remote machine or VM>`.
 
 {{< c8y-admon-info >}}
-If you have performed a kubernetes-native install rather than installing with the `c8yedge` tool, it is sometimes the case that Edge is not accessible via either URL. This depends on the Kubernetes distribution you have used. See [Accessing Edge via an external IP](/edge-kubernetes/manage-edge/#external-ip)
+If you have performed the install on a self-managed Kubernetes cluster rather than installing with the `c8yedge` tool, it is sometimes the case that Edge is not accessible via either URL. This depends on the Kubernetes distribution you have used. See [Accessing Edge via an external IP](/edge-kubernetes/manage-edge/#external-ip)
 {{< /c8y-admon-info >}}
 
 When signing into Edge this way, you will be prompted for the Cumulocity tenant id you are signing into. Edge has two tenants, `management` and `edge`. When signing in for the first time, use the default credentials username “**admin**” and password “**admin-pass**”. If you have installed using the `c8yedge` tool, the email address will have been initially configured to `company@edgebootstrap.example` which you will also need when signing in for the first time. These credentials are set for both Cumulocity tenants, and should be changed on both even if you do not intend to use the `management` tenant.

--- a/content/edge-kubernetes/installing-edge-on-k8-bundle/install-edge-with-edge-operator.md
+++ b/content/edge-kubernetes/installing-edge-on-k8-bundle/install-edge-with-edge-operator.md
@@ -1,10 +1,10 @@
 ---
 weight: 50
-title: Installing with the Kubernetes-native approach
+title: Installing on a self-managed Kubernetes cluster
 layout: redirect
 ---
 
-This method is suitable for users who already have a Kubernetes cluster and want to install Edge using the Kubernetes-native approach. Before you start the installation, ensure that you have met the [prerequisites](/edge-kubernetes/installing-edge-on-k8/#prerequisites).
+This method is suitable for users who already have a Kubernetes cluster and want to install Edge using existing Kubernetes tools. Before you start the installation, ensure that you have met the [prerequisites](/edge-kubernetes/installing-edge-on-k8/#prerequisites).
 
 You will need Helm version 3.x available on your system. Refer to [Installing Helm](https://helm.sh/docs/intro/install/) for the installation instructions.
 

--- a/content/edge-kubernetes/installing-edge-on-k8.md
+++ b/content/edge-kubernetes/installing-edge-on-k8.md
@@ -17,9 +17,9 @@ Edge can be installed using one of two supported methods. The method you choose 
     <br/>
     <br/>
 
-  - **[Installing with the Kubernetes-native approach](#install-edge-with-edge-operator) (For users with an existing Kubernetes setup)**
+  - **[Installing on a self-managed Kubernetes cluster](#install-edge-with-edge-operator)**
     <br/>
-    This method is suitable for users who already have a Kubernetes cluster and want to install Edge using the Kubernetes-native approach. Even a single-node Kubernetes cluster will suffice, but is not required.
+    This method is suitable for users who already have a Kubernetes cluster and want to install Edge using existing Kubernetes tools. Even a single-node Kubernetes cluster will suffice, but is not required.
     <br/>
     In this case, you are expected to:
     - Set up and manage the Kubernetes cluster yourself (using K3s or any compatible Kubernetes distribution).

--- a/content/edge-kubernetes/manage-edge-bundle/undeploy-edge.md
+++ b/content/edge-kubernetes/manage-edge-bundle/undeploy-edge.md
@@ -9,7 +9,7 @@ If you have installed Edge using the `c8yedge` tool, uninstallation is as simple
 sudo c8yedge uninstall
 ```
 
-For a kubernetes-native install, remove both the Edge Custom Resource and the Edge operator. Assuming the Custom Resource is called `c8yedge` in the `c8yedge` namespace:
+Otherwise, remove both the Edge Custom Resource and the Edge operator. Assuming the Custom Resource is called `c8yedge` in the `c8yedge` namespace:
 ```shell
 kubectl delete edge c8yedge --namespace=c8yedge
 helm uninstall c8yedge-operator --namespace=c8yedge

--- a/content/edge-kubernetes/manage-edge-bundle/version-upgrade.md
+++ b/content/edge-kubernetes/manage-edge-bundle/version-upgrade.md
@@ -22,7 +22,7 @@ You can upgrade to the latest fix of Edge in the current release train from the 
 ```shell
 c8yedge upgrade
 ```
-For example, this will perform an upgrade from `{{< c8y-edge-current-version >}}.0.4` to `{{< c8y-edge-current-version >}}.0.5`, but not `{{< c8y-edge-current-version >}}.0.4` to new release train after `{{< c8y-edge-current-version >}}`. To specify an explicit version to upgrade to:
+For example, this will perform an upgrade from `{{< c8y-edge-current-version >}}.0.4` to `{{< c8y-edge-current-version >}}.0.5`, but not `{{< c8y-edge-current-version >}}.0.4` to a new release train after `{{< c8y-edge-current-version >}}`. To specify an explicit version to upgrade to:
 ```shell
 c8yedge upgrade --version <version number>
 ```

--- a/content/edge-kubernetes/manage-edge-bundle/version-upgrade.md
+++ b/content/edge-kubernetes/manage-edge-bundle/version-upgrade.md
@@ -12,7 +12,33 @@ To upgrade your Kubernetes version, follow the official upgrade instructions for
 <br>See [Prerequisites](/edge-kubernetes/installing-edge-on-k8/#prerequisites) for the supported Kubernetes versions and platforms.
 {{< /c8y-admon-info >}}
 
-### Starting the upgrade {#starting-the-upgrade}
+### Upgrading with the c8yedge tool {#upgrade-with-c8yedge}
+
+{{< c8y-admon-info >}}
+Upgrading with the `c8yedge` tool is only supported if the initial installation was created using the `c8yedge` tool.
+{{< /c8y-admon-info >}}
+
+You can upgrade to the latest fix of Edge in the current release train from the command line in your environment:
+```shell
+c8yedge upgrade
+```
+For example, this will perform an upgrade from `{{< c8y-edge-current-version >}}.0.4` to `{{< c8y-edge-current-version >}}.0.5`, but not `{{< c8y-edge-current-version >}}.0.4` to new release train after `{{< c8y-edge-current-version >}}`. To specify an explicit version to upgrade to:
+```shell
+c8yedge upgrade --version <version number>
+```
+Unlike the initial installation, no use of `sudo` is required for any kind of upgrade using `c8yedge`.
+
+#### Upgrading in an airgapped environment {#upgrade-edge-airgapped}
+
+If Edge is now running in an environment with no or limited internet access, you can upgrade by creating an offline package and transferring it to your airgapped environment. See [Install Edge in an airgapped environment](/edge-kubernetes/installing-edge-on-k8/#install-edge-airgapped). There is no difference between a package created for an initial installation, and a package created for an upgrade.
+
+Once in the airgapped environment:
+```shell
+c8yedge upgrade -s c8yedge.tar
+```
+
+
+### Upgrading with the Kubernetes-native approach {#upgrade-with-kubernetes-native}
 
 Upgrading Edge works similarly to applying a configuration change, with the target version specified as a configuration value.
 To upgrade to the latest available version from the current release, set the version to `"{{< c8y-edge-current-version >}}"`. To upgrade to a specific patch version, use a fully qualified version string such as `"{{< c8y-edge-current-version >}}.0.1"`.
@@ -21,16 +47,6 @@ To upgrade to the latest available version from the current release, set the ver
 kubectl --namespace=c8yedge patch edge/c8yedge --type=merge -p '{"spec":{"version":"{{< c8y-edge-current-version >}}"}}'
 ```
 The operator will also upgrade itself as part of this process. See [Monitoring changes](/edge-kubernetes/manage-edge/#monitoring-changes) to follow the progress of the upgrade.
-
-### Upgrading Edge in an airgapped environment {#upgrade-edge-airgapped}
-
-If you have installed Edge using the `c8yedge` tool, and Edge is now running in an environment with no or limited internet access, you can upgrade by creating an offline package and transferring it to your airgapped environment. See [Install Edge in an airgapped environment](/edge-kubernetes/installing-edge-on-k8/#install-edge-airgapped).
-
-Once in the airgapped environment:
-```shell
-c8yedge upgrade -s c8yedge.tar
-```
-Unlike the initial installation, no use of `sudo` is required.
 
 ### Upgrading Edge remotely {#upgrading-edge-remotely}
 

--- a/content/edge-kubernetes/manage-edge-bundle/version-upgrade.md
+++ b/content/edge-kubernetes/manage-edge-bundle/version-upgrade.md
@@ -18,11 +18,11 @@ To upgrade your Kubernetes version, follow the official upgrade instructions for
 Upgrading with the `c8yedge` tool is only supported if the initial installation was created using the `c8yedge` tool.
 {{< /c8y-admon-info >}}
 
-You can upgrade to the latest fix of Edge in the current release train from the command line in your environment:
+You can upgrade to the latest fix of Edge by running the following command:
 ```shell
 c8yedge upgrade
 ```
-For example, this will perform an upgrade from `{{< c8y-edge-current-version >}}.0.4` to `{{< c8y-edge-current-version >}}.0.5`, but not `{{< c8y-edge-current-version >}}.0.4` to a new release train after `{{< c8y-edge-current-version >}}`. To specify an explicit version to upgrade to:
+This will only apply the latest fixes for the current release train. For example, this will perform an upgrade from `{{< c8y-edge-current-version >}}.0.3` to `{{< c8y-edge-current-version >}}.0.5`, but not `{{< c8y-edge-current-version >}}.0.3` to a new major version after `{{< c8y-edge-current-version >}}`. To specify an explicit version to upgrade to:
 ```shell
 c8yedge upgrade --version <version number>
 ```

--- a/content/edge-kubernetes/manage-edge-bundle/version-upgrade.md
+++ b/content/edge-kubernetes/manage-edge-bundle/version-upgrade.md
@@ -7,11 +7,6 @@ The Edge operator follows the recreate update strategy to upgrade the Edge deplo
 
 Recreating update strategy is an all-or-nothing process that updates all aspects of the system at once with a brief downtime period. The Edge operator selects all the outdated pods and deactivates them at once. Once all old pods are deactivated, the Edge operator creates updated pods for the entire system. Edge is not operational while the old pods are deactivating and until the final updated pod is created.
 
-{{< c8y-admon-info >}}
-To upgrade your Kubernetes version, follow the official upgrade instructions for your platform.
-<br>See [Prerequisites](/edge-kubernetes/installing-edge-on-k8/#prerequisites) for the supported Kubernetes versions and platforms.
-{{< /c8y-admon-info >}}
-
 ### Upgrading with the c8yedge tool {#upgrade-with-c8yedge}
 
 {{< c8y-admon-info >}}
@@ -39,6 +34,11 @@ c8yedge upgrade -s c8yedge.tar
 
 
 ### Upgrading Edge in a self-managed Kubernetes cluster {#upgrade-with-kubernetes-native}
+
+{{< c8y-admon-info >}}
+Upgrading the version of your self-managed Kubernetes is outside the scope of the Edge product and documentation. Follow the official upgrade instructions for your platform.
+<br>See [Prerequisites](/edge-kubernetes/installing-edge-on-k8/#prerequisites) for the supported Kubernetes versions and platforms.
+{{< /c8y-admon-info >}}
 
 Upgrading Edge works similarly to applying a configuration change, with the target version specified as a configuration value.
 To upgrade to the latest available version from the current release, set the version to `"{{< c8y-edge-current-version >}}"`. To upgrade to a specific patch version, use a fully qualified version string such as `"{{< c8y-edge-current-version >}}.0.1"`.

--- a/content/edge-kubernetes/manage-edge-bundle/version-upgrade.md
+++ b/content/edge-kubernetes/manage-edge-bundle/version-upgrade.md
@@ -13,11 +13,11 @@ Recreating update strategy is an all-or-nothing process that updates all aspects
 Upgrading with the `c8yedge` tool is only supported if the initial installation was created using the `c8yedge` tool.
 {{< /c8y-admon-info >}}
 
-You can upgrade to the latest fix of Edge by running the following command:
+You can upgrade to the latest patch of Edge by running the following command:
 ```shell
 c8yedge upgrade
 ```
-This will only apply the latest fixes for the current release train. For example, this will perform an upgrade from `{{< c8y-edge-current-version >}}.0.3` to `{{< c8y-edge-current-version >}}.0.5`, but not `{{< c8y-edge-current-version >}}.0.3` to a new major version after `{{< c8y-edge-current-version >}}`. To specify an explicit version to upgrade to:
+This will only apply the latest patches for the current release train. For example, this command will perform an upgrade from `{{< c8y-edge-current-version >}}.0.3` to `{{< c8y-edge-current-version >}}.0.5`, but not `{{< c8y-edge-current-version >}}.0.3` to a new major version after `{{< c8y-edge-current-version >}}`. To specify an explicit version to upgrade to:
 ```shell
 c8yedge upgrade --version <version number>
 ```

--- a/content/edge-kubernetes/manage-edge-bundle/version-upgrade.md
+++ b/content/edge-kubernetes/manage-edge-bundle/version-upgrade.md
@@ -38,7 +38,7 @@ c8yedge upgrade -s c8yedge.tar
 ```
 
 
-### Upgrading with the Kubernetes-native approach {#upgrade-with-kubernetes-native}
+### Upgrading Edge in a self-managed Kubernetes cluster {#upgrade-with-kubernetes-native}
 
 Upgrading Edge works similarly to applying a configuration change, with the target version specified as a configuration value.
 To upgrade to the latest available version from the current release, set the version to `"{{< c8y-edge-current-version >}}"`. To upgrade to a specific patch version, use a fully qualified version string such as `"{{< c8y-edge-current-version >}}.0.1"`.

--- a/data/date_settings.toml
+++ b/data/date_settings.toml
@@ -54,3 +54,7 @@ version = "Edge-2025.0.3"
 [[versions]]
 date = "January 5, 2024"
 version = "Edge-2025.0.4"
+
+[[versions]]
+date = "January 6, 2024"
+version = "Edge-2025.0.5"


### PR DESCRIPTION
As well as documenting this new feature, I'm also taking the opportunity to remove the awkward term "kubernetes-native", which is really just internal terminology. It's replaced with "self-managed kubernetes", which is more descriptive to a customer.