### PR TITLE
Unbreak the 2025 build's shortcode mistake

### DIFF
--- a/content/glossary/c.md
+++ b/content/glossary/c.md
@@ -130,7 +130,7 @@ The {{< product-c8y-iot >}} Developer Codex is {{< product-c8y-iot >}}'s compreh
 
 {{< product-c8y-iot >}} Edge is the onsite solution of {{< product-c8y-iot >}} intended to run as a local software application on industrial PC’s or local servers.
 
-See also [Edge](/{{< c8y-edge-version-major >}}/edge-kubernetes/k8-edge-introduction/) in the documentation.
+See also [Edge](/{{< c8y-edge-current-version >}}/edge-kubernetes/k8-edge-introduction/) in the documentation.
 
 {{< c8y-details title="Developer details" >}}
 Core REST APIs (such as [Inventory API](https://cumulocity.com/api/core/#tag/Inventory-API), [Event API](https://cumulocity.com/api/core/#tag/Event-API), [Alarm API](https://cumulocity.com/api/core/#tag/Alarm-API), [Measurement API](https://cumulocity.com/api/core/#tag/Measurement-API)) are typically available locally on the Edge instance.


### PR DESCRIPTION
release/y2025 somehow mentioned {{< c8y-edge-current-version >}} which hasn't been valid for quite some time