### PR TITLE
CIE-5502 - A cautionary note about kubernetes Ingress providers blocking ports we need

### DIFF
--- a/content/edge-kubernetes/installing-edge-on-k8-bundle/install-edge-with-edge-operator.md
+++ b/content/edge-kubernetes/installing-edge-on-k8-bundle/install-edge-with-edge-operator.md
@@ -13,6 +13,7 @@ Edge has been tested and officially supported on Kubernetes version 1.32.x, the 
 
 **Important:**
 * Edge requires that your Kubernetes cluster has support for **LoadBalancer services**.
+* Edge requires that your Kubernetes cluster does not have an **Ingress provider** (for example, Traefik) enabled on common ports that would block those used by Edge, such as ports 80 and 443.
 * Edge requires that your Kubernetes cluster has **dynamic volume provisioning** enabled with a default storage class.
 * Edge is tested and supported on **single-node Kubernetes clusters** only.
 {{< /c8y-admon-info >}}

--- a/content/edge-kubernetes/manage-edge-bundle/external-ip.md
+++ b/content/edge-kubernetes/manage-edge-bundle/external-ip.md
@@ -34,4 +34,4 @@ When manually assigning the external IP, see the following Kubernetes API docume
 "These IPs are not managed by Kubernetes. The user is responsible for ensuring that traffic arrives at a node with this IP."
 {{< /c8y-admon-info >}}
 
-Even if a load balancer is available, it may be that some of the ports required are already being monopolised by a Kubernetes Ingress provider. For example, Traefik will normally take over ports 80 and 443, and will need to be disabled or reconfigured.
+Even if a load balancer is available, it may be that some of the ports required are already being monopolized by a Kubernetes Ingress provider. For example, Traefik will normally take over ports 80 and 443, and will need to be disabled or reconfigured.

--- a/content/edge-kubernetes/manage-edge-bundle/external-ip.md
+++ b/content/edge-kubernetes/manage-edge-bundle/external-ip.md
@@ -17,7 +17,9 @@ Sample output of the `kubectl get service` command:
 NAME              	TYPE           CLUSTER-IP          EXTERNAL-IP         PORT(S)
 cumulocity-ontoplb  LoadBalancer   X.X.X.X **REDACTED  X.X.X.X **REDACTED  443:32443/TCP,8443:32442/TCP,1883:32083/TCP,8883:32084/TCP ...
 ```
-Sometimes the external IP displays as `<pending>` or `<none>`. The IP assignment process is dependent on the Kubernetes hosting environment. An external load balancer in the hosting environment handles the IP allocation and any other configurations necessary to route the external traffic to the Kubernetes service. Most on-premise Kubernetes clusters do not have external load balancers that can dynamically allocate IPs. The most common solution is to manually assign an external IP to the service. This can be done in the service’s YAML configuration. You can use the following command to manually assign an external IP to the `cumulocity-ontoplb` service (replace `<EXTERNAL-IP>` in the command below with the IP address you want to assign).
+Sometimes the external IP displays as `<pending>` or `<none>`. The IP assignment process is dependent on the Kubernetes hosting environment. An external load balancer in the hosting environment handles the IP and port allocation, along with any other configurations necessary to route the external traffic to the Kubernetes service.
+
+Most on-premise Kubernetes clusters do not have external load balancers that can dynamically allocate IPs. The most common solution is to manually assign an external IP to the service. This can be done in the service’s YAML configuration. You can use the following command to manually assign an external IP to the `cumulocity-ontoplb` service (replace `<EXTERNAL-IP>` in the command below with the IP address you want to assign).
 
 ```shell
 kubectl patch service cumulocity-ontoplb --namespace=c8yedge -p '{"spec":{"type": "LoadBalancer", "externalIPs":["<EXTERNAL-IP>"]}}'
@@ -32,4 +34,4 @@ When manually assigning the external IP, see the following Kubernetes API docume
 "These IPs are not managed by Kubernetes. The user is responsible for ensuring that traffic arrives at a node with this IP."
 {{< /c8y-admon-info >}}
 
-
+Even if a load balancer is available, it may be that some of the ports required are already being monopolised by a Kubernetes Ingress provider. For example, Traefik will normally take over ports 80 and 443, and will need to be disabled or reconfigured.


### PR DESCRIPTION
Being helpful, while technically sticking to the principle of not being responsible for individual Kubernetes providers.