### PR TITLE
Clarified roles versus permissions usage

### DIFF
--- a/content/authentication/sso-bundle/custom-template.md
+++ b/content/authentication/sso-bundle/custom-template.md
@@ -53,7 +53,7 @@ Under **Dynamic access mapping principle** you can select one of the following o
 
 * **Roles selected in the rules above will be reassigned to a user on each log in and other ones will be cleared**: This is the default. Dynamic access mapping assigns user roles, based on the token, on every user login. It is not possible to change the user roles inside {{< product-c8y-iot >}} as they would be overwritten on the next user login. To change this behavior, select one of the remaining options.
 
-If you select either of the first two options mentioned above, this will also allow administrators to edit the roles of SSO users in the user management. For details, refer to [Managing permissions](/standard-tenant/managing-permissions/#to-assign-global-roles).
+If you select either of the first two options mentioned above, this will also allow administrators to edit the roles of SSO users in the user management. For details, refer to [Managing permissions and roles](/standard-tenant/managing-permissions/#to-assign-global-roles).
 
 The dynamic access mapping configuration allows you to define the rules for assigning roles to users based on JWT claims. The rule that matches the token's value is used to assign the appropriate set of roles to the user.
 
@@ -146,7 +146,7 @@ Inside some fields you can use placeholders that are resolved by {{< product-c8y
 |:-------------|:-------------------------------------------------------------------------------|
 | clientId     | Value of the **Client ID** field                                               
 | redirectUri  | Value of the **Redirect URI** field                                            
-| code         | Code returned by the authorization server in response to authorization request 
+| code         | Code returned by the authorization server in response to authorization request
 | refreshToken | Refresh token returned by the authorization server after token request         
 | id_token     | A JWT token issued by the authorization server that contains claims about the authenticated user; can be used for logout from the authorization server
 | idp_hint     | Value of the `idp_hint` parameter passed by the UI application, to select which IdP should be preselected during the authentication flow                   

--- a/content/change-logs/platform-services/cumulocity-undefined-pre-announce-hz-changes.md
+++ b/content/change-logs/platform-services/cumulocity-undefined-pre-announce-hz-changes.md
@@ -19,7 +19,7 @@ the default on  https://eu-latest.cumulocity.com/ and available on all other ins
 The new implementation will go to GA and become the default on all SaaS systems by the end of September 2025.
 The purpose of this announcement is to invite customers who wish to take advantage of this update to participate in the public preview.
 
-Enabling the new implementation is on a per tenant basis and requires the `ROLE_TENANT_MANAGEMENT_ADMIN` permission and use of
+Enabling the new implementation is on a per tenant basis and requires your role to include ADMIN permission for "Tenant management" (API string = `ROLE_TENANT_MANAGEMENT_ADMIN`) and use of
 the [Feature Toggles REST API](https://cumulocity.com/api/core/#operation/setCurrentTenantFeatureToggleValue):
 
 ```bash

--- a/content/change-logs/platform-services/cumulocity-undefined-pre-announce-hz-changes.md
+++ b/content/change-logs/platform-services/cumulocity-undefined-pre-announce-hz-changes.md
@@ -19,8 +19,8 @@ the default on  https://eu-latest.cumulocity.com/ and available on all other ins
 The new implementation will go to GA and become the default on all SaaS systems by the end of September 2025.
 The purpose of this announcement is to invite customers who wish to take advantage of this update to participate in the public preview.
 
-Enabling the new implementation is on a per tenant basis and requires the `ROLE_TENANT_MANAGEMENT_ADMIN` role and use of
-the [Feature Toggles REST API](https://cumulocity.com/api/core/#operation/setCurrentTenantFeatureToggleValue), i.e.:
+Enabling the new implementation is on a per tenant basis and requires the `ROLE_TENANT_MANAGEMENT_ADMIN` permission and use of
+the [Feature Toggles REST API](https://cumulocity.com/api/core/#operation/setCurrentTenantFeatureToggleValue):
 
 ```bash
 curl --location --request PUT "https://<TENANT_DOMAIN>/features/cluster-subscriptions.mongo-persistence/by-tenant" \

--- a/content/cloud-remote-access/setting-up-cloud-remote-access-bundle/endpoints.md
+++ b/content/cloud-remote-access/setting-up-cloud-remote-access-bundle/endpoints.md
@@ -13,7 +13,7 @@ The "endpoint" is the IP address and port of the VNC, SSH or Telnet server runni
 3. Follow the descriptions below for the protocol-specific settings.
 
 {{< c8y-admon-info >}}
-To be able to configure an endpoint, you need ADMIN permission for "Remote access" and "Device control". To read data, a READ permission is sufficient. For more information on permissions, refer to [Managing permissions and roles](/standard-tenant/managing-permissions/).
+To be able to configure an endpoint, you must have a role that includes ADMIN permission for "Remote access" and "Device control". To read data, READ permission is sufficient. For more information on permissions, refer to [Managing permissions and roles](/standard-tenant/managing-permissions/).
 {{< /c8y-admon-info >}}
 
 #### To add a remote access endpoint via VNC {#to-add-a-remote-access-endpoint-via-vnc}

--- a/content/cloud-remote-access/setting-up-cloud-remote-access-bundle/endpoints.md
+++ b/content/cloud-remote-access/setting-up-cloud-remote-access-bundle/endpoints.md
@@ -13,7 +13,7 @@ The "endpoint" is the IP address and port of the VNC, SSH or Telnet server runni
 3. Follow the descriptions below for the protocol-specific settings.
 
 {{< c8y-admon-info >}}
-To be able to configure an endpoint, you need ADMIN permission for "Remote access" and "Device control". To read data, a READ permission is sufficient. For more information on permissions, refer to [Managing permissions](/standard-tenant/managing-permissions/).
+To be able to configure an endpoint, you need ADMIN permission for "Remote access" and "Device control". To read data, a READ permission is sufficient. For more information on permissions, refer to [Managing permissions and roles](/standard-tenant/managing-permissions/).
 {{< /c8y-admon-info >}}
 
 #### To add a remote access endpoint via VNC {#to-add-a-remote-access-endpoint-via-vnc}

--- a/content/cloud-remote-access/setting-up-cloud-remote-access-bundle/troubleshooting-cra.md
+++ b/content/cloud-remote-access/setting-up-cloud-remote-access-bundle/troubleshooting-cra.md
@@ -10,7 +10,7 @@ If you cannot set up new endpoints, check if you have sufficient permissions.
 
 To set up new endpoints, you need ADMIN permission for "Device control" to be able to register a device and ADMIN permission for "Remote access" to be able to add an endpoint.
 
-For more information on permissions, refer to [Managing permissions](/standard-tenant/managing-permissions/).
+For more information on permissions, refer to [Managing permissions and roles](/standard-tenant/managing-permissions/).
 
 **Connection fails**
 

--- a/content/concepts/security-bundle/access-control.md
+++ b/content/concepts/security-bundle/access-control.md
@@ -56,7 +56,7 @@ A detailed description on available default roles and on creating and assigning 
 For details on permission management using the API refer to [the User API](https://{{< domain-c8y >}}/api/core/#tag/User-API) in the {{< openapi >}}.
 
 {{< c8y-admon-important >}}
-In the Cumulocity API, each granular permission is identifed by a unique “permission” string, which is prefixed with `ROLE_` (for example, `ROLE_ALARM_READ`, `ROLE_INVENTORY_ADMIN`). Therefore, permissions are frequently referred to as "roles" throughout the API as well as in the configuration files. For example, the microservice manifest includes a `requiredRoles` field which actually expects a permission string.   
+In the Cumulocity API, each granular permission is identifed by a unique “permission” string, which is prefixed with `ROLE_` (for example, `ROLE_ALARM_READ`, `ROLE_INVENTORY_ADMIN`). Therefore, permissions are frequently referred to as "roles" throughout the API as well as in the configuration files. For example, the microservice manifest includes a `requiredRoles` field which actually expects a permission string. See also the glossary for the usage of the terms "[permission](/glossary/#permission)" and "[role](/glossary/#role)" in the Cumulocity context.  
 {{< /c8y-admon-important >}}
 
 ### Globally accessible objects {#globally-accessible-objects}

--- a/content/concepts/security-bundle/access-control.md
+++ b/content/concepts/security-bundle/access-control.md
@@ -19,7 +19,7 @@ Permissions define explicitly what functionality can be executed by a user.
 
 {{< product-c8y-iot >}} distinguishes read permissions and administration permissions. Read permissions enable users to read data. Administration permissions enable users to create, update and delete data. Read and administration permissions are separately available for the different types of data in {{< product-c8y-iot >}}. For example, there are read permissions for inventory data, measurements, operations and so forth.
 
-To manage permissions more easily, they are grouped into so-called "roles". Every user can be associated with a number of roles, adding up permissions of the user.
+To manage permissions more easily, they are grouped into roles. Every user can be associated with a number of roles, adding up permissions of the user.
 
 The following types of roles can be associated with users:
 
@@ -51,9 +51,13 @@ This concept helps to assign minimal permissions to devices.
 
 Global roles and inventory roles are created and managed in the **Roles** page of the Administration application in the UI.
 
-A detailed description on available default roles and on creating and assigning global and inventory roles can be found in [Managing permissions](/standard-tenant/managing-permissions).
+A detailed description on available default roles and on creating and assigning global and inventory roles can be found in [Managing permissions and roles](/standard-tenant/managing-permissions).
 
 For details on permission management using the API refer to [the User API](https://{{< domain-c8y >}}/api/core/#tag/User-API) in the {{< openapi >}}.
+
+{{< c8y-admon-important >}}
+In the Cumulocity API, each granular permission is identifed by a unique “permission” string, which is prefixed with `ROLE_` (for example, `ROLE_ALARM_READ`, `ROLE_INVENTORY_ADMIN`). Therefore, permissions are frequently referred to as "roles" throughout the API as well as in the configuration files. For example, the microservice manifest includes a `requiredRoles` field which actually expects a permission string.   
+{{< /c8y-admon-important >}}
 
 ### Globally accessible objects {#globally-accessible-objects}
 

--- a/content/concepts/security-bundle/access-control.md
+++ b/content/concepts/security-bundle/access-control.md
@@ -19,7 +19,7 @@ Permissions define explicitly what functionality can be executed by a user.
 
 {{< product-c8y-iot >}} distinguishes read permissions and administration permissions. Read permissions enable users to read data. Administration permissions enable users to create, update and delete data. Read and administration permissions are separately available for the different types of data in {{< product-c8y-iot >}}. For example, there are read permissions for inventory data, measurements, operations and so forth.
 
-To manage permissions more easily, they are grouped into roles. Every user can be associated with a number of roles, adding up permissions of the user.
+To manage permissions more easily, they are grouped into roles. When you assign one or more roles to a user, they gain the combined permissions of all these roles.
 
 The following types of roles can be associated with users:
 

--- a/content/concepts/security-bundle/application-security.md
+++ b/content/concepts/security-bundle/application-security.md
@@ -31,5 +31,5 @@ Due to the very flexible nature of application management within {{< product-c8y
 - [Platform administration > {{< standard-tenant >}} > Changing settings > Application settings](/standard-tenant/changing-settings/) for details on managing application settings in {{< product-c8y-iot >}}.
 - [Application enablement & solutions > Web SDK > Application configuration > Application options](/web/application-configuration/#application-options) for details on application configuration in {{< product-c8y-iot >}}.
 - [Access control](/concepts/security/#access-control) for details on access control configuration.
-- [Managing permissions](/standard-tenant/managing-permissions/) for details on permission management.
+- [Managing permissions and roles](/standard-tenant/managing-permissions/) for details on permission management.
 {{< /c8y-admon-related >}}

--- a/content/datahub/setting-up-datahub-bundle/defining-permissions.md
+++ b/content/datahub/setting-up-datahub-bundle/defining-permissions.md
@@ -4,7 +4,7 @@ title: Defining Cumulocity DataHub permissions and roles
 layout: redirect
 ---
 
-Dedicated permissions define what a user is allowed to do in {{< product-c8y-iot >}} DataHub. To ease assigning permissions to users, permissions are grouped in roles. During deployment of the {{< product-c8y-iot >}} DataHub applications the corresponding permissions as well as roles are created. If a role with the same name already exists, no new role will be created. The same holds for permissions.
+Dedicated permissions define what a user is allowed to do in {{< product-c8y-iot >}} DataHub. To ease assigning permissions to users, permissions are grouped into roles. During deployment of the {{< product-c8y-iot >}} DataHub applications the corresponding permissions as well as roles are created. If a role with the same name already exists, no new role will be created. The same holds for permissions.
 
 If you do not have corresponding {{< product-c8y-iot >}} DataHub permissions, you will get a warning after login.
 
@@ -52,7 +52,7 @@ The permissions for the role DataHub Reader are defined as follows:
 |DataHub query|yes|no|
 
 ### Assignment of {{< product-c8y-iot >}} DataHub roles and permissions {#assignment-of-datahub-roles-and-permissions}
-The roles DataHub Administrator, DataHub Manager, and DataHub Reader must be assigned to the respective users of your tenant. For assigning roles to users see [Managing permissions](/standard-tenant/managing-permissions/). You need at least one user with the DataHub Administrator role to complete the {{< product-c8y-iot >}} DataHub configuration.
+The roles DataHub Administrator, DataHub Manager, and DataHub Reader must be assigned to the respective users of your tenant. For assigning roles to users see [Managing permissions and roles](/standard-tenant/managing-permissions/). You need at least one user with the DataHub Administrator role to complete the {{< product-c8y-iot >}} DataHub configuration.
 
 {{< c8y-admon-info >}}
 You do not necessarily need to use the predefined roles to enable {{< product-c8y-iot >}} users to work with {{< product-c8y-iot >}} DataHub. Alternatively, you can modify other roles the users are associated with and add the corresponding permissions to those roles. In that case you also must add the DataHub application to the user's applications.

--- a/content/datahub/setting-up-datahub-bundle/defining-permissions.md
+++ b/content/datahub/setting-up-datahub-bundle/defining-permissions.md
@@ -4,7 +4,7 @@ title: Defining Cumulocity DataHub permissions and roles
 layout: redirect
 ---
 
-Dedicated permissions define what a user is allowed to do in {{< product-c8y-iot >}} DataHub. To ease assigning permissions to users, permissions are grouped into roles. During deployment of the {{< product-c8y-iot >}} DataHub applications the corresponding permissions as well as roles are created. If a role with the same name already exists, no new role will be created. The same holds for permissions.
+Dedicated permissions define what a user is allowed to do in {{< product-c8y-iot >}} DataHub. You assign these permissions to users by using roles, which group permission into bundles. During deployment of the {{< product-c8y-iot >}} DataHub applications the corresponding permissions as well as roles are created. If a role with the same name already exists, no new role will be created. The same holds for permissions.
 
 If you do not have corresponding {{< product-c8y-iot >}} DataHub permissions, you will get a warning after login.
 

--- a/content/device-certificate-authentication/certificate-authority.md
+++ b/content/device-certificate-authentication/certificate-authority.md
@@ -104,7 +104,7 @@ The following response is returned:
 This certificate is identified as a TENANT CA and it has the attribute `"tenantCertificateAuthority":true`.
 
 {{< c8y-admon-info >}}
-In order to call `/certificate-authority` one of the following permissions is required: ROLE_TENANT_MANAGEMENT_ADMIN or ROLE_TENANT_ADMIN, otherwise an HTTP response 403 will be returned.
+To call `/certificate-authority`, your role must include ADMIN permission for "Tenant" (API string = `ROLE_TENANT_ADMIN`) or "Tenant management" (API string = `ROLE_TENANT_MANAGEMENT_ADMIN`). Without this, the request will fail (HTTP 403 error).
 {{< /c8y-admon-info >}}
 
 ### Creating a CA certificate via the UI {#creating-a-ca-certificate-via-the-ui}

--- a/content/device-certificate-authentication/certificate-authority.md
+++ b/content/device-certificate-authentication/certificate-authority.md
@@ -104,7 +104,7 @@ The following response is returned:
 This certificate is identified as a TENANT CA and it has the attribute `"tenantCertificateAuthority":true`.
 
 {{< c8y-admon-info >}}
-In order to call `/certificate-authority` one of the following roles is required: ROLE_TENANT_MANAGEMENT_ADMIN or ROLE_TENANT_ADMIN, otherwise an HTTP response 403 will be returned.
+In order to call `/certificate-authority` one of the following permissions is required: ROLE_TENANT_MANAGEMENT_ADMIN or ROLE_TENANT_ADMIN, otherwise an HTTP response 403 will be returned.
 {{< /c8y-admon-info >}}
 
 ### Creating a CA certificate via the UI {#creating-a-ca-certificate-via-the-ui}

--- a/content/device-integration/lpwan-custom-codec-bundle/using-the-lpwan-custom-codec-library.md
+++ b/content/device-integration/lpwan-custom-codec-bundle/using-the-lpwan-custom-codec-library.md
@@ -75,7 +75,7 @@ To create a custom codec microservice using this library, do the following:
         }
         ```
 
-4. Add the following roles as `requiredRoles` in the microservice manifest file `cumulocity.json`:
+4. Add the following permissions as `requiredRoles` in the microservice manifest file `cumulocity.json`:
 
     ```json
     "requiredRoles": [

--- a/content/device-integration/lpwan-custom-codec-bundle/using-the-lpwan-custom-codec-library.md
+++ b/content/device-integration/lpwan-custom-codec-bundle/using-the-lpwan-custom-codec-library.md
@@ -75,7 +75,7 @@ To create a custom codec microservice using this library, do the following:
         }
         ```
 
-4. Add the following permissions as `requiredRoles` in the microservice manifest file `cumulocity.json`:
+4. Add the following permissions in the microservice manifest file `cumulocity.json`. Note that the respective field in the manifest is called `requiredRoles`, but what you actually add is a list of required permissions strings.
 
     ```json
     "requiredRoles": [

--- a/content/device-management-application/grouping-devices-bundle/managing-groups.md
+++ b/content/device-management-application/grouping-devices-bundle/managing-groups.md
@@ -59,7 +59,7 @@ To add a new group as a child of an existing group, navigate to its **Subassets*
 1. In the navigator, click a group to open it.
 2. In the **Subassets** page, you can edit the name and description of the group.
 
-For further information on permissions, see [Managing permissions](/standard-tenant/managing-permissions/).
+For further information on permissions, see [Managing permissions and roles](/standard-tenant/managing-permissions/).
 
 ### To delete a group {#to-delete-a-group}
 

--- a/content/dtm/asset-hierarchy-bundle/introduction.md
+++ b/content/dtm/asset-hierarchy-bundle/introduction.md
@@ -35,7 +35,7 @@ ROLES & PERMISSIONS
 - To view specific assets: READ permissions for "Inventory" in the inventory roles
 - To manage or delete specific assets: READ and CHANGE permissions for "Inventory" in the inventory roles
 
-Note that global inventory permissions override inventory role permissions. By default, the user has full access to assets created by them regardless of permissions granted to them. See [Managing permissions](/standard-tenant/managing-permissions/) for further information.
+Note that global inventory permissions override inventory role permissions. By default, the user has full access to assets created by them regardless of permissions granted to them. See [Managing permissions and roles](/standard-tenant/managing-permissions/) for further information.
 {{< /c8y-admon-req >}}
 
 ### Asset hierarchy {#asset-hierarchy}

--- a/content/glossary/a.md
+++ b/content/glossary/a.md
@@ -10,7 +10,7 @@ _build:
 
 ### Administration application {#administration-application}
 
-The Administration application is a default {{< product-c8y-iot >}} application that serves as the central management console for platform administrators. It is used to govern a [tenant](#tenant) by managing [users](#user), roles, and [permissions](#permission), subscribing to and managing [applications](#application) and [microservices](#microservice), and configuring tenant-level settings such as retention rules, custom properties, and [branding](#branding).   
+The Administration application is a default {{< product-c8y-iot >}} application that serves as the central management console for platform administrators. It is used to govern a [tenant](#tenant) by managing [users](#user), [roles](#role), and [permissions](#permission), subscribing to and managing [applications](#application) and [microservices](#microservice), and configuring tenant-level settings such as retention rules, custom properties, and [branding](#branding).   
 
 
 ### Alarm {#alarm}

--- a/content/glossary/a.md
+++ b/content/glossary/a.md
@@ -10,7 +10,7 @@ _build:
 
 ### Administration application {#administration-application}
 
-The Administration application is a default {{< product-c8y-iot >}} application that serves as the central management console for platform administrators. It is used to govern a [tenant](#tenant) by managing [users](#user), [roles](#role), and [permissions](#permission), subscribing to and managing [applications](#application) and [microservices](#microservice), and configuring tenant-level settings such as retention rules, custom properties, and [branding](#branding).   
+The Administration application is a default {{< product-c8y-iot >}} application and the central place for platform administrators to manage a tenant. It is used to govern a [tenant](#tenant) by managing [users](#user), [roles](#role), and [permissions](#permission), subscribing to and managing [applications](#application) and [microservices](#microservice), and configuring tenant-level settings such as retention rules, custom properties, and [branding](#branding).   
 
 
 ### Alarm {#alarm}

--- a/content/glossary/u.md
+++ b/content/glossary/u.md
@@ -12,7 +12,7 @@ _build:
 
 ### User {#user}
 
-An individual account within a {{< product-c8y-iot >}} [tenant](#tenant), identified by a unique username. Users are assigned [roles](#role) and [permissions](#permission) that determine their access rights to data and functionalities.  
+An individual account within a {{< product-c8y-iot >}} [tenant](#tenant), identified by a unique username. Users are assigned [roles](#role) with specific [permissions](#permission) that determine their access rights to data and functionalities.  
 
 
 ### User hierarchy {#user-hierarchy}

--- a/content/microservice-sdk/general-aspects-bundle/microservice-manifest.md
+++ b/content/microservice-sdk/general-aspects-bundle/microservice-manifest.md
@@ -166,7 +166,7 @@ See below for detailed information about available settings.
 <tr>
 <td style="text-align:left">roles</td>
 <td style="text-align:left">String[ ]</td>
-<td style="text-align:left">Roles provided by the microservice. <b>Important:</b> Be aware that despite of the term "role" in the field name the field expects a "permission" string (for example, ROLE_INVENTORY_ADMIN). <br>Default: [ ] (empty list)</td>
+<td style="text-align:left">Roles provided by the microservice. <b>Important:</b> Be aware that despite the use of the term "role" in the field name, the field expects a "permission" string (for example, ROLE_INVENTORY_ADMIN). <br>Default: [ ] (empty list)</td>
 <td style="text-align:left">No</td>
 </tr>
 <tr>

--- a/content/microservice-sdk/general-aspects-bundle/microservice-manifest.md
+++ b/content/microservice-sdk/general-aspects-bundle/microservice-manifest.md
@@ -160,13 +160,13 @@ See below for detailed information about available settings.
 <tr>
 <td style="text-align:left">requiredRoles</td>
 <td style="text-align:left">String[ ]</td>
-<td style="text-align:left">List of permissions required by a microservice to work. **Important:** Be aware that the term "role" in the field name might be misleading as the field expects a "permission" string (for example, ROLE_INVENTORY_ADMIN). <br/>Default: [ ] (no permissions)</td>
+<td style="text-align:left">List of permissions required by a microservice to work. <b>Important:</b> Be aware that despite of the term "role" in the field name the field expects a "permission" string (for example, ROLE_INVENTORY_ADMIN). <br/>Default: [ ] (no permissions)</td>
 <td style="text-align:left">No</td>
 </tr>
 <tr>
 <td style="text-align:left">roles</td>
 <td style="text-align:left">String[ ]</td>
-<td style="text-align:left">Roles provided by the microservice. **Important:** Be aware that the term "role" in the field name might be misleading as the field expects a "permission" string (for example, ROLE_INVENTORY_ADMIN). <br>Default: [ ] (empty list)</td>
+<td style="text-align:left">Roles provided by the microservice. <b>Important:</b> Be aware that despite of the term "role" in the field name the field expects a "permission" string (for example, ROLE_INVENTORY_ADMIN). <br>Default: [ ] (empty list)</td>
 <td style="text-align:left">No</td>
 </tr>
 <tr>

--- a/content/microservice-sdk/general-aspects-bundle/microservice-manifest.md
+++ b/content/microservice-sdk/general-aspects-bundle/microservice-manifest.md
@@ -160,7 +160,7 @@ See below for detailed information about available settings.
 <tr>
 <td style="text-align:left">requiredRoles</td>
 <td style="text-align:left">String[ ]</td>
-<td style="text-align:left">List of permissions required by a microservice to work. <b>Important:</b> Be aware that despite the term "role" in the field name, the field expects a "permission" string (for example, ROLE_INVENTORY_ADMIN). <br/>Default: [ ] (no permissions)</td>
+<td style="text-align:left">List of permissions required by a microservice to work. <b>Important:</b> Be aware that despite the use of term "role" in the field name, the field expects a "permission" string (for example, ROLE_INVENTORY_ADMIN). <br/>Default: [ ] (no permissions)</td>
 <td style="text-align:left">No</td>
 </tr>
 <tr>

--- a/content/microservice-sdk/general-aspects-bundle/microservice-manifest.md
+++ b/content/microservice-sdk/general-aspects-bundle/microservice-manifest.md
@@ -160,7 +160,7 @@ See below for detailed information about available settings.
 <tr>
 <td style="text-align:left">requiredRoles</td>
 <td style="text-align:left">String[ ]</td>
-<td style="text-align:left">List of permissions required by a microservice to work.<br/>Default: [ ] (no permissions)</td>
+<td style="text-align:left">List of permissions required by a microservice to work. **Important:** Be aware that the term "role" in the field name might be misleading as the field expects a "permission" string (for example, ROLE_INVENTORY_ADMIN) which actually refers to a permission from a UI perspective. <br/>Default: [ ] (no permissions)</td>
 <td style="text-align:left">No</td>
 </tr>
 <tr>
@@ -198,13 +198,13 @@ Some manifest settings are used exclusively by internal components, and are not 
 
 The version has an impact on the microservice upload behavior:
 
-* If the version specified in the manifest is a snapshot version, for example, "1.1.0-SNAPSHOT", the microservices image will be pushed to the registry on each upload. 
+* If the version specified in the manifest is a snapshot version, for example, "1.1.0-SNAPSHOT", the microservices image will be pushed to the registry on each upload.
 
 * If the version specified in the manifest is NOT a snapshot version, for example, "2.0.0", and no microservice image with this version exists in the registry, the upload will be successful.
 
-* If the version specified in the manifest is NOT a snapshot version, for example, "2.0.0", and a microservice image with this version exists in the registry, additional validation is performed. The upload will be rejected if the provided image differs from the one currently in the registry. You cannot upload a different image using an existing version. 
+* If the version specified in the manifest is NOT a snapshot version, for example, "2.0.0", and a microservice image with this version exists in the registry, additional validation is performed. The upload will be rejected if the provided image differs from the one currently in the registry. You cannot upload a different image using an existing version.
 
-* If the version specified in the manifest is NOT a snapshot version, for example, "2.0.0", and a microservice image with this version exists in the registry, the upload will succeed if and only if the provided microservice image is the same as the one currently in the registry. 
+* If the version specified in the manifest is NOT a snapshot version, for example, "2.0.0", and a microservice image with this version exists in the registry, the upload will succeed if and only if the provided microservice image is the same as the one currently in the registry.
 
 The "-SNAPSHOT" postfix means that the image build is a snapshot of your application at a given time and it is still under development.
 When the microservice is ready for a production release, the "-SNAPSHOT" postfix must be removed, and the microservice must be uploaded with a unique (higher) version number (for example, "2.1.0").

--- a/content/microservice-sdk/general-aspects-bundle/microservice-manifest.md
+++ b/content/microservice-sdk/general-aspects-bundle/microservice-manifest.md
@@ -160,13 +160,13 @@ See below for detailed information about available settings.
 <tr>
 <td style="text-align:left">requiredRoles</td>
 <td style="text-align:left">String[ ]</td>
-<td style="text-align:left">List of permissions required by a microservice to work. **Important:** Be aware that the term "role" in the field name might be misleading as the field expects a "permission" string (for example, ROLE_INVENTORY_ADMIN) which actually refers to a permission from a UI perspective. <br/>Default: [ ] (no permissions)</td>
+<td style="text-align:left">List of permissions required by a microservice to work. **Important:** Be aware that the term "role" in the field name might be misleading as the field expects a "permission" string (for example, ROLE_INVENTORY_ADMIN). <br/>Default: [ ] (no permissions)</td>
 <td style="text-align:left">No</td>
 </tr>
 <tr>
 <td style="text-align:left">roles</td>
 <td style="text-align:left">String[ ]</td>
-<td style="text-align:left">Roles provided by the microservice. <br>Default: [ ] (empty list)</td>
+<td style="text-align:left">Roles provided by the microservice. **Important:** Be aware that the term "role" in the field name might be misleading as the field expects a "permission" string (for example, ROLE_INVENTORY_ADMIN). <br>Default: [ ] (empty list)</td>
 <td style="text-align:left">No</td>
 </tr>
 <tr>

--- a/content/microservice-sdk/general-aspects-bundle/microservice-manifest.md
+++ b/content/microservice-sdk/general-aspects-bundle/microservice-manifest.md
@@ -160,7 +160,7 @@ See below for detailed information about available settings.
 <tr>
 <td style="text-align:left">requiredRoles</td>
 <td style="text-align:left">String[ ]</td>
-<td style="text-align:left">List of permissions required by a microservice to work. <b>Important:</b> Be aware that despite of the term "role" in the field name the field expects a "permission" string (for example, ROLE_INVENTORY_ADMIN). <br/>Default: [ ] (no permissions)</td>
+<td style="text-align:left">List of permissions required by a microservice to work. <b>Important:</b> Be aware that despite the term "role" in the field name, the field expects a "permission" string (for example, ROLE_INVENTORY_ADMIN). <br/>Default: [ ] (no permissions)</td>
 <td style="text-align:left">No</td>
 </tr>
 <tr>

--- a/content/microservice-sdk/general-aspects-bundle/security.md
+++ b/content/microservice-sdk/general-aspects-bundle/security.md
@@ -135,13 +135,13 @@ There are three types of users:
 
 The following role types are defined for users:
 
-* Required roles: The roles that are predefined to allow access to {{< product-c8y-iot >}} REST APIs.
-For instance, if a microservice creates measurements using the service user, measurement admin role must be added as a required role of the application.
+* Required roles: The permissions that are predefined to allow access to {{< product-c8y-iot >}} REST APIs.
+For instance, if a microservice creates measurements using the service user, measurement admin permission must be added as a required role of the application.
 Required roles are added to the service users.
 * Roles: The custom roles provided to tenant platform users by the microservice developer.
 These roles can be assigned or revoked to the tenant platform users or groups using the Administration application.
 
-Custom roles must adhere to this name format in order to be shown in the UI:
+Custom roles/permissions must adhere to this name format in order to be shown in the UI:
 
 ROLE_<NAME>_(READ|ADMIN|CREATE)
 
@@ -156,7 +156,11 @@ You can add them to the [application manifest](#microservice-manifest) in the `r
 
 <!-- TODO: add/describe a picture of "required roles" and "provided roles" showing a microservice as a block -->
 
-The roles are set in the [Microservice manifest](#microservice-manifest). For more details about users and roles, review the [User API](https://{{< domain-c8y >}}/api/core/#tag/User-API) in the {{< openapi >}}.
+The roles are set in the [Microservice manifest](#microservice-manifest). For more details about users and roles, refer to [Managing permissions and roles](/standard-tenant/managing-permissions) or to the [User API](https://{{< domain-c8y >}}/api/core/#tag/User-API) in the {{< openapi >}}.
+
+{{< c8y-admon-important >}}
+Be aware that the term "role" might be misleading here as the `requiredRoles` field expects a "permission" string (for example, ROLE_INVENTORY_ADMIN) which actually refers to a permission from a UI perspective UI.
+{{< /c8y-admon-important >}}
 
 ### Microservice bootstrap {#microservice-bootstrap}
 
@@ -205,7 +209,7 @@ Steps:
 
 There is a mechanism to encrypt the tenant options.
 
-If a tenant option is created with a key name that starts with "credentials.", it is automatically encrypted and can be fetched as unencrypted only by system users. Note that a space (" ") is not allowed as a tenant option value. 
+If a tenant option is created with a key name that starts with "credentials.", it is automatically encrypted and can be fetched as unencrypted only by system users. Note that a space (" ") is not allowed as a tenant option value.
 
 The options can be fetched via REST using the options endpoint at microservice runtime. Encrypted options are decrypted only if the tenant option category matches the category defined by the microservice. This category is determined based on the first non-blank value from:
 

--- a/content/microservice-sdk/general-aspects-bundle/security.md
+++ b/content/microservice-sdk/general-aspects-bundle/security.md
@@ -159,7 +159,7 @@ You can add them to the [application manifest](#microservice-manifest) in the `r
 The roles are set in the [Microservice manifest](#microservice-manifest). For more details about users and roles, refer to [Managing permissions and roles](/standard-tenant/managing-permissions) or to the [User API](https://{{< domain-c8y >}}/api/core/#tag/User-API) in the {{< openapi >}}.
 
 {{< c8y-admon-important >}}
-Be aware that the term "role" might be misleading here as the the `roles`field and `requiredRoles` field expect a "permission" string (for example, ROLE_INVENTORY_ADMIN). Also see the glossary for the usage of the terms "[permission](/glossary/#permission)" and "[role](/glossary/#role)" in the Cumulocity context.
+Be aware that the term "role" might be misleading here as the the `roles`field and `requiredRoles` field expect a "permission" string (for example, ROLE_INVENTORY_ADMIN). See also the glossary for the usage of the terms [permission](/glossary/#permission) and [role](/glossary/#role) in the Cumulocity context.
 {{< /c8y-admon-important >}}
 
 ### Microservice bootstrap {#microservice-bootstrap}

--- a/content/microservice-sdk/general-aspects-bundle/security.md
+++ b/content/microservice-sdk/general-aspects-bundle/security.md
@@ -136,10 +136,10 @@ There are three types of users:
 The following role types are defined for users:
 
 * Required roles: The permissions that are predefined to allow access to {{< product-c8y-iot >}} REST APIs.
-For instance, if a microservice creates measurements using the service user, measurement admin permission must be added as a required role of the application.
+For instance, if a microservice creates measurements using the service user, measurement ADMIN permission must be added as a required role/permission of the application.
 Required roles are added to the service users.
 * Roles: The custom roles provided to tenant platform users by the microservice developer.
-These roles can be assigned or revoked to the tenant platform users or groups using the Administration application.
+These permissions can be assigned or revoked to the tenant platform users or groups using the Administration application.
 
 Custom roles/permissions must adhere to this name format in order to be shown in the UI:
 
@@ -159,7 +159,7 @@ You can add them to the [application manifest](#microservice-manifest) in the `r
 The roles are set in the [Microservice manifest](#microservice-manifest). For more details about users and roles, refer to [Managing permissions and roles](/standard-tenant/managing-permissions) or to the [User API](https://{{< domain-c8y >}}/api/core/#tag/User-API) in the {{< openapi >}}.
 
 {{< c8y-admon-important >}}
-Be aware that the term "role" might be misleading here as the `requiredRoles` field expects a "permission" string (for example, ROLE_INVENTORY_ADMIN) which actually refers to a permission from a UI perspective UI.
+Be aware that the term "role" might be misleading here as the the `roles`field and `requiredRoles` field expect a "permission" string (for example, ROLE_INVENTORY_ADMIN). Also see the glossary for the usage of the terms "[permission](/glossary/#permission)" and "[role](/glossary/#role)" in the Cumulocity context.
 {{< /c8y-admon-important >}}
 
 ### Microservice bootstrap {#microservice-bootstrap}

--- a/content/microservice-sdk/general-aspects-bundle/security.md
+++ b/content/microservice-sdk/general-aspects-bundle/security.md
@@ -141,7 +141,7 @@ Required roles are added to the service users.
 * Roles: The custom permissions provided to tenant platform users by the microservice developer.
 These permissions can be assigned or revoked to the tenant platform users or groups using the Administration application.
 
-Custom rpermissions must adhere to this name format to be shown in the UI:
+Custom permissions must adhere to this name format to be shown in the UI:
 
 ROLE_<NAME>_(READ|ADMIN|CREATE)
 

--- a/content/microservice-sdk/general-aspects-bundle/security.md
+++ b/content/microservice-sdk/general-aspects-bundle/security.md
@@ -138,10 +138,10 @@ The following role types are defined for users:
 * Required roles: The permissions that are predefined to allow access to {{< product-c8y-iot >}} REST APIs.
 For instance, if a microservice creates measurements using the service user, the measurement ADMIN permission must be added as a required role/permission of the application.
 Required roles are added to the service users.
-* Roles: The custom roles provided to tenant platform users by the microservice developer.
+* Roles: The custom permissions provided to tenant platform users by the microservice developer.
 These permissions can be assigned or revoked to the tenant platform users or groups using the Administration application.
 
-Custom roles/permissions must adhere to this name format in order to be shown in the UI:
+Custom rpermissions must adhere to this name format to be shown in the UI:
 
 ROLE_<NAME>_(READ|ADMIN|CREATE)
 

--- a/content/microservice-sdk/general-aspects-bundle/security.md
+++ b/content/microservice-sdk/general-aspects-bundle/security.md
@@ -136,7 +136,7 @@ There are three types of users:
 The following role types are defined for users:
 
 * Required roles: The permissions that are predefined to allow access to {{< product-c8y-iot >}} REST APIs.
-For instance, if a microservice creates measurements using the service user, measurement ADMIN permission must be added as a required role/permission of the application.
+For instance, if a microservice creates measurements using the service user, the measurement ADMIN permission must be added as a required role/permission of the application.
 Required roles are added to the service users.
 * Roles: The custom roles provided to tenant platform users by the microservice developer.
 These permissions can be assigned or revoked to the tenant platform users or groups using the Administration application.
@@ -156,10 +156,10 @@ You can add them to the [application manifest](#microservice-manifest) in the `r
 
 <!-- TODO: add/describe a picture of "required roles" and "provided roles" showing a microservice as a block -->
 
-The roles are set in the [Microservice manifest](#microservice-manifest). For more details about users and roles, refer to [Managing permissions and roles](/standard-tenant/managing-permissions) or to the [User API](https://{{< domain-c8y >}}/api/core/#tag/User-API) in the {{< openapi >}}.
+The permissions are set in the [Microservice manifest](#microservice-manifest). For more details about users, permissions, and roles, refer to [Managing permissions and roles](/standard-tenant/managing-permissions) or to the [User API](https://{{< domain-c8y >}}/api/core/#tag/User-API) in the {{< openapi >}}.
 
 {{< c8y-admon-important >}}
-Be aware that the term "role" might be misleading here as the the `roles`field and `requiredRoles` field expect a "permission" string (for example, ROLE_INVENTORY_ADMIN). See also the glossary for the usage of the terms [permission](/glossary/#permission) and [role](/glossary/#role) in the Cumulocity context.
+Be aware that the term "role" might be misleading here as the the `roles` field and `requiredRoles` field expect a "permission" string (for example, ROLE_INVENTORY_ADMIN). See also the glossary for the usage of the terms [permission](/glossary/#permission) and [role](/glossary/#role) in the Cumulocity context.
 {{< /c8y-admon-important >}}
 
 ### Microservice bootstrap {#microservice-bootstrap}

--- a/content/microservice-sdk/java-bundle/ip-tracker-microservice.md
+++ b/content/microservice-sdk/java-bundle/ip-tracker-microservice.md
@@ -57,7 +57,7 @@ Finally, add the following dependency:
 
 In your _cumulocity.json_ file:
 
-1. Add the required roles (permissions) to be able to create events and alarms.
+1. Add the required permissions (using the `requiredRoles` field) to be able to create events and alarms.
 2. Add the readiness and liveness probes.
 3. Add two keys for the microservice settings: `"ipstack.key"` and `"tracker.id"`.
 4. Set the isolation level to `"PER_TENANT"`. This means that there will be a separate instance for each tenant. For more details see the Settings section in [Microservice manifest](/microservice-sdk/general-aspects/#microservice-manifest).

--- a/content/microservice-sdk/java-bundle/ip-tracker-microservice.md
+++ b/content/microservice-sdk/java-bundle/ip-tracker-microservice.md
@@ -57,7 +57,7 @@ Finally, add the following dependency:
 
 In your _cumulocity.json_ file:
 
-1. Add the required roles to be able to create events and alarms.
+1. Add the required roles (permissions) to be able to create events and alarms.
 2. Add the readiness and liveness probes.
 3. Add two keys for the microservice settings: `"ipstack.key"` and `"tracker.id"`.
 4. Set the isolation level to `"PER_TENANT"`. This means that there will be a separate instance for each tenant. For more details see the Settings section in [Microservice manifest](/microservice-sdk/general-aspects/#microservice-manifest).

--- a/content/microservice-sdk/java-bundle/services-platform-sms-api.md
+++ b/content/microservice-sdk/java-bundle/services-platform-sms-api.md
@@ -30,10 +30,10 @@ SmsMessagingApi smsMessagingApi = platform.getSmsMessagingApi();
 
 Using this handle, you can send and retrieve the SMS messages from Java by calling its functions.
 
-### Assigning required roles {#assigning-required-roles}
+### Assigning required permissions and roles {#assigning-required-roles}
 
-To use the SMS messaging API, the user must have the required roles SMS_ADMIN and SMS_READ for sending and receiving messages respectively.
-Refer to [Managing permissions](/standard-tenant/managing-permissions/) for more information.
+To use the SMS messaging API, the user must have the required permissions SMS_ADMIN and SMS_READ for sending and receiving messages respectively.
+Refer to [Managing permissions and roles](/standard-tenant/managing-permissions/) for more information.
 
 ### Sending a message {#sending-a-message}
 

--- a/content/microservice-sdk/java-bundle/services-platform-sms-api.md
+++ b/content/microservice-sdk/java-bundle/services-platform-sms-api.md
@@ -32,7 +32,7 @@ Using this handle, you can send and retrieve the SMS messages from Java by calli
 
 ### Assigning required permissions and roles {#assigning-required-roles}
 
-To use the SMS messaging API, the user must have the required permissions SMS_ADMIN and SMS_READ for sending and receiving messages respectively.
+To use the SMS messaging API, the user must have the ADMIN and READ permission for "SMS" (SMS_ADMIN and SMS_READ) for sending and receiving messages respectively.
 Refer to [Managing permissions and roles](/standard-tenant/managing-permissions/) for more information.
 
 ### Sending a message {#sending-a-message}

--- a/content/microservice-sdk/rest-bundle/microservice-development.md
+++ b/content/microservice-sdk/rest-bundle/microservice-development.md
@@ -30,7 +30,7 @@ A success response consists of a 201 status and a location header similar to `<H
 
 The properties `key`, `name` and `type` from the above request body are self explanatory, and about the roles:
 
-* `requiredRoles` - A list of {{< product-c8y-iot >}} permissions the microservice user needs in order to get data from {{< product-c8y-iot >}}, for example, if the microservice creates a managed object, one of the required roles shall be `ROLE_INVENTORY_ADMIN`.
+* `requiredRoles` - A list of {{< product-c8y-iot >}} permissions the microservice user needs in order to get data from {{< product-c8y-iot >}}, for example, if the microservice creates a managed object, one of the required permissions shall be `ROLE_INVENTORY_ADMIN`.
 * `roles` - A list of microservice permissions. If the microservice exposes an own REST API, it can be secured with an own set of permissions, for example, a SMS microservice would require `SMS_ADMIN` permission to send SMS messages. These permissions become available in the tenant after microservice subscription. Afterwards, an admin user can grant such permission to  another user that wants to send SMS messages via the {{< product-c8y-iot >}} platform.
 
 The application ID for existing applications can be obtained employing a GET request with the name of the application:
@@ -91,7 +91,7 @@ Content-Type: application/vnd.com.nsn.cumulocity.application+json
     "name": "<APPLICATION_NAME>",
     "type": "MICROSERVICE",
     "requiredRoles": [ "ROLE_INVENTORY_READ" ],
-    "roles": [ "ROLE_CUSTOM_MICSROSERVICE" ]
+    "roles": [ "ROLE_CUSTOM_MICROSERVICE" ]
 }
 ```
 

--- a/content/microservice-sdk/rest-bundle/microservice-development.md
+++ b/content/microservice-sdk/rest-bundle/microservice-development.md
@@ -33,6 +33,10 @@ The properties `key`, `name` and `type` from the above request body are self exp
 * `requiredRoles` - A list of {{< product-c8y-iot >}} permissions the microservice user needs in order to get data from {{< product-c8y-iot >}}, for example, if the microservice creates a managed object, one of the required permissions shall be `ROLE_INVENTORY_ADMIN`.
 * `roles` - A list of microservice permissions. If the microservice exposes an own REST API, it can be secured with an own set of permissions, for example, a SMS microservice would require `SMS_ADMIN` permission to send SMS messages. These permissions become available in the tenant after microservice subscription. Afterwards, an admin user can grant such permission to  another user that wants to send SMS messages via the {{< product-c8y-iot >}} platform.
 
+{{< c8y-admon-important >}}
+Be aware that the term "role" might be misleading here as the `roles`field and the `requiredRoles` field expect a "permission" string (for example, ROLE_INVENTORY_ADMIN). Also see the glossary for the usage of the terms "[permission](/glossary/#permission)" and "[role](/glossary/#role)" in the Cumulocity context.
+{{< /c8y-admon-important >}}
+
 The application ID for existing applications can be obtained employing a GET request with the name of the application:
 
 ```http

--- a/content/microservice-sdk/rest-bundle/microservice-development.md
+++ b/content/microservice-sdk/rest-bundle/microservice-development.md
@@ -31,10 +31,10 @@ A success response consists of a 201 status and a location header similar to `<H
 The properties `key`, `name` and `type` from the above request body are self explanatory, and about the roles:
 
 * `requiredRoles` - A list of {{< product-c8y-iot >}} permissions the microservice user needs in order to get data from {{< product-c8y-iot >}}, for example, if the microservice creates a managed object, one of the required permissions shall be `ROLE_INVENTORY_ADMIN`.
-* `roles` - A list of microservice permissions. If the microservice exposes an own REST API, it can be secured with an own set of permissions, for example, a SMS microservice would require `SMS_ADMIN` permission to send SMS messages. These permissions become available in the tenant after microservice subscription. Afterwards, an admin user can grant such permission to  another user that wants to send SMS messages via the {{< product-c8y-iot >}} platform.
+* `roles` - A list of microservice permissions defined by this microservice. If the microservice exposes its own REST API, it can be secured with its own set of permissions, for example, an SMS microservice would require `SMS_ADMIN` permission to send SMS messages. These permissions become available in the tenant after microservice subscription. Afterwards, an admin user can grant such permission to  another user that wants to send SMS messages via the {{< product-c8y-iot >}} platform.
 
 {{< c8y-admon-important >}}
-Be aware that the term "role" might be misleading here as the `roles`field and the `requiredRoles` field expect a "permission" string (for example, ROLE_INVENTORY_ADMIN). Also see the glossary for the usage of the terms [permission](/glossary/#permission) and [role](/glossary/#role) in the Cumulocity context.
+Be aware that the term "role" might be misleading here as the `roles` field and the `requiredRoles` field expect a "permission" string (for example, `ROLE_INVENTORY_ADMIN`). Also see the glossary for the usage of the terms [permission](/glossary/#permission) and [role](/glossary/#role) in the Cumulocity context.
 {{< /c8y-admon-important >}}
 
 The application ID for existing applications can be obtained employing a GET request with the name of the application:

--- a/content/microservice-sdk/rest-bundle/microservice-development.md
+++ b/content/microservice-sdk/rest-bundle/microservice-development.md
@@ -34,7 +34,7 @@ The properties `key`, `name` and `type` from the above request body are self exp
 * `roles` - A list of microservice permissions. If the microservice exposes an own REST API, it can be secured with an own set of permissions, for example, a SMS microservice would require `SMS_ADMIN` permission to send SMS messages. These permissions become available in the tenant after microservice subscription. Afterwards, an admin user can grant such permission to  another user that wants to send SMS messages via the {{< product-c8y-iot >}} platform.
 
 {{< c8y-admon-important >}}
-Be aware that the term "role" might be misleading here as the `roles`field and the `requiredRoles` field expect a "permission" string (for example, ROLE_INVENTORY_ADMIN). Also see the glossary for the usage of the terms "[permission](/glossary/#permission)" and "[role](/glossary/#role)" in the Cumulocity context.
+Be aware that the term "role" might be misleading here as the `roles`field and the `requiredRoles` field expect a "permission" string (for example, ROLE_INVENTORY_ADMIN). Also see the glossary for the usage of the terms [permission](/glossary/#permission) and [role](/glossary/#role) in the Cumulocity context.
 {{< /c8y-admon-important >}}
 
 The application ID for existing applications can be obtained employing a GET request with the name of the application:

--- a/content/standard-tenant/changing-settings-bundle/localization.md
+++ b/content/standard-tenant/changing-settings-bundle/localization.md
@@ -21,7 +21,7 @@ Using the **Localization** functionality you can add custom translations for exi
 
 - To add/update/delete localization identifiers: ADMIN permission for permission type "Application management"
 
-- Your user must have a role with READ permission for the permission type "Application management". See [Managing permissions](/standard-tenant/managing-permissions/) for more information.
+- Your user must have a role with READ permission for the permission type "Application management". See [Managing permissions and roles](/standard-tenant/managing-permissions/) for more information.
 
 {{< /c8y-admon-req >}}
 

--- a/content/standard-tenant/changing-settings-bundle/localization.md
+++ b/content/standard-tenant/changing-settings-bundle/localization.md
@@ -21,7 +21,7 @@ Using the **Localization** functionality you can add custom translations for exi
 
 - To add/update/delete localization identifiers: ADMIN permission for permission type "Application management"
 
-- Your user must have a role with READ permission for the permission type "Application management". See [Managing permissions and roles](/standard-tenant/managing-permissions/) for more information.
+- Your user must have a role with READ permission for "Application management". See [Managing permissions and roles](/standard-tenant/managing-permissions/) for more information.
 
 {{< /c8y-admon-req >}}
 

--- a/content/standard-tenant/ecosystem-bundle/monitoring-microservices.md
+++ b/content/standard-tenant/ecosystem-bundle/monitoring-microservices.md
@@ -14,7 +14,7 @@ The status of the microservice can be checked in the **Status** tab of the respe
 
 <img src="/images/users-guide/Administration/admin-microservice-status.png" alt="Microservice status" style="max-width: 100%">
 
-To view the status you need the following permissions: role Application management READ and role Inventory READ.
+To view the status you need the following permissions: READ permission for Application management and READ permission for Inventory.
 
 The following information is provided on the **Status** tab:
 

--- a/content/standard-tenant/ecosystem-bundle/monitoring-microservices.md
+++ b/content/standard-tenant/ecosystem-bundle/monitoring-microservices.md
@@ -14,7 +14,7 @@ The status of the microservice can be checked in the **Status** tab of the respe
 
 <img src="/images/users-guide/Administration/admin-microservice-status.png" alt="Microservice status" style="max-width: 100%">
 
-To view the status you need the following permissions: READ permission for Application management and READ permission for Inventory.
+To view the status you need the following permissions: READ permission for "Application management" and "Inventory".
 
 The following information is provided on the **Status** tab:
 

--- a/content/standard-tenant/managing-permissions.md
+++ b/content/standard-tenant/managing-permissions.md
@@ -46,5 +46,4 @@ The above permissions can be used to create roles for robust user management. Ev
 - [Platform administration > {{< enterprise-tenant >}} administration > Managing user hierarchies](/enterprise-tenant/managing-user-hierarchies) for more information on managing user hierarchies.
 - [Device management & connectivity > Device integration > Fragment library](/device-integration/fragment-library/) for further information on fragment types.
 - [Roles](https://{{< domain-c8y >}}/api/core/#tag/Roles) and [Inventory Roles](https://{{< domain-c8y >}}/api/core/#tag/Inventory-Roles) in the {{< openapi >}} for managing permissions via REST.
--
 {{< /c8y-admon-related >}}

--- a/content/standard-tenant/managing-permissions.md
+++ b/content/standard-tenant/managing-permissions.md
@@ -10,7 +10,7 @@ sector:
 helpcontent:
 - label: managing-permissions
   title: Managing permissions
-  content: "Permissions define what a user is allowed to do in Cumulocity applications. To manage permissions more easily, they are grouped into global and inventory roles. Every user can be associated with a number of roles, adding up permissions of the user.
+  content: "Permissions define what a user is allowed to do in Cumulocity applications. To manage permissions more easily, they are grouped into global and inventory roles. When you assign one or more roles to a user, they gain the combined permissions of all these roles.
 
 
   In the **Global roles** tab you can find the roles which grant permissions on a general level. There are several global roles pre-defined (which may serve as a template), but you can define your own according to your needs.

--- a/content/standard-tenant/managing-permissions.md
+++ b/content/standard-tenant/managing-permissions.md
@@ -24,7 +24,7 @@ Permissions define what a user is allowed to do in {{< product-c8y-iot >}} appli
 Permissions are not assigned to users directly. To manage permissions more easily, they are grouped into roles (global and inventory roles). Every user can be associated with a number of roles, adding up permissions of the user.
 
 {{< c8y-admon-important >}}
-In the Cumulocity API, each granular permission is identifed by a unique “permission” string, which is prefixed with `ROLE_` (for example, `ROLE_ALARM_READ`, `ROLE_INVENTORY_ADMIN`). Therefore, permissions are frequently referred to as "roles" throughout the API as well as in the configuration files. For example, the microservice manifest includes a `requiredRoles` field which actually expects a permission string.   
+In the Cumulocity API, each granular permission is identifed by a unique “permission” string, which is prefixed with `ROLE_` (for example, `ROLE_ALARM_READ`, `ROLE_INVENTORY_ADMIN`). Therefore, permissions are frequently referred to as "roles" throughout the API as well as in the configuration files. For example, the microservice manifest includes a `requiredRoles` field which actually expects a permission string. See also the glossary for the usage of the terms "[permission](/glossary/#permission)" and "[role](/glossary/#role)" in the Cumulocity context.  
 {{< /c8y-admon-important >}}
 
 {{< c8y-admon-req >}}

--- a/content/standard-tenant/managing-permissions.md
+++ b/content/standard-tenant/managing-permissions.md
@@ -23,9 +23,9 @@ Permissions define what a user is allowed to do in {{< product-c8y-iot >}} appli
 
 Permissions are not assigned to users directly. To manage permissions more easily, they are grouped into roles (global and inventory roles). Every user can be associated with a number of roles, adding up permissions of the user.
 
-{{< c8y-admon-important >}}
-In the Cumulocity API, each granular permission is identifed by a unique “permission” string, which is prefixed with `ROLE_` (for example, `ROLE_ALARM_READ`, `ROLE_INVENTORY_ADMIN`). Therefore, permissions are frequently referred to as "roles" throughout the API as well as in the configuration files. For example, the microservice manifest includes a `requiredRoles` field which actually expects a permission string. See also the glossary for the usage of the terms "[permission](/glossary/#permission)" and "[role](/glossary/#role)" in the Cumulocity context.  
-{{< /c8y-admon-important >}}
+{{< c8y-admon-info >}}
+In the Cumulocity API, each granular permission is identifed by a unique “permission” string, which is prefixed with `ROLE_` (for example, `ROLE_ALARM_READ`, `ROLE_INVENTORY_ADMIN`). Therefore, permissions are frequently referred to as "roles" throughout the API as well as in the configuration files. See also the glossary for the usage of the terms [permission](/glossary/#permission) and [role](/glossary/#role) in the Cumulocity context.  
+{{< /c8y-admon-info >}}
 
 {{< c8y-admon-req >}}
 ROLES & PERMISSIONS:

--- a/content/standard-tenant/managing-permissions.md
+++ b/content/standard-tenant/managing-permissions.md
@@ -1,6 +1,6 @@
 ---
 weight: 20
-title: Managing permissions
+title: Managing permissions and roles
 layout: bundle
 outputs:
   - html
@@ -10,7 +10,7 @@ sector:
 helpcontent:
 - label: managing-permissions
   title: Managing permissions
-  content: "Permissions define what a user is allowed to do in Cumulocity applications. To manage permissions more easily, they are grouped into so-called 'roles'. Every user can be associated with a number of roles, adding up permissions of the user.
+  content: "Permissions define what a user is allowed to do in Cumulocity applications. To manage permissions more easily, they are grouped into global and inventory roles. Every user can be associated with a number of roles, adding up permissions of the user.
 
 
   In the **Global roles** tab you can find the roles which grant permissions on a general level. There are several global roles pre-defined (which may serve as a template), but you can define your own according to your needs.
@@ -19,7 +19,13 @@ helpcontent:
   In the **Inventory roles** tab you can manage user permissions for particular groups of devices and/or its children. For example, an inventory role can contain the permission to restart a particular device."
 ---
 
-Permissions define what a user is allowed to do in {{< product-c8y-iot >}} applications. To manage permissions more easily, they are grouped into global and inventory roles. Every user can be associated with a number of roles, adding up permissions of the user.
+Permissions define what a user is allowed to do in {{< product-c8y-iot >}} applications.
+
+Permissions are not assigned to users directly. To manage permissions more easily, they are grouped into roles (global and inventory roles). Every user can be associated with a number of roles, adding up permissions of the user.
+
+{{< c8y-admon-important >}}
+In the Cumulocity API, each granular permission is identifed by a unique “permission” string, which is prefixed with `ROLE_` (for example, `ROLE_ALARM_READ`, `ROLE_INVENTORY_ADMIN`). Therefore, permissions are frequently referred to as "roles" throughout the API as well as in the configuration files. For example, the microservice manifest includes a `requiredRoles` field which actually expects a permission string.   
+{{< /c8y-admon-important >}}
 
 {{< c8y-admon-req >}}
 ROLES & PERMISSIONS:
@@ -29,7 +35,7 @@ ROLES & PERMISSIONS:
 * To assign owned roles to users ("feature-user-hierarchy" application subscription required): CREATE permission for the "User management" permission type.
 * To create new roles with available (owned) permissions: CREATE and ADMIN permission.
 
-The above permissions can be used to create roles for robust user management. Every new tenant have specified typical roles by default:
+The above permissions can be used to create roles for robust user management. Every new tenant has specified typical roles by default:
 * Global User Manager - Can access and modify the full user hierarchy
 * Shared User Manager - Can create new own sub-users and manage them ("feature-user-hierarchy" application subscription required)
 {{< /c8y-admon-req >}}

--- a/content/standard-tenant/managing-permissions.md
+++ b/content/standard-tenant/managing-permissions.md
@@ -35,7 +35,7 @@ ROLES & PERMISSIONS:
 * To assign owned roles to users ("feature-user-hierarchy" application subscription required): CREATE permission for the "User management" permission type.
 * To create new roles with available (owned) permissions: CREATE and ADMIN permission.
 
-The above permissions can be used to create roles for robust user management. Every new tenant has specified typical roles by default:
+The above permissions can be used to create roles for robust user management. Every new tenant has these roles by default:
 * Global User Manager - Can access and modify the full user hierarchy
 * Shared User Manager - Can create new own sub-users and manage them ("feature-user-hierarchy" application subscription required)
 {{< /c8y-admon-req >}}

--- a/content/standard-tenant/managing-users.md
+++ b/content/standard-tenant/managing-users.md
@@ -162,7 +162,7 @@ If single sign-on is enabled for your tenant, a message will show up which remin
 While entering the password, the strength of the password is checked. See [To change your password](/get-familiar-with-the-ui/user-settings/#to-change-your-password) for further information on password reset and strength.
     {{< /c8y-admon-info >}}
 
-5. On the right of the page, select the global roles for the user. Details on global roles are described in [Managing permissions](/standard-tenant/managing-permissions).
+5. On the right of the page, select the global roles for the user. Details on global roles are described in [Managing permissions and roles](/standard-tenant/managing-permissions).
 6. Click **Save** to save your settings.
 
 The new user will be added to the user list.

--- a/content/streaming-analytics/analytics-builder-bundle/monitoring-and-configuration.md
+++ b/content/streaming-analytics/analytics-builder-bundle/monitoring-and-configuration.md
@@ -319,7 +319,7 @@ You can customize the settings of Analytics Builder, the so-called “tenant opt
 
 You can find some concrete examples in [Using curl commands for setting various tenant options](/streaming-analytics/analytics-builder/#using-curl-commands-for-setting-various-tenant-options). However, you can use any tool you like.
 
-To change the tenant options, you need ADMIN permission for "Option management". See [Managing permissions](/standard-tenant/managing-permissions/) for more information.
+To change the tenant options, you need ADMIN permission for "Option management". See [Managing permissions and roles](/standard-tenant/managing-permissions/) for more information.
 
 {{< c8y-admon-caution>}}
 After you have changed a tenant option using a REST request, the correlator will automatically restart. An alarm with a MAJOR severity will be created in this case; you can view it on the **Alarms** page of the Cockpit application \(see [Working with alarms](/device-management-application/monitoring-and-controlling-devices/#working-with-alarms) for more information\).

--- a/content/streaming-analytics/analytics-customization-bundle/control-access.md
+++ b/content/streaming-analytics/analytics-customization-bundle/control-access.md
@@ -67,7 +67,7 @@ curl --user username -X POST -H 'Content-Type: application/json' -d '{"name":"fe
 
 By default, all users can see the same set of pages (according to the limitations above).
 You can also restrict the visibility of the pages to only users who have the permission ROLE_ANALYTICSBUILDER_READ or ROLE_EPLAPPS_READ,
-which can be assigned directly to users or via groups, see also [Managing permissions](/standard-tenant/managing-permissions/).
+which can be assigned directly to users or via groups, see also [Managing permissions and roles](/standard-tenant/managing-permissions/).
 To enable this, set the category of the tenant option to `streaminganalytics` and the `applicationAccess` key to the value "role", see the [Tenant API](https://{{< domain-c8y >}}/api/core/#tag/Tenant-API) in the {{< openapi >}}, or use a curl command as given in the example below:
 
 ```

--- a/content/streaming-analytics/analytics-customization-bundle/control-access.md
+++ b/content/streaming-analytics/analytics-customization-bundle/control-access.md
@@ -67,7 +67,7 @@ curl --user username -X POST -H 'Content-Type: application/json' -d '{"name":"fe
 
 By default, all users can see the same set of pages (according to the limitations above).
 You can also restrict the visibility of the pages to only users who have the permission ROLE_ANALYTICSBUILDER_READ or ROLE_EPLAPPS_READ,
-which can be assigned directly to users or via groups, see also [Managing permissions and roles](/standard-tenant/managing-permissions/).
+see also [Managing permissions and roles](/standard-tenant/managing-permissions/).
 To enable this, set the category of the tenant option to `streaminganalytics` and the `applicationAccess` key to the value "role", see the [Tenant API](https://{{< domain-c8y >}}/api/core/#tag/Tenant-API) in the {{< openapi >}}, or use a curl command as given in the example below:
 
 ```

--- a/content/streaming-analytics/analytics-customization-bundle/microservice-permissions.md
+++ b/content/streaming-analytics/analytics-customization-bundle/microservice-permissions.md
@@ -39,4 +39,4 @@ The manifest also specifies the permissions with which the microservice runs. Th
 - ROLE_BULK_OPERATION_READ
 - ROLE_NOTIFICATION_2_ADMIN
 
-You can add other roles to this list (or remove them from it) to grant (or remove) permissions to EPL code.
+You can add other permissions to this list (or remove them from it) to grant (or remove) permissions to EPL code.

--- a/content/streaming-analytics/epl-apps-bundle/basic-functionality.md
+++ b/content/streaming-analytics/epl-apps-bundle/basic-functionality.md
@@ -25,7 +25,7 @@ An EPL app has the ability to make nearly arbitrary changes to the objects in a 
 
 The **EPL Apps** page of the Streaming Analytics application provides an interface for interactively editing new or existing EPL apps (\*.mon files) as well as importing and activating (deploying) EPL apps.
 
-Any user on the tenant wishing to use the **EPL Apps** page must be a **CEP Manager**. See [Managing permissions](/standard-tenant/managing-permissions/).
+Any user on the tenant wishing to use the **EPL Apps** page must be a **CEP Manager**. See [Managing permissions and roles](/standard-tenant/managing-permissions/).
 
 ##### Step 1 - Invoke the Streaming Analytics application {#step-1---invoke-the-streaming-analytics-application}
 
@@ -263,7 +263,7 @@ The **Cumulocity Notifications 2.0** connectivity bundle has been added for rece
 
 EPL apps are designed to listen for REST (Representational State Transfer) services and supports all GET, POST, PUT and DELETE operations. Example requests for the different operations are listed below.
 
-To perform these operations, you must have READ and ADMIN permissions for "CEP management" (see also [Managing permissions](/standard-tenant/managing-permissions/)).
+To perform these operations, you must have READ and ADMIN permissions for "CEP management" (see also [Managing permissions and roles](/standard-tenant/managing-permissions/)).
 
 #### Request headers for all operations {#request-headers-for-all-operations}
 

--- a/content/streaming-analytics/introduction-analytics-bundle/prerequisites.md
+++ b/content/streaming-analytics/introduction-analytics-bundle/prerequisites.md
@@ -18,7 +18,7 @@ To use Analytics Builder, you must at least have the following permissions:
 |Option management|READ|
 |Inventory|READ|
 
-This is typically achieved by using a global role which has those permissions, and where the role has access to the Analytics Builder application. See [Managing permissions](/standard-tenant/managing-permissions/) for details.
+This is typically achieved by using a global role which has those permissions, and where the role has access to the Analytics Builder application. See [Managing permissions and roles](/standard-tenant/managing-permissions/) for details.
 
 To use EPL Apps, you only need the following permission:
 

--- a/content/streaming-analytics/troubleshooting-bundle/diagnostics-download.md
+++ b/content/streaming-analytics/troubleshooting-bundle/diagnostics-download.md
@@ -8,7 +8,7 @@ layout: redirect
 Diagnostics are not available for the Apama-ctrl-smartrules and Apama-ctrl-smartrulesmt microservices.
 {{< /c8y-admon-info >}}
 
-To download diagnostics information, you need READ permission for "CEP management". See [Managing permissions](/standard-tenant/managing-permissions/) for more information.
+To download diagnostics information, you need READ permission for "CEP management". See [Managing permissions and roles](/standard-tenant/managing-permissions/) for more information.
 
 {{< c8y-admon-info>}}
 ADMIN permission for "CEP management" does not include READ permission.

--- a/static/llms.txt
+++ b/static/llms.txt
@@ -201,7 +201,7 @@ The below links provide direct access to the available documentation sections:
 - [Home screen](http://localhost:1313/docs/standard-tenant/home-screen/)
 - [Introduction](http://localhost:1313/docs/standard-tenant/standard-tenant-introduction/)
 - [Managing data](http://localhost:1313/docs/standard-tenant/managing-data/)
-- [Managing permissions](http://localhost:1313/docs/standard-tenant/managing-permissions/)
+- [Managing permissions and roles](http://localhost:1313/docs/standard-tenant/managing-permissions/)
 - [Managing the ecosystem](http://localhost:1313/docs/standard-tenant/ecosystem/)
 - [Managing users](http://localhost:1313/docs/standard-tenant/managing-users/)
 - [Monitoring](http://localhost:1313/docs/standard-tenant/monitoring/)


### PR DESCRIPTION
To clarify the inconsistent usage of the terms "role" and "permission" in the UI and API, I made the following changes:

- Added a note in
- - https://cumulocity.com/docs/standard-tenant/managing-permissions/
- - https://cumulocity.com/docs/microservice-sdk/general-aspects/#microservice-manifest
- - https://cumulocity.com/docs/microservice-sdk/general-aspects/#security
- - https://cumulocity.com/docs/microservice-sdk/rest/#microservice-development
- Checked throughout the documentation and corrected the usage of these terms in various cases.
- Renamed the section "Managing permissions" to "Managing permissions and roles" as this is actually what it is about.

The glossary entries for "role" and "permission" will be updated in a separate PR together with the API details. 
