### PR TITLE
[MTM-64133] Single sign on, document new idp_hint mechanism

### DIFF
--- a/content/authentication/sso-bundle/configuring-access-tokens.md
+++ b/content/authentication/sso-bundle/configuring-access-tokens.md
@@ -1,5 +1,5 @@
 ---
-weight: 50
+weight: 60
 title: Using access tokens from the authorization server
 layout: redirect
 sector:

--- a/content/authentication/sso-bundle/custom-template.md
+++ b/content/authentication/sso-bundle/custom-template.md
@@ -183,7 +183,7 @@ https://{{< domain-c8y >}}/apps/public/login/index.html?idp_hint=google
 2. The {{< product-c8y-iot >}} application extracts the value of `idp_hint` (for example, "google").
 3. During the OAuth2/OIDC authorization request, this value is mapped and passed to the underlying authentication server.
 
-##### Example with Keycloak
+#### Example with Keycloak {#example-with-keycloak}
 Keycloak supports [an identity provider hinting feature](https://www.keycloak.org/docs/latest/server_admin/index.html#_client_suggested_idp) using the `kc_idp_hint` parameter.  
 If the `idp_hint` value is `google`, and authorization request headers are configured with key: `kc_idp_hint`, value `${idp_hint}`, {{< product-c8y-iot >}} will translate it into a Keycloak compatible parameter and forward it:
 

--- a/content/authentication/sso-bundle/custom-template.md
+++ b/content/authentication/sso-bundle/custom-template.md
@@ -180,7 +180,7 @@ It allows a client application (for example, a custom welcome page) to suggest w
 https://{{< domain-c8y >}}/apps/public/login/index.html?idp_hint=google
 ```
 
-2. The {{< product-c8y-iot >}} application extracts the value of `idp_hint` (e.g., `google`).
+2. The {{< product-c8y-iot >}} application extracts the value of `idp_hint` (for example, "google").
 3. During the OAuth2/OIDC authorization request, this value is mapped and passed to the underlying Auth Server.
 
 ##### Example with Keycloak

--- a/content/authentication/sso-bundle/custom-template.md
+++ b/content/authentication/sso-bundle/custom-template.md
@@ -168,7 +168,7 @@ Placeholders can also be used as a part of text:
 Placeholders are not validated for correctness. Any not recognized or misspelled placeholder will be left in text unprocessed.
 {{< /c8y-admon-info >}}
 
-### Client Suggested Identity Provider
+### Client suggested identity provider {#client-suggested-identity-provider}
 When the default login mode is **Single sign-on redirect**, and the Auth Server supports multiple identity providers, instead of displaying an intermediate "select identity provider" screen to the user, the `idp_hint` parameter can be collected by {{< product-c8y-iot >}} and forwarded to the Auth Server as part of the initial authorization request. This ensures that the user is redirected directly to the specified IdP.
 
 The `idp_hint` is a custom parameter supported by the application to improve the login experience in multi-Identity Provider (IdP) scenarios.

--- a/content/authentication/sso-bundle/custom-template.md
+++ b/content/authentication/sso-bundle/custom-template.md
@@ -181,7 +181,7 @@ https://{{< domain-c8y >}}/apps/public/login/index.html?idp_hint=google
 ```
 
 2. The {{< product-c8y-iot >}} application extracts the value of `idp_hint` (for example, "google").
-3. During the OAuth2/OIDC authorization request, this value is mapped and passed to the underlying Auth Server.
+3. During the OAuth2/OIDC authorization request, this value is mapped and passed to the underlying authentication server.
 
 ##### Example with Keycloak
 Keycloak supports [an identity provider hinting feature](https://www.keycloak.org/docs/latest/server_admin/index.html#_client_suggested_idp) using the `kc_idp_hint` parameter.  

--- a/content/authentication/sso-bundle/custom-template.md
+++ b/content/authentication/sso-bundle/custom-template.md
@@ -172,7 +172,7 @@ Placeholders are not validated for correctness. Any not recognized or misspelled
 When the default login mode is **Single sign-on redirect**, and the authentication server supports multiple identity providers, instead of requesting the user to select an identity provider, the `idp_hint` parameter can be collected by {{< product-c8y-iot >}} and forwarded to the authentication server as part of the initial authorization request. This ensures that the user is redirected directly to the specified IdP.
 
 The `idp_hint` is a custom parameter supported by the application to improve the login experience in multi-identity provider (IdP) scenarios.
-It allows a client application (e.g., a custom welcome page) to suggest which IdP should be preselected during the authentication flow.
+It allows a client application (for example, a custom welcome page) to suggest which IdP should be preselected during the authentication flow.
 
 1. A client custom application appends the `idp_hint` parameter to the login URL:
 

--- a/content/authentication/sso-bundle/custom-template.md
+++ b/content/authentication/sso-bundle/custom-template.md
@@ -149,7 +149,7 @@ Inside some fields you can use placeholders that are resolved by {{< product-c8y
 | code         | Code returned by the authorization server in response to authorization request 
 | refreshToken | Refresh token returned by the authorization server after token request         
 | id_token     | A JWT token issued by the authorization server that contains claims about the authenticated user; can be used for logout from the authorization server
-| idp_hint     | Value of the **idp_hint** parameter passed by UI aplication, to choose which IdP should be preselected during the authentication flow.                    
+| idp_hint     | Value of the `idp_hint` parameter passed by the UI application, to select which IdP should be preselected during the authentication flow                   
 
 These placeholders can be used in authorization requests, token requests, refresh requests and logout request in the fields:
 

--- a/content/authentication/sso-bundle/custom-template.md
+++ b/content/authentication/sso-bundle/custom-template.md
@@ -171,7 +171,7 @@ Placeholders are not validated for correctness. Any not recognized or misspelled
 ### Client suggested identity provider {#client-suggested-identity-provider}
 When the default login mode is **Single sign-on redirect**, and the authentication server supports multiple identity providers, instead of requesting the user to select an identity provider, the `idp_hint` parameter can be collected by {{< product-c8y-iot >}} and forwarded to the authentication server as part of the initial authorization request. This ensures that the user is redirected directly to the specified IdP.
 
-The `idp_hint` is a custom parameter supported by the application to improve the login experience in multi-Identity Provider (IdP) scenarios.
+The `idp_hint` is a custom parameter supported by the application to improve the login experience in multi-identity provider (IdP) scenarios.
 It allows a client application (e.g., a custom welcome page) to suggest which IdP should be preselected during the authentication flow.
 
 1. A client custom application appends the `idp_hint` parameter to the login URL:

--- a/content/authentication/sso-bundle/custom-template.md
+++ b/content/authentication/sso-bundle/custom-template.md
@@ -169,7 +169,7 @@ Placeholders are not validated for correctness. Any not recognized or misspelled
 {{< /c8y-admon-info >}}
 
 ### Client suggested identity provider {#client-suggested-identity-provider}
-When the default login mode is **Single sign-on redirect**, and the Auth Server supports multiple identity providers, instead of displaying an intermediate "select identity provider" screen to the user, the `idp_hint` parameter can be collected by {{< product-c8y-iot >}} and forwarded to the Auth Server as part of the initial authorization request. This ensures that the user is redirected directly to the specified IdP.
+When the default login mode is **Single sign-on redirect**, and the authentication server supports multiple identity providers, instead of requesting the user to select an identity provider, the `idp_hint` parameter can be collected by {{< product-c8y-iot >}} and forwarded to the authentication server as part of the initial authorization request. This ensures that the user is redirected directly to the specified IdP.
 
 The `idp_hint` is a custom parameter supported by the application to improve the login experience in multi-Identity Provider (IdP) scenarios.
 It allows a client application (e.g., a custom welcome page) to suggest which IdP should be preselected during the authentication flow.

--- a/content/authentication/sso-bundle/custom-template.md
+++ b/content/authentication/sso-bundle/custom-template.md
@@ -142,12 +142,14 @@ Each token is signed by a signing certificate. The following options are availab
 ### Placeholders {#placeholders}
 Inside some fields you can use placeholders that are resolved by {{< product-c8y-iot >}} at runtime. Available placeholders are:
 
-|Placeholder|Description|
-|:---|:---|
-|clientId|Value of the **Client ID** field
-|redirectUri| Value of the **Redirect URI** field
-|code|Code returned by the authorization server in response to authorization request
-|refreshToken| Refresh token returned by the authorization server after token request
+| Placeholder  | Description                                                                    |
+|:-------------|:-------------------------------------------------------------------------------|
+| clientId     | Value of the **Client ID** field                                               
+| redirectUri  | Value of the **Redirect URI** field                                            
+| code         | Code returned by the authorization server in response to authorization request 
+| refreshToken | Refresh token returned by the authorization server after token request         
+| id_token     | A jwt token issued by the Auth Server, that contains claims about the authenticated user, can be used for logout in Auth Server
+| idp_hint     | Value of the **idp_hint** parameter passed by UI aplication, to choose which IdP should be preselected during the authentication flow.                    
 
 These placeholders can be used in authorization requests, token requests, refresh requests and logout request in the fields:
 
@@ -165,3 +167,33 @@ Placeholders can also be used as a part of text:
 {{< c8y-admon-info >}}
 Placeholders are not validated for correctness. Any not recognized or misspelled placeholder will be left in text unprocessed.
 {{< /c8y-admon-info >}}
+
+### Client Suggested Identity Provider
+When the default login mode is **Single sign-on redirect**, and the Auth Server supports multiple identity providers, instead of displaying an intermediate "select identity provider" screen to the user, the `idp_hint` parameter can be collected by {{< product-c8y-iot >}} and forwarded to the Auth Server as part of the initial authorization request. This ensures that the user is redirected directly to the specified IdP.
+
+The `idp_hint` is a custom parameter supported by the application to improve the login experience in multi-Identity Provider (IdP) scenarios.
+It allows a client application (e.g., a custom welcome page) to suggest which IdP should be preselected during the authentication flow.
+
+1. A client custom application appends the `idp_hint` parameter to the login URL:
+
+```
+https://{{< domain-c8y >}}/apps/public/login/index.html?idp_hint=google
+```
+
+2. The {{< product-c8y-iot >}} application extracts the value of `idp_hint` (e.g., `google`).
+3. During the OAuth2/OIDC authorization request, this value is mapped and passed to the underlying Auth Server.
+
+##### Example with Keycloak
+Keycloak supports [an identity provider hinting feature](https://www.keycloak.org/docs/latest/server_admin/index.html#_client_suggested_idp) using the `kc_idp_hint` parameter.  
+If the `idp_hint` value is `google`, and authorization request headers are configured with key: `kc_idp_hint`, value `${idp_hint}`, {{< product-c8y-iot >}} will translate it into a Keycloak compatible parameter and forward it:
+
+```
+https://keycloak.com/realms/myrealm/protocol/openid-connect/auth
+  ?kc_idp_hint=google
+  &...
+```
+
+In this example:
+- A custom "welcome page" provides `idp_hint=google`.
+- {{< product-c8y-iot >}} translates this hint into Keycloak’s `kc_idp_hint=google`.
+- The user is immediately redirected to the Google IdP without having to manually select it from the Keycloak login screen.

--- a/content/authentication/sso-bundle/custom-template.md
+++ b/content/authentication/sso-bundle/custom-template.md
@@ -148,7 +148,7 @@ Inside some fields you can use placeholders that are resolved by {{< product-c8y
 | redirectUri  | Value of the **Redirect URI** field                                            
 | code         | Code returned by the authorization server in response to authorization request 
 | refreshToken | Refresh token returned by the authorization server after token request         
-| id_token     | A jwt token issued by the Auth Server, that contains claims about the authenticated user, can be used for logout in Auth Server
+| id_token     | A JWT token issued by the authorization server that contains claims about the authenticated user; can be used for logout from the authorization server
 | idp_hint     | Value of the **idp_hint** parameter passed by UI aplication, to choose which IdP should be preselected during the authentication flow.                    
 
 These placeholders can be used in authorization requests, token requests, refresh requests and logout request in the fields:

--- a/content/authentication/sso-bundle/custom-template.md
+++ b/content/authentication/sso-bundle/custom-template.md
@@ -185,7 +185,7 @@ https://{{< domain-c8y >}}/apps/public/login/index.html?idp_hint=google
 
 #### Example with Keycloak {#example-with-keycloak}
 Keycloak supports [an identity provider hinting feature](https://www.keycloak.org/docs/latest/server_admin/index.html#_client_suggested_idp) using the `kc_idp_hint` parameter.  
-If the `idp_hint` value is `google`, and authorization request headers are configured with key: `kc_idp_hint`, value `${idp_hint}`, {{< product-c8y-iot >}} will translate it into a Keycloak compatible parameter and forward it:
+If the `idp_hint` value is "google", and the authorization request headers are configured with key `kc_idp_hint`, value `${idp_hint}`, {{< product-c8y-iot >}} will translate it into a Keycloak compatible parameter and forward it:
 
 ```
 https://keycloak.com/realms/myrealm/protocol/openid-connect/auth

--- a/content/authentication/sso-bundle/integration-with-azure.md
+++ b/content/authentication/sso-bundle/integration-with-azure.md
@@ -1,5 +1,5 @@
 ---
-weight: 40
+weight: 50
 title: Integration with Azure AD
 layout: bundle
 sector:

--- a/content/authentication/sso-bundle/integration-with-keycloak.md
+++ b/content/authentication/sso-bundle/integration-with-keycloak.md
@@ -1,5 +1,5 @@
 ---
-weight: 60
+weight: 40
 title: Integration with Keycloak
 layout: redirect
 sector:


### PR DESCRIPTION
For reviewers:
- Single sign-on, document new IDP_hint mechanism. The optional SSO parameter allows for preselecting the Identity provider during login via SSO default mode.
- Document missing id_token parameter.
- Change the order of tabs (In my opinion, it fits better)

[Feature details description](https://docs.google.com/document/d/1KJxY_EMP3yNXH7Lb1hhMq58jmYSVCGgXRvzRrmwdgA4/edit?tab=t.0#heading=h.2qwwb911rm0j)
