### PR TITLE
Breaking-change announcement for MQTT CN validation enforcement

### DIFF
--- a/content/change-logs/platform-services/mqtt-service-0.9.x-cn-validation-announcement.md
+++ b/content/change-logs/platform-services/mqtt-service-0.9.x-cn-validation-announcement.md
@@ -55,4 +55,8 @@ Please contact [Cumulocity Support](/additional-resources/contacting-support/) i
 
 ### Roll-out plan
 
+{{< c8y-admon-info >}}
+Because the {{< product-c8y-iot >}} [MQTT Service](/device-integration/mqtt-service/) is currently in Public Preview, it is not subject to the standard 6-month compatibility notice period defined in the Cumulocity IoT [Compatibility policy](/service-terms/compatibility-policy/).
+{{< /c8y-admon-info >}}
+
 To allow a smooth transition, CN validation will be introduced no sooner than **four weeks after this announcement**.

--- a/content/change-logs/platform-services/mqtt-service-0.9.x-cn-validation-announcement.md
+++ b/content/change-logs/platform-services/mqtt-service-0.9.x-cn-validation-announcement.md
@@ -1,5 +1,5 @@
 ---
-date: 2025-11-XX
+date: 2025-12-02
 title: MQTT Service will enforce Common Name validation for certificate-authenticated clients
 change_type:
   - value: change-inv-3bw8e

--- a/content/change-logs/platform-services/mqtt-service-0.9.x-cn-validation-announcement.md
+++ b/content/change-logs/platform-services/mqtt-service-0.9.x-cn-validation-announcement.md
@@ -14,6 +14,12 @@ build_artifact:
 issue: MTM-65167
 ---
 
+{{< c8y-admon-caution >}}
+This change only affects the new {{< product-c8y-iot >}} [MQTT Service](/device-integration/mqtt-service/) capability.
+
+The existing {{< product-c8y-iot >}} [Core MQTT](/device-integration/mqtt/) capability is **not** affected.
+{{< /c8y-admon-caution >}}
+
 ### Introduction
 
 To strengthen identity assurance for certificate-authenticated MQTT clients, the {{< product-c8y-iot >}} [MQTT Service](/device-integration/mqtt-service/) will begin enforcing **Common Name (CN) validation** during client certificate authentication.
@@ -24,20 +30,24 @@ This tight binding of certificates to devices will significantly reduce the risk
 
 ### What is changing?
 
-When an MQTT client connects using certificate-based authentication, **the Common Name (CN) in the certificate must match the MQTT client ID**.
+When an MQTT client connects using certificate-based authentication, **the Common Name (CN) in the certificate must match the MQTT device ID**.
 
-Only **two CN formats** will be accepted for any given client ID:
-1. `CN == <clientId>` - the standard and **required** format for all new devices.
-2. `CN == d:<clientId>` - supported **only for legacy SmartREST devices** migrating to the MQTT Service. This format must **not** be used for new devices.
+MQTT clients may identify themselves using either of the following client ID formats:
+1. `<deviceId>` – standard format
+2. `d:<deviceId>` – supported only for legacy SmartREST devices migrating to the MQTT Service. This format must **not** be used for new devices.
 
-If the CN does not match one of these two allowed forms for the client ID presented during connection, the client will fail authentication.
+However, in **both** cases, the certificate’s CN must be:
+
+* `CN == <deviceId>`
+
+Any certificate whose CN does not equal the device ID will fail authentication.
 
 Only certificate-authenticated clients are affected; all other authentication methods remain unchanged.
 
 ### Impact on existing MQTT clients
 
 This is a **breaking change**.  
-Devices using certificates whose CN does not align with the MQTT client ID will fail authentication once enforcement begins.
+Devices using certificates whose CN does not match the device ID will fail authentication once enforcement begins.
 
 Customers should verify and update their certificate issuance processes during the grace period.
 

