### PR TITLE
MTM-65091 / y2025 / changelog: revert validation and allow collon in full device registration

### DIFF
--- a/content/change-logs/device-management/cumulocity-2025-0-131-full-bulk-device-registration-special-characters-fix.md
+++ b/content/change-logs/device-management/cumulocity-2025-0-131-full-bulk-device-registration-special-characters-fix.md
@@ -1,0 +1,22 @@
+---
+date:
+title: Fixed issue with special characters in full bulk device registration 
+change_type:
+  - value: change-VSkj2iV9m
+    label: Fix
+product_area: Device management & connectivity
+component:
+  - value: component--KIsStyzM
+    label: Device Management app
+build_artifact:
+  - value: tc-QHwMfWtBk7
+    label: cumulocity
+ticket: MTM-65091
+version: 2025.0.131
+---
+In version 2025 of the {{< product-c8y-iot >}}, we added validation for the Device Request API to ensure that IDs do not contain characters that are forbidden in usernames. 
+
+With this fix, we have reverted this change for **full** [bulk device registration](/device-management-application/registering-devices/#bulk-device-registration) scenarios. In these cases, the ID of Device Request is also used to create external IDs for automatically created managed objects, 
+and characters such as colons are particularly useful for configuring the identity of LWM2M devices.
+
+

--- a/content/change-logs/device-management/cumulocity-2025-0-131-full-bulk-device-registration-special-characters-fix.md
+++ b/content/change-logs/device-management/cumulocity-2025-0-131-full-bulk-device-registration-special-characters-fix.md
@@ -17,6 +17,6 @@ version: 2025.0.131
 In version 2025 of the {{< product-c8y-iot >}}, we added validation for the Device Request API to ensure that IDs do not contain characters that are forbidden in usernames. 
 
 With this fix, we have reverted this change for **full** [bulk device registration](/device-management-application/registering-devices/#bulk-device-registration) scenarios. In these cases, the ID of Device Request is also used to create external IDs for automatically created managed objects, 
-and characters such as colons are particularly useful for configuring the identity of LWM2M devices.
+and characters such as colons are particularly useful for configuring the identity of some devices in the field.
 
 

--- a/content/change-logs/device-management/cumulocity-2025-0-131-full-bulk-device-registration-special-characters-fix.md
+++ b/content/change-logs/device-management/cumulocity-2025-0-131-full-bulk-device-registration-special-characters-fix.md
@@ -14,7 +14,7 @@ build_artifact:
 ticket: MTM-65091
 version: 2025.0.131
 ---
-In version 2025 of the {{< product-c8y-iot >}}, we added validation for the Device Request API to ensure that IDs do not contain characters that are forbidden in usernames. 
+In release 2025 of {{< product-c8y-iot >}}, validation for the Device Request API has been added to ensure that IDs do not contain characters that are forbidden in usernames. 
 
 With this fix, we have reverted this change for **full** [bulk device registration](/device-management-application/registering-devices/#bulk-device-registration) scenarios. In these cases, the ID of Device Request is also used to create external IDs for automatically created managed objects, 
 and characters such as colons are particularly useful for configuring the identity of some devices in the field.

--- a/content/change-logs/device-management/cumulocity-2025-0-131-full-bulk-device-registration-special-characters-fix.md
+++ b/content/change-logs/device-management/cumulocity-2025-0-131-full-bulk-device-registration-special-characters-fix.md
@@ -16,7 +16,7 @@ version: 2025.0.131
 ---
 In release 2025 of {{< product-c8y-iot >}}, validation for the Device Request API has been added to ensure that IDs do not contain characters that are forbidden in usernames. 
 
-With this fix, we have reverted this change for **full** [bulk device registration](/device-management-application/registering-devices/#bulk-device-registration) scenarios. In these cases, the ID of Device Request is also used to create external IDs for automatically created managed objects, 
+With this change, this validation has been reverted for **full** [bulk device registration](/device-management-application/registering-devices/#bulk-device-registration) scenarios. In these cases, the ID of the device request is also used to create external IDs for automatically created managed objects, 
 and characters such as colons are particularly useful for configuring the identity of some devices in the field.
 
 

--- a/content/get-familiar-with-the-ui/gui-features.md
+++ b/content/get-familiar-with-the-ui/gui-features.md
@@ -4,8 +4,6 @@ title: UI functionalities and features
 layout: bundle
 sector:
   - getting_started
-sector:
-  - getting_started
 
 ---
 


### PR DESCRIPTION
Preview from local build, with temporary added date:
<img width="934" height="333" alt="image" src="https://github.com/user-attachments/assets/03589380-e3cf-43ef-8c4e-0a2930f25137" />
