### PR TITLE
Changed availability date for release candidates

### DIFF
--- a/content/service-terms/releases.md
+++ b/content/service-terms/releases.md
@@ -49,7 +49,7 @@ To help ensure that applications built on {{< product-c8y-iot >}}  continue to f
 For customers in particularly sensitive industries, {{< company-c8y >}} offers an annual deployment model, designed to provide a predictable, stable upgrade cycle. Each year, {{< company-c8y >}} designates one release as the annual release, which is deployed to customers following a carefully coordinated schedule, as outlined in the example below.
 
 In the annual deployment model:
-* A release candidate is made available on the last day of January for selected customers on non-production instances for a two-month period.
+* A release candidate is made available in the first half of February for selected customers on non-production instances for a two-month period.
 * The official release is published on the last day of March.
 * Maintenance for each annual release ends three months after the next annual release becomes generally available (End of Maintenance, or EOM).
 * After EOM, support will continue for up to three additional months (End of Sustained Support, or EOSS); however, no further fixes will be issued during this period. Customers are expected to complete upgrades within this timeframe and will receive dedicated support to facilitate this process.


### PR DESCRIPTION
The 2025 release retrospective revealed that the Cloud operations team requires a longer upgrade testing period. Consequently, the testing window has been extended from one week to two weeks. For the 2026 release, this means that the originally calculated Release Candidate (RC) availability date of Friday, February 6th, has been shifted to Monday, February 9th.