--- a/content/change-logs/platform-services/mqtt-service-0.9.x-cn-validation-announcement.md
+++ b/content/change-logs/platform-services/mqtt-service-0.9.x-cn-validation-announcement.md
@@ -1,0 +1,47 @@
+---
+date: 2025-11-XX
+title: MQTT Service will enforce CN validation for certificate-authenticated clients
+change_type:
+  - value: change-inv-3bw8e
+    label: Announcement
+product_area: Platform services
+component:
+  - value: component-LcWEQW5gs
+    label: MQTT
+build_artifact:
+  - value: tc-hc5Tfixeqqei
+    label: mqtt-service
+issue: MTM-65167
+---
+
+### Introduction
+
+To strengthen identity assurance for certificate-authenticated MQTT clients, the {{< product-c8y-iot >}} [MQTT Service](/device-integration/mqtt-service/) will begin enforcing **Common Name (CN) validation** during client certificate authentication.
+
+Currently, the MQTT Service accepts certificates where the CN does not match the MQTT client ID.  
+This will change: the CN must correspond to the client ID used during connection, improving device-to-certificate integrity and reducing the risk of certificate misuse.
+
+### What is changing?
+
+When an MQTT client connects using certificate-based authentication:
+
+* The **CN in the certificate must match the MQTT client ID**.
+* SmartREST-style identifiers are supported, including:
+  * `CN == <clientId>`
+  * `CN == "d:<clientId>"`
+
+Only clients using certificate-based authentication are affected.  
+No changes apply to clients using other authentication mechanisms.
+
+### Impact on existing MQTT clients
+
+This is a **breaking change**.  
+Devices using certificates whose CN does not align with the MQTT client ID will fail authentication once enforcement begins.
+
+Customers should verify and update their certificate issuance processes during the grace period.
+
+For support, please contact product support.
+
+### Roll-out plan
+
+To allow a smooth transition, CN validation will be introduced **four weeks after this announcement**.

--- a/content/change-logs/platform-services/mqtt-service-0.9.x-cn-validation-announcement.md
+++ b/content/change-logs/platform-services/mqtt-service-0.9.x-cn-validation-announcement.md
@@ -24,15 +24,15 @@ This tight binding of certificates to devices will significantly reduce the risk
 
 ### What is changing?
 
-When an MQTT client connects using certificate-based authentication:
+When an MQTT client connects using certificate-based authentication, **the Common Name (CN) in the certificate must match the MQTT client ID**.
 
-* The **CN in the certificate must match the MQTT client ID**.
-* SmartREST-style identifiers are supported, including:
-  * `CN == <clientId>`
-  * `CN == "d:<clientId>"`
+Only **two CN formats** will be accepted for any given client ID:
+1. `CN == <clientId>` - the standard and **required** format for all new devices.
+2. `CN == d:<clientId>` - supported **only for legacy SmartREST devices** migrating to the MQTT Service. This format must **not** be used for new devices.
 
-Only clients using certificate-based authentication are affected.  
-No changes apply to clients using other authentication mechanisms.
+If the CN does not match one of these two allowed forms for the client ID presented during connection, the client will fail authentication.
+
+Only certificate-authenticated clients are affected; all other authentication methods remain unchanged.
 
 ### Impact on existing MQTT clients
 
@@ -41,7 +41,7 @@ Devices using certificates whose CN does not align with the MQTT client ID will 
 
 Customers should verify and update their certificate issuance processes during the grace period.
 
-For support, please contact product support.
+Please contact [Cumulocity Support](/additional-resources/contacting-support/) if you have any questions or concerns about these changes.
 
 ### Roll-out plan
 

--- a/content/change-logs/platform-services/mqtt-service-0.9.x-cn-validation-announcement.md
+++ b/content/change-logs/platform-services/mqtt-service-0.9.x-cn-validation-announcement.md
@@ -1,6 +1,6 @@
 ---
 date: 2025-11-XX
-title: MQTT Service will enforce CN validation for certificate-authenticated clients
+title: MQTT Service will enforce Common Name validation for certificate-authenticated clients
 change_type:
   - value: change-inv-3bw8e
     label: Announcement
@@ -19,7 +19,8 @@ issue: MTM-65167
 To strengthen identity assurance for certificate-authenticated MQTT clients, the {{< product-c8y-iot >}} [MQTT Service](/device-integration/mqtt-service/) will begin enforcing **Common Name (CN) validation** during client certificate authentication.
 
 Currently, the MQTT Service accepts certificates where the CN does not match the MQTT client ID.  
-This will change: the CN must correspond to the client ID used during connection, improving device-to-certificate integrity and reducing the risk of certificate misuse.
+After this change, the CN must match the client ID used during connection.
+This tight binding of certificates to devices will significantly reduce the risk of certificate misuse.
 
 ### What is changing?
 
@@ -44,4 +45,4 @@ For support, please contact product support.
 
 ### Roll-out plan
 
-To allow a smooth transition, CN validation will be introduced **four weeks after this announcement**.
+To allow a smooth transition, CN validation will be introduced no sooner than **four weeks after this announcement**.


### PR DESCRIPTION
Adds breaking-change announcement for upcoming CN validation enforcement in the MQTT Service. 