### PR TITLE
Feat/yearly preview and free trial button

### DIFF
--- a/data/date_settings.toml
+++ b/data/date_settings.toml
@@ -1,2 +1,3 @@
 yearly_release = false
+yearly_release_preview = false
 date = 2023-12-06T10:32:39.947Z

--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -262,6 +262,11 @@ collections:
             widget: string
             required: false
             hint: If it is a yearly release, add the name of the release
+          - name: yearly_release_preview
+            label: Yearly release preview
+            widget: boolean
+            default: false
+            hint: If it is a yearly release preview, switch on to display dates intead of versions
           - name: date
             label: Starting from
             widget: datetime

--- a/themes/c8ydocs/assets/scss/_main-top-bar.scss
+++ b/themes/c8ydocs/assets/scss/_main-top-bar.scss
@@ -60,6 +60,16 @@
       border-radius: 2px;
       outline-offset: -1px;
     }
+    &.btn-free-trial{
+      background-color: var(--c8y-palette-yellow-60);
+      color: var(--c8y-text-color);
+      font-weight: bold;
+      &:hover{
+        background-color: var(--c8y-palette-yellow-30);
+        color: var(--c8y-palette-high);
+        outline: 1px solid var(--c8y-text-color);
+      }
+    }
   }
   .dropdown-menu {
     // padding-top: 34px;

--- a/themes/c8ydocs/layouts/partials/change-logs-list.html
+++ b/themes/c8ydocs/layouts/partials/change-logs-list.html
@@ -109,7 +109,7 @@
         {{end}}
       {{end}}
 
-      {{ if not site.Data.date_settings.yearly_release}}
+      {{ if or (not site.Data.date_settings.yearly_release) site.Data.date_settings.yearly_release_preview }}
         <div
           id="cl-{{$listDate | urlize }}"
           class="page-section change-log__date {{range $classes}}{{.}} {{end}}"
@@ -195,7 +195,11 @@
               {{end}}
           </div>
            -->
-          {{.Content }}
+            {{- .Content
+             | replaceRE `<script[\s\S]*?</script>` ""
+             | replaceRE `\s+on\w+\s*=\s*"[^"]*"` ""
+             | replaceRE `\s+on\w+\s*=\s*'[^']*'` ""
+             | safeHTML -}}
         </div>
       </section>
       {{ end }}

--- a/themes/c8ydocs/layouts/partials/header.html
+++ b/themes/c8ydocs/layouts/partials/header.html
@@ -43,6 +43,14 @@
       >
         <i class="dlt-c8y-icon-communication-internet"></i> <span>Company website</span></a>
     </div>
+        <div class="dropdown version">
+      <a
+        class="dropdown-toggle version btn-free-trial"
+        title="Try for free"
+        href="https://www.cumulocity.com/start-your-journey/free-trial/"
+      >
+        Try Cumulocity free</a>
+    </div>
     <div class="dropdown version">
       <button
         class="dropdown-toggle version"


### PR DESCRIPTION
* Added a new `yearly_release_preview` boolean field to `data/date_settings.toml` and exposed it in the Netlify CMS config (`static/admin/config.yml`). This allows for previewing yearly releases by displaying dates instead of versions. [[1]](diffhunk://#diff-2e3d4eb8df7588bb4ac38f5ad5546ffc34d6c94c9058cbf8c412592c3da8a4d4R2) [[2]](diffhunk://#diff-2a71451a3327b5be51d2420abc4a205adb5de8531414203b316bf05f51b0d12dR265-R269)
* Updated the change logs list template to conditionally display dates or versions based on the new `yearly_release_preview` flag.
* Added a prominent "Try Cumulocity free" button to the top bar and header, with new styles for the `.btn-free-trial` class and a corresponding link in the header partial. [[1]](diffhunk://#diff-03ede85dfa586625044871bc93c701c9a070d7a122a3a812d35fb6a080273652R63-R72) [[2]](diffhunk://#diff-950cb1743cb2c7c35c9483c1c1494630258245e4714c240d36e00b272009dbeaR45-R52)
* Sanitized rendered change log content by stripping out `<script>` tags and inline event handlers, reducing the risk of XSS vulnerabilities.