### PR TITLE
MTM-62874 add changelog about jetty upgrade to 12.0.25 in java SDK

### DIFF
--- a/content/change-logs/platform-services/cumulocity-2025-72-0-upgrade-jetty-in-sdk-to-ver-12.md
+++ b/content/change-logs/platform-services/cumulocity-2025-72-0-upgrade-jetty-in-sdk-to-ver-12.md
@@ -16,7 +16,9 @@ version: 2025.72.0
 ---
 
 The Jetty library version in the Java SDK was upgraded from version 11.0.24 to the most recent version 12.0.25. 
-This version is compatible with the current Spring Boot version 3.5.5 in the Java SDK. Detailed upgrade notes can be found
-in the official [Jetty migration documentation](https://jetty.org/docs/jetty/12.1/programming-guide/migration/11-to-12.html).
+This version is compatible with the current Spring Boot version 3.5.5 in the Java SDK.
+No impact is expected on microservice code using standard Microservice SDK features.
+For microservices that use advanced customization of the Jetty server configuration we would advise referring to the official 
+ [migration guide from Jetty 11.0.x to Jetty 12.0.x ](https://jetty.org/docs/jetty/12.1/programming-guide/migration/11-to-12.html).
 
 

--- a/content/change-logs/platform-services/cumulocity-2025-72-0-upgrade-jetty-in-sdk-to-ver-12.md
+++ b/content/change-logs/platform-services/cumulocity-2025-72-0-upgrade-jetty-in-sdk-to-ver-12.md
@@ -1,7 +1,7 @@
 ---
 date:
 title: Upgraded Jetty in Java SDK to version 12
-product_area: Application enablement & solutions 
+product_area: Application enablement & solutions
 change_type:
   - value: change-2c7RdTdXo4
     label: Improvement
@@ -16,6 +16,7 @@ version: 2025.72.0
 ---
 
 The Jetty library version in the Java SDK was upgraded from version 11.0.24 to the most recent version 12.0.25. 
-This version is compatible with the current Spring Boot version 3.5.5 in the Java SDK.
+This version is compatible with the current Spring Boot version 3.5.5 in the Java SDK. Detailed upgrade notes can be found
+in the official [Jetty migration documentation](https://jetty.org/docs/jetty/12.1/programming-guide/migration/11-to-12.html).
 
 

--- a/content/change-logs/platform-services/cumulocity-2025-72-0-upgrade-jetty-in-sdk-to-ver-12.md
+++ b/content/change-logs/platform-services/cumulocity-2025-72-0-upgrade-jetty-in-sdk-to-ver-12.md
@@ -1,7 +1,7 @@
 ---
 date:
 title: Upgraded Jetty in Java SDK to version 12
-product_area: Application enablement & solutions
+product_area: Application enablement & solutions 
 change_type:
   - value: change-2c7RdTdXo4
     label: Improvement

--- a/content/change-logs/platform-services/cumulocity-2025-72-0-upgrade-jetty-in-sdk-to-ver-12.md
+++ b/content/change-logs/platform-services/cumulocity-2025-72-0-upgrade-jetty-in-sdk-to-ver-12.md
@@ -1,0 +1,21 @@
+---
+date:
+title: Upgraded Jetty in Java SDK to version 12
+product_area: Application enablement & solutions
+change_type:
+  - value: change-2c7RdTdXo4
+    label: Improvement
+component:
+  - value: QWPx3rFfn
+    label: Java SDK
+build_artifact:
+  - value: tc-QHwMfWtBk7
+    label: cumulocity
+ticket: MTM-62874
+version: 2025.72.0
+---
+
+The Jetty library version in the Java SDK was upgraded from version 11.0.24 to the most recent version 12.0.25. 
+This version is compatible with the current Spring Boot version 3.5.5 in the Java SDK.
+
+


### PR DESCRIPTION
Screenshot from local hugo run, after adding date:
<img width="876" height="293" alt="image" src="https://github.com/user-attachments/assets/9aff6e76-2926-4cc5-8327-935926440cbd" />

