### PR TITLE
Add depreaction notice for EPL apps support for MQTT service

### DIFF
--- a/content/change-logs/analytics/apama-in-c8y-20251010-Deprecation-of-MQTT-Service-support-in-EPL-Apps.md
+++ b/content/change-logs/analytics/apama-in-c8y-20251010-Deprecation-of-MQTT-Service-support-in-EPL-Apps.md
@@ -1,0 +1,17 @@
+---
+date: 
+title: Deprecation of MQTT Service support in EPL Apps
+change_type:
+  - value: change-inv-3bw8e
+    label: Announcement
+product_area: Analytics
+component:
+  - value: component-M5-cepIIS
+    label: Streaming Analytics
+build_artifact:
+  - value: tc-KXXmo2SUR
+    label: apama-in-c8y
+version: 
+---
+
+The API to support MQTT Service in EPL Apps has been deprecated. The replacement API will be provided in a future release.

--- a/content/change-logs/analytics/apama-in-c8y-20251010-Deprecation-of-MQTT-Service-support-in-EPL-Apps.md
+++ b/content/change-logs/analytics/apama-in-c8y-20251010-Deprecation-of-MQTT-Service-support-in-EPL-Apps.md
@@ -14,4 +14,4 @@ build_artifact:
 version: 
 ---
 
-The API to support MQTT Service in EPL Apps has been deprecated. A replacement API may be provided in future.
+The API to support MQTT Service in EPL Apps has been deprecated.

--- a/content/change-logs/analytics/apama-in-c8y-20251010-Deprecation-of-MQTT-Service-support-in-EPL-Apps.md
+++ b/content/change-logs/analytics/apama-in-c8y-20251010-Deprecation-of-MQTT-Service-support-in-EPL-Apps.md
@@ -14,4 +14,4 @@ build_artifact:
 version: 
 ---
 
-The API to support MQTT Service in EPL Apps has been deprecated. The replacement API will be provided in a future release.
+The API to support MQTT Service in EPL Apps has been deprecated. A replacement API may be provided in future.


### PR DESCRIPTION
The current EPL API for MQTT Service is deprecated. Add a release note for it. The replacement API will be provided in future.