### PR TITLE
Clarify 'none' permission mode in asset management

### DIFF
--- a/content/change-logs/application-enablement/dtm-1023-0-0-added-permission-check-when-creating-updating-deleting-an-asset-based-on-c-8-y-external-asset-assets-permission-mode.md
+++ b/content/change-logs/application-enablement/dtm-1023-0-0-added-permission-check-when-creating-updating-deleting-an-asset-based-on-c-8-y-external-asset-assets-permission-mode.md
@@ -18,4 +18,4 @@ The Digital Twin Manager now supports fine-grained permission control for managi
 This tenant option supports three modes:
 - external (Default): Digital twin assets permissions are only enforced for assets marked with the **c8y_ExternalAsset** key. Users require the Digital twin assets UPDATE or ADMIN permission to modify or delete these assets.
 - all: Digital twin assets permissions are strictly required for all assets. Users must possess the Digital twin assets CREATE permission for creation, the UPDATE permission for modification, and the ADMIN permission for full management (create, update, or delete) of any asset.
--none: Digital twin assets permissions are not applicable to any assets. Asset control defaults to standard Inventory permissions.
+- none: Digital twin assets permissions are not applicable to any assets. Asset control defaults to standard Inventory permissions.


### PR DESCRIPTION
Removed the space that was making the changelog look incorrect( fixed the list formatting error )to clarify the behavior of the “none” permission mode for digital twin assets.
<img width="2882" height="736" alt="image" src="https://github.com/user-attachments/assets/d6f02f07-bd6c-4d38-b018-e1f52a74aaf0" />
