### PR TITLE
[MTM-64106] Move-certificate-authority-feature-to-generally-available

### DIFF
--- a/content/change-logs/platform-services/cumulocity-2025-346-0-certificate-authority-feature-generally-available.md
+++ b/content/change-logs/platform-services/cumulocity-2025-346-0-certificate-authority-feature-generally-available.md
@@ -15,7 +15,7 @@ ticket: MTM-64106
 version: 2025.346.0
 ---
 The certificate authority feature previously released in [Public Preview](/change-logs/?component=.component-authentication%2C.component-web-sdk#cumulocity-undefined-certificate-authority-feature-preview) is now Generally Available (GA).
-It is enabled by default for all tenants, with no additional configuration or activation required.
+It is available in CD versions 2025.346.0 and higher, and in the 2026 annual release.
 
 The feature can be accessed in the Device Management application under Management → Trusted Certificates, where the “Add CA Certificate” option is now available by default.
 

--- a/content/change-logs/platform-services/cumulocity-2025-346-0-certificate-authority-feature-generally-available.md
+++ b/content/change-logs/platform-services/cumulocity-2025-346-0-certificate-authority-feature-generally-available.md
@@ -1,5 +1,5 @@
 ---
-date: '2025-10-13'
+date:
 title: Enhanced certificate management with ability to sign and issue certificates
 product_area: Platform services
 change_type:

--- a/content/change-logs/platform-services/cumulocity-2025-346-0-certificate-authority-feature-generally-available.md
+++ b/content/change-logs/platform-services/cumulocity-2025-346-0-certificate-authority-feature-generally-available.md
@@ -12,10 +12,10 @@ build_artifact:
   - value: tc-QHwMfWtBk7
     label: cumulocity
 ticket: MTM-64106
-version: 2025.346.0
+version: 2025.348.0
 ---
 The certificate authority feature previously released in [Public Preview](/change-logs/?component=.component-authentication%2C.component-web-sdk#cumulocity-undefined-certificate-authority-feature-preview) is now Generally Available (GA).
-It is available in CD versions 2025.346.0 and higher, and in the 2026 annual release.
+It is available in CD versions 2025.348.0 and higher, and in the 2026 annual release.
 
 The feature can be accessed in the Device Management application under Management → Trusted Certificates, where the “Add CA Certificate” option is now available by default.
 

--- a/content/change-logs/platform-services/cumulocity-2025-346-0-certificate-authority-feature-generally-available.md
+++ b/content/change-logs/platform-services/cumulocity-2025-346-0-certificate-authority-feature-generally-available.md
@@ -1,0 +1,28 @@
+---
+date: '2025-10-13'
+title: Enhanced certificate management with ability to sign and issue certificates
+product_area: Platform services
+change_type:
+  - value: change-QHu1GdukP
+    label: Feature
+component:
+  - value: q3kclF6pO
+    label: Authentication
+build_artifact:
+  - value: tc-QHwMfWtBk7
+    label: cumulocity
+ticket: MTM-64106
+version: 2025.346.0
+---
+The certificate authority feature previously released in [Public Preview](/change-logs/?component=.component-authentication%2C.component-web-sdk#cumulocity-undefined-certificate-authority-feature-preview) is now Generally Available (GA).
+It is enabled by default for all tenants, with no additional configuration or activation required.
+
+The feature can be accessed in the Device Management application under Management → Trusted Certificates, where the “Add CA Certificate” option is now available by default.
+
+{{< product-c8y-iot >}} has been enhanced to function as a Certificate Authority (CA), providing the following capabilities:
+- Manage signing certificates
+- Accept Certificate Signing Requests (CSR)
+- Perform legitimacy checks, as defined by each tenant
+- Issue signed X.509 certificates trusted by the device tenant
+
+For more details about this feature refer to [Certificate Authority (CA)](/device-certificate-authentication/certificate-authority).


### PR DESCRIPTION
Release notes about enabling the certificate authority feature by default.
Related changes: https://github.com/Cumulocity-IoT/cumulocity-helm_charts/pull/473

@JanePorter @mgrumann  please review and update the content of the announcement to make it sound better.