### PR TITLE
changed Thin Edge to thin-edge.io

### DIFF
--- a/content/change-logs/device-management/opcua-1021-9-0-opc-ua-device-gateway-with-thin-edge-mqtt-forwarding.md
+++ b/content/change-logs/device-management/opcua-1021-9-0-opc-ua-device-gateway-with-thin-edge-mqtt-forwarding.md
@@ -1,6 +1,6 @@
 ---
 date: 2025-07-28
-title: OPC UA device gateway with Thin Edge MQTT Forwarding
+title: OPC UA device gateway with thin-edge.io MQTT Forwarding
 product_area: Device management & connectivity
 change_type:
   - value: change-pXAlHAWka
@@ -14,4 +14,4 @@ build_artifact:
 ticket: DM-4473
 version: 1021.9.0
 ---
-Starting from the opcua-device-gateway version 1021.9.0, the OPC UA device gateway can forward data from OPC UA servers to Thin Edge MQTT topics instead of sending it directly to {{< product-c8y-iot >}}. The primary use case is to utilize Thin Edge also for data forwarding when running in Thin Edge mode. While doing this, the OPC UA device gateway bundles multiple collected measurement/event series into a single measurement/event when they are from the same device protocol and use cyclic reads.
+Starting from the opcua-device-gateway version 1021.9.0, the OPC UA device gateway can forward data from OPC UA servers to thin-edge.io MQTT topics instead of sending it directly to {{< product-c8y-iot >}}. The primary use case is to utilize thin-edge.io also for data forwarding when running in thin-edge.io mode. While doing this, the OPC UA device gateway bundles multiple collected measurement/event series into a single measurement/event when they are from the same device protocol and use cyclic reads.

