### PR TITLE
Clarify that a quota is per device

### DIFF
--- a/content/service-terms/quotas.md
+++ b/content/service-terms/quotas.md
@@ -84,7 +84,7 @@ The quotas listed here reflect the maximum values for the cloud subscriptions un
 | Quota                                                                                        | Type | Value |
 | -------------------------------------------------------------------------------------------- | ---- | ----: |
 | [File size for LWM2M bulk registration](/device-integration/lwm2m/#bulk-device-registration) | Hard | 10 MB |
-| [Concurrent pending LWM2M operations](/device-integration/lwm2m/#device-operations-handling) | Hard |    10 |
+| [Concurrent pending LWM2M operations per device](/device-integration/lwm2m/#device-operations-handling) | Hard |    10 |
 | Maximum number of Loriot devices that can be registered per deployment                       | Soft | 40000 |
 | Maximum number of Loriot devices that can be registered per tenant                           | Soft | 20000 |
 


### PR DESCRIPTION
This adds a small clarification that the pending LWM2M operations quota is per device