### PR TITLE
Refactor change log date automation script to get latest version of an active helm chart

### DIFF
--- a/.github/workflows/daily-changelog-dates-trigger.yml
+++ b/.github/workflows/daily-changelog-dates-trigger.yml
@@ -46,7 +46,7 @@ jobs:
           echo "[]" > output.json
            for artifact in $buildartifacts ;
            do
-               cat pipeline/clusters/helm_charts_data.json | jq --arg artifact "$artifact" --arg zone "c8y-ops-zone-1" --arg cluster "eu-latest-cumulocity-com-eks" '[to_entries[] | select(.value.component_name==$artifact and .value.status=="ACTIVE" and .value.zones[$zone].clusters[$cluster].version != null and .value.zones[$zone].clusters[$cluster].version != "")] | sort_by(.value.zones[$zone].clusters[$cluster].version | split(".") | map(tonumber)) | reverse [0].value.zones[$zone].clusters[$cluster]' > details.json
+               cat pipeline/clusters/helm_charts_data.json | jq --arg artifact "$artifact" --arg zone "c8y-ops-zone-1" --arg cluster "eu-latest-cumulocity-com-eks" '([to_entries[] | select(.value.component_name==$artifact and .value.status=="ACTIVE" and .value.zones[$zone].clusters[$cluster].version != null and .value.zones[$zone].clusters[$cluster].version != "")] | sort_by(.value.zones[$zone].clusters[$cluster].version | split(".") | map(tonumber)) | reverse)[0].value.zones[$zone].clusters[$cluster]' > details.json
                versionOfArtifact=$(cat details.json | jq '.version' | xargs)
                timestamp=$(cat details.json | jq '.updated_at' | xargs)
                rm details.json

--- a/.github/workflows/daily-changelog-dates-trigger.yml
+++ b/.github/workflows/daily-changelog-dates-trigger.yml
@@ -46,7 +46,7 @@ jobs:
           echo "[]" > output.json
            for artifact in $buildartifacts ;
            do
-               cat pipeline/clusters/helm_charts_data.json | jq --arg artifact "$artifact" '[to_entries[] | select(.value.component_name==$artifact)][0].value.zones["c8y-ops-zone-1"].clusters["eu-latest-cumulocity-com-eks"]' > details.json
+               cat pipeline/clusters/helm_charts_data.json | jq --arg artifact "$artifact" --arg zone "c8y-ops-zone-1" --arg cluster "eu-latest-cumulocity-com-eks" '[to_entries[] | select(.value.component_name==$artifact and .value.status=="ACTIVE" and .value.zones[$zone].clusters[$cluster].version != null and .value.zones[$zone].clusters[$cluster].version != "")] | sort_by(.value.zones[$zone].clusters[$cluster].version | split(".") | map(tonumber)) | reverse [0].value.zones[$zone].clusters[$cluster]' > details.json
                versionOfArtifact=$(cat details.json | jq '.version' | xargs)
                timestamp=$(cat details.json | jq '.updated_at' | xargs)
                rm details.json


### PR DESCRIPTION
Summary of changes:
- Pass zone and cluster name as arguments
- Filter on "ACTIVE" helm charts for a given component. Example: Our previous monolithic helm chart is no longer present and is no longer receiving updates - https://github.com/Cumulocity-IoT/c8y-iot-build-pipeline/blob/fa7c286b99e51ca9a5281c77a2add6ee2dbf79ee/clusters/helm_charts_data.json#L5
- For all helm charts belonging to a specific component, filter on versions that are not onboarded to the given cluster. Example: `apama-ctrl-mt` is currently onboarded to only zone-0 and so no entry exists for zone-1/eu-latest https://github.com/Cumulocity-IoT/c8y-iot-build-pipeline/blob/fa7c286b99e51ca9a5281c77a2add6ee2dbf79ee/clusters/helm_charts_data.json#L7310
- Finally sort the resultant helm charts in reverse order to get the helm chart with the latest version


**Root cause**: Ever since we split our old monolithic helm chart in to sub-components, change log date automation is not working for our component as the wrong entry is getting picked up

Tested that the automation works for all components and lists the correct versions