### PR TITLE
[DTM] Undo help content label change

### DIFF
--- a/content/dtm/asset-types-bundle/asset-models.md
+++ b/content/dtm/asset-types-bundle/asset-models.md
@@ -4,7 +4,7 @@ title: Overview
 layout: redirect
 helpcontent:
 - label: asset-types
-  title: The asset model
+  title: Asset models
   content: "An asset model is a blueprint or template to create one or multiple assets. It defines how an asset will look like after it is created. An asset model consists of one or more asset properties or child asset models.
 
 


### PR DESCRIPTION
Changing back the help content title to Asset models