### PR TITLE
[MTM-64869] Change logs for Java SDK, bugfix for resolving tenant or …

### DIFF
--- a/content/change-logs/platform-services/cumulocity-2025-78-0-External-Jwt-token-load-correctly-tenant-and-username.md
+++ b/content/change-logs/platform-services/cumulocity-2025-78-0-External-Jwt-token-load-correctly-tenant-and-username.md
@@ -15,7 +15,7 @@ ticket: MTM-64869
 version: 2025.78.0
 ---
 
-Resolved an issue in the Java SDK where authentication using [external IAM JWT tokens](/authentication/sso/#configuring-access-tokens) failed to correctly identify the tenant and user when the token did not include a tenant ID or username in its claims.
+If using [external IAM JWT tokens](/authentication/sso/#configuring-access-tokens), the authentication failed to correctly identify the tenant and user when the token did not include a tenant ID or username in its claims. 
 With this fix, the SDK now properly retrieves the tenantId and username from the CumulocityCredentials context, ensuring correct identification and smoother integration with external identity providers.
 
 

--- a/content/change-logs/platform-services/cumulocity-2025-78-0-External-Jwt-token-load-correctly-tenant-and-username.md
+++ b/content/change-logs/platform-services/cumulocity-2025-78-0-External-Jwt-token-load-correctly-tenant-and-username.md
@@ -15,7 +15,7 @@ ticket: MTM-64869
 version: 2025.78.0
 ---
 
-If using [external IAM JWT tokens](/authentication/sso/#configuring-access-tokens), the authentication failed to correctly identify the tenant and user when the token did not include a tenant ID or username in its claims. 
+When using [external IAM JWT tokens](/authentication/sso/#configuring-access-tokens), the authentication failed to correctly identify the tenant and user when the token did not include a tenant ID or username in its claims. 
 With this fix, the Java SDK now properly retrieves the tenant ID and username from the {{< product-c8y-iot >}} credentials context, ensuring correct identification and smoother integration with external identity providers.
 
 

--- a/content/change-logs/platform-services/cumulocity-2025-78-0-External-Jwt-token-load-correctly-tenant-and-username.md
+++ b/content/change-logs/platform-services/cumulocity-2025-78-0-External-Jwt-token-load-correctly-tenant-and-username.md
@@ -16,6 +16,6 @@ version: 2025.78.0
 ---
 
 When using [external IAM JWT tokens](/authentication/sso/#configuring-access-tokens), the authentication failed to correctly identify the tenant and user when the token did not include a tenant ID or username in its claims. 
-With this fix, the Java SDK now properly retrieves the tenant ID and username from the {{< product-c8y-iot >}} credentials context, ensuring correct identification and smoother integration with external identity providers.
+With this change, the Java SDK now properly retrieves the tenant ID and username from the {{< product-c8y-iot >}} credentials context, ensuring correct identification and smoother integration with external identity providers.
 
 

--- a/content/change-logs/platform-services/cumulocity-2025-78-0-External-Jwt-token-load-correctly-tenant-and-username.md
+++ b/content/change-logs/platform-services/cumulocity-2025-78-0-External-Jwt-token-load-correctly-tenant-and-username.md
@@ -1,0 +1,21 @@
+---
+date:
+title: Improved Java SDK support for external IAM tokens without tenant or username claims
+product_area: Application enablement & solutions
+change_type:
+  - value: change-2c7RdTdXo4
+    label: Improvement
+component:
+  - value: QWPx3rFfn
+    label: Java SDK
+build_artifact:
+  - value: tc-QHwMfWtBk7
+    label: cumulocity
+ticket: MTM-64869
+version: 2025.78.0
+---
+
+Resolved an issue in the Java SDK where authentication using [external IAM JWT tokens](/authentication/sso/#configuring-access-tokens) failed to correctly identify the tenant and user when the token did not include a tenant ID or username in its claims.
+With this fix, the SDK now properly retrieves the tenantId and username from the CumulocityCredentials context, ensuring correct identification and smoother integration with external identity providers.
+
+

--- a/content/change-logs/platform-services/cumulocity-2025-78-0-External-Jwt-token-load-correctly-tenant-and-username.md
+++ b/content/change-logs/platform-services/cumulocity-2025-78-0-External-Jwt-token-load-correctly-tenant-and-username.md
@@ -16,6 +16,6 @@ version: 2025.78.0
 ---
 
 If using [external IAM JWT tokens](/authentication/sso/#configuring-access-tokens), the authentication failed to correctly identify the tenant and user when the token did not include a tenant ID or username in its claims. 
-With this fix, the SDK now properly retrieves the tenantId and username from the CumulocityCredentials context, ensuring correct identification and smoother integration with external identity providers.
+With this fix, the Java SDK now properly retrieves the tenant ID and username from the {{< product-c8y-iot >}} credentials context, ensuring correct identification and smoother integration with external identity providers.
 
 


### PR DESCRIPTION
Reported by SAP, External IAM tokens come directly from authorization servers (not generated by Cumulocity).
These tokens have their own custom claims. They don't have the 'ten' claim, which is used in C8Y to identify tenants.

Bugfix was about passing the tenant through a microservice proxy.
So it will be accessible in CumulocityCredentials in the SDK. 