--- a/content/device-integration/opcua-bundle/device-protocols.md
+++ b/content/device-integration/opcua-bundle/device-protocols.md
@@ -160,16 +160,16 @@ If [MQTT Forwarding mode](#mqtt-forwarding-mode) is enabled, the configured func
 
 **Send measurement (MQTT Forwarding mode)**
 
-Measurements are sent to the MQTT topic `te/<identifier>/m/<measurement-type>` of Thin Edge. As Thin Edge only supports measurement values in measurements, the measurement units configured in the device protocol are ignored. Also, the standard fragments of the OPC-UA Gateway and additionally configured static fragments are not populated.
+Measurements are sent to the MQTT topic `te/<identifier>/m/<measurement-type>` of thin-edge.io. As thin-edge.io only supports measurement values in measurements, the measurement units configured in the device protocol are ignored. Also, the standard fragments of the OPC-UA Gateway and additionally configured static fragments are not populated.
 
 
 **Create alarm (MQTT Forwarding mode)**
 
-Alarms are created by sending them to the `te/<identifier>/a/<alarm-type>` MQTT topic of Thin Edge. Alarms are cleared by sending an empty message to the same topic. The logic to clear and deduplicate alarms is unchanged.
+Alarms are created by sending them to the `te/<identifier>/a/<alarm-type>` MQTT topic of thin-edge.io. Alarms are cleared by sending an empty message to the same topic. The logic to clear and deduplicate alarms is unchanged.
 
 **Send event (MQTT Forwarding mode)**
 
-Events are sent to the `te/<identifier>/e/<event-type>` MQTT topic of Thin Edge.
+Events are sent to the `te/<identifier>/e/<event-type>` MQTT topic of thin-edge.io.
 
 **Custom actions (MQTT Forwarding mode)**
 
@@ -177,13 +177,13 @@ Custom actions in MQTT Forwarding mode use the same body template mechanism. The
 
 **Send measurement (MQTT Forwarding mode, merging enabled)**
 
-Merging measurements is only supported for cyclic reads but not for subscriptions. Variables coming in the same cyclic read (meaning they use the same data reporting in a device protocol) are sent as a single, multi-value measurement to the `te/<identifier>/m/<measurement-type>` of Thin Edge. The configured type and series for the variable will be used as fragment and series in the measurement. If multiple variables are configured for the same type, they will be consolidated into a single fragment.
+Merging measurements is only supported for cyclic reads but not for subscriptions. Variables coming in the same cyclic read (meaning they use the same data reporting in a device protocol) are sent as a single, multi-value measurement to the `te/<identifier>/m/<measurement-type>` of thin-edge.io. The configured type and series for the variable will be used as fragment and series in the measurement. If multiple variables are configured for the same type, they will be consolidated into a single fragment.
 
 The measurement type of the measurement is `c8y_OpcuaMeasurement` unless `gateway.mappings.mergedMeasurementType` in the configuration has been set to a different type.
 
 **Send event (MQTT Forwarding mode, merging enabled)**
 
-Merging events is only supported for cyclic reads but not for subscriptions. Variables coming in the same cyclic read (meaning they use the same data reporting in a device protocol) are sent as a single event with multiple fragments to the `te/<identifier>/e/<event-type>` of Thin Edge. The configured type for the variable is used as the fragment name. While it is allowed to use the same event type for multiple variables in a device protocol, here this will result in variables overwriting each other and hence generally discouraged.
+Merging events is only supported for cyclic reads but not for subscriptions. Variables coming in the same cyclic read (meaning they use the same data reporting in a device protocol) are sent as a single event with multiple fragments to the `te/<identifier>/e/<event-type>` of thin-edge.io. The configured type for the variable is used as the fragment name. While it is allowed to use the same event type for multiple variables in a device protocol, here this will result in variables overwriting each other and hence generally discouraged.
 
 The event type of the event is `c8y_OpcuaEvent` unless `gateway.mappings.mergedEventType` in the configuration has been set to a different type.
 

--- a/content/device-integration/opcua-bundle/gateway-configuration-and-registration.md
+++ b/content/device-integration/opcua-bundle/gateway-configuration-and-registration.md
@@ -33,7 +33,7 @@ gateway:
 Windows OS is used for the example.
 {{< /c8y-admon-info >}}
 
-### Thin Edge {#thin-edge}
+### thin-edge.io {#thin-edge}
 
 The OPC UA gateway can also be registered and operated via [thin-edge.io](https://thin-edge.io/). In contrast to the standalone mode, `thinEdge` configurations must be added to the YAML file:
 
@@ -54,13 +54,13 @@ gateway:
         deviceId: Thin-Edge_Device
 ```
 
-With the configuration `gateway.thinEdge.enabled: true` you switch to the thinEdge mode. This means that the authentication and registration to the platform will be done via Thin Edge. The OPC UA gateway is automatically registered and created as a sub-device under the Thin Edge device. `gateway.thinEdge.mqttServerURL` and `gateway.thinEdge.deviceId` are the connection information for the MQTT client to connect to the local Thin Edge MQTT broker.
+With the configuration `gateway.thinEdge.enabled: true` you switch to the thin-edge.io mode. This means that the authentication and registration to the platform will be done via thin-edge.io. The OPC UA gateway is automatically registered and created as a subdevice under the thin-edge.io device. `gateway.thinEdge.mqttServerURL` and `gateway.thinEdge.deviceId` are the connection information for the MQTT client to connect to the local thin-edge.io MQTT broker.
 
 {{< c8y-admon-preview-feature >}}
 
 ### MQTT Forwarding mode {#mqtt-forwarding-mode}
 
-The OPC UA gateway supports an MQTT Forwarding mode that can be used together with the Thin Edge mode. In addition to the OPC UA gateway being registered as a child device of the Thin Edge device and the OPC UA gateway using credentials provided by Thin Edge, in MQTT Forwarding mode the OPC UA gateway also uses Thin Edge to send the data it receives from OPC UA servers to {{< product-c8y-iot >}}. When using cyclic reads, the data received in a single cyclic read that is mapped to measurements, events, or custom actions can be batched into a single message.
+The OPC UA gateway supports an MQTT Forwarding mode that can be used together with the thin-edge.io mode. In addition to the OPC UA gateway being registered as a child device of the thin-edge.io device and the OPC UA gateway using credentials provided by thin-edge.io, in MQTT Forwarding mode the OPC UA gateway also uses thin-edge.io to send the data it receives from OPC UA servers to {{< product-c8y-iot >}}. When using cyclic reads, the data received in a single cyclic read that is mapped to measurements, events, or custom actions can be batched into a single message.
 
 The MQTT Forwarding mode uses the existing `thinEdge` configuration and introduces a number of additional configuration options to the YAML file:
 
@@ -168,7 +168,7 @@ C8Y:
 
   # Password for HTTP proxy authentication
   # proxyPassword: yourProxyPassword
-  
+
 #
 # Gateway-specific settings
 #
@@ -182,17 +182,17 @@ gateway:
   # where local data is stored.
   db:
     baseDir: ${user.home}/.opcua/data
-  # These settings configure and enable/disable Thin Edge mode (registration and operating OPC UA gateway via Thin Edge).
+  # These settings configure and enable/disable thin-edge.io mode (registration and operating OPC UA gateway via thin-edge.io).
   thinEdge:
-    # Enable Thin Edge if the OPC UA gateway is running next to Thin Edge and should use it to connect to {{< product-c8y-iot >}}.
-    # Set enabled to false if the OPC UA gateway is running without Thin Edge.
+    # Enable thin-edge.io if the OPC UA gateway is running next to thin-edge.io and should use it to connect to {{< product-c8y-iot >}}.
+    # Set enabled to false if the OPC UA gateway is running without thin-edge.io.
     enabled: false
-    # MQTT Server URL of Thin Edge (localhost).
+    # MQTT Server URL of thin-edge.io (localhost).
     mqttServerURL: tcp://127.0.0.1:1883
     # Enable this if the MQTT client uses a single steady connection. Note that MQTT is only used to retrieve the JWT, which is dependent on how long the JWT is valid. See https://{{< domain-c8y >}}/guides/device-integration/mqtt/#jwt-token-retrieval.
     # We recommend you to use a steady connection only if the JWT is valid for a short time. If the JWT is valid for a longer time, the standard is one hour. It is generally not recommended to have a steady MQTT connection.
     mqttSteadyConnection: false
-    # The Thin Edge deviceId must be changed, depending on the configured deviceId of the Thin Edge certificate.
+    # The thin-edge.io deviceId must be changed, depending on the configured deviceId of the thin-edge.io certificate.
     deviceId: my-thin-edge-device
   # These settings control the device bootstrap process of the gateway.
   # In general, the default settings are sufficient, and should not be changed.

--- a/content/device-integration/opcua-bundle/registering-gateway-as-device.md
+++ b/content/device-integration/opcua-bundle/registering-gateway-as-device.md
@@ -17,5 +17,5 @@ layout: redirect
 ![Device Registration Acceptance](/images/device-protocols/opcua/opcua-device-registration.png)
 
 {{< c8y-admon-info >}}
-If you run the OPC UA Gateway in Thin Edge mode, manual registration is not needed. Thin Edge automatically registers the OPC UA Gateway at {{< product-c8y-iot >}} as a sub-device of its device.
+If you run the OPC UA Gateway in thin-edge.io mode, manual registration is not needed. thin-edge.io automatically registers the OPC UA Gateway at {{< product-c8y-iot >}} as a sub-device of its device.
 {{< /c8y-admon-info >}}


### PR DESCRIPTION
As discussed change all occurrences of "Thin Edge" to "thin-edge.io" throughout the user docs.