### PR TITLE
mtm 65113 make documentation version more obvious

### DIFF
--- a/data/date_settings.toml
+++ b/data/date_settings.toml
@@ -1,3 +1,4 @@
 yearly_release = false
 yearly_release_preview = false
 date = 2023-12-06T10:32:39.947Z
+version = "Latest"

--- a/themes/c8ydocs/layouts/index.html
+++ b/themes/c8ydocs/layouts/index.html
@@ -4,7 +4,8 @@
   <div class="home-top">
     <section class="home-top__content">
         <h1 class="m-b-8">{{replace (replace (replace .Title "var-company-sag" .Site.Params.company_sag) "var-enterprise-tenant" .Site.Params.enterprise_tenant)  "var-product-c8y-iot" .Site.Params.product_c8y_iot}}</h1>
-        <div class="label label-info">{{ .Site.Data.date_settings.version }} version</div>
+        {{ $version := .Site.Data.date_settings.version }}
+        <div class="label label-info">{{ if eq $version "Latest" }}Latest release{{ else }}Release {{ $version }}{{ end }}</div>
         <p class="m-t-8">{{replace (replace (replace .Site.Params.description "var-company-sag" .Site.Params.company_sag) "var-enterprise-tenant" .Site.Params.enterprise_tenant)  "var-product-c8y-iot" .Site.Params.product_c8y_iot}}</p>
     </section>
     {{- partial "home-illustration.html" . -}}

--- a/themes/c8ydocs/layouts/index.html
+++ b/themes/c8ydocs/layouts/index.html
@@ -5,7 +5,7 @@
     <section class="home-top__content">
         <h1 class="m-b-8">{{replace (replace (replace .Title "var-company-sag" .Site.Params.company_sag) "var-enterprise-tenant" .Site.Params.enterprise_tenant)  "var-product-c8y-iot" .Site.Params.product_c8y_iot}}</h1>
         {{ $version := .Site.Data.date_settings.version }}
-        <div class="label label-info">{{ if eq $version "Latest" }}Latest release{{ else }}Release {{ $version }}{{ end }}</div>
+        <div class="label label-info">{{ if eq $version "Latest" }}Latest version{{ else }}Release {{ $version }}{{ end }}</div>
         <p class="m-t-8">{{replace (replace (replace .Site.Params.description "var-company-sag" .Site.Params.company_sag) "var-enterprise-tenant" .Site.Params.enterprise_tenant)  "var-product-c8y-iot" .Site.Params.product_c8y_iot}}</p>
     </section>
     {{- partial "home-illustration.html" . -}}

--- a/themes/c8ydocs/layouts/index.html
+++ b/themes/c8ydocs/layouts/index.html
@@ -3,8 +3,9 @@
   <div class="breadcrumbs-container p-t-16"></div>
   <div class="home-top">
     <section class="home-top__content">
-        <h1>{{replace (replace (replace .Title "var-company-sag" .Site.Params.company_sag) "var-enterprise-tenant" .Site.Params.enterprise_tenant)  "var-product-c8y-iot" .Site.Params.product_c8y_iot}}</h1>
-        <p>{{replace (replace (replace .Site.Params.description "var-company-sag" .Site.Params.company_sag) "var-enterprise-tenant" .Site.Params.enterprise_tenant)  "var-product-c8y-iot" .Site.Params.product_c8y_iot}}</p>
+        <h1 class="m-b-8">{{replace (replace (replace .Title "var-company-sag" .Site.Params.company_sag) "var-enterprise-tenant" .Site.Params.enterprise_tenant)  "var-product-c8y-iot" .Site.Params.product_c8y_iot}}</h1>
+        <div class="label label-info">{{ .Site.Data.date_settings.version }} version</div>
+        <p class="m-t-8">{{replace (replace (replace .Site.Params.description "var-company-sag" .Site.Params.company_sag) "var-enterprise-tenant" .Site.Params.enterprise_tenant)  "var-product-c8y-iot" .Site.Params.product_c8y_iot}}</p>
     </section>
     {{- partial "home-illustration.html" . -}}
   </div>

--- a/themes/c8ydocs/layouts/partials/head.html
+++ b/themes/c8ydocs/layouts/partials/head.html
@@ -8,7 +8,12 @@
     <base href="" />
     <meta name="generator" content="Hugo {{ hugo.Version }} with theme C8yDocs">
     {{ $version := .Site.Data.date_settings.version }}
-    {{ $siteTitle := printf "Cumulocity %s documentation" $version }}
+    {{ $siteTitle := "" }}
+    {{ if eq $version "Latest" }}
+      {{ $siteTitle = "Cumulocity documentation" }}
+    {{ else }}
+      {{ $siteTitle = printf "Cumulocity Release %s documentation" $version }}
+    {{ end }}
     {{if eq .Title $.Site.Title }}
       <title>{{ $siteTitle }}</title>
     {{else}}

--- a/themes/c8ydocs/layouts/partials/head.html
+++ b/themes/c8ydocs/layouts/partials/head.html
@@ -7,15 +7,17 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <base href="" />
     <meta name="generator" content="Hugo {{ hugo.Version }} with theme C8yDocs">
+    {{ $version := .Site.Data.date_settings.version }}
+    {{ $siteTitle := printf "Cumulocity %s documentation" $version }}
     {{if eq .Title $.Site.Title }}
-      <title>{{ .Title }}</title>
+      <title>{{ $siteTitle }}</title>
     {{else}}
-      <title>{{ with .Title }}{{ . }} - {{$.Site.Title }}{{ else }}{{ .Site.Title }}{{ end }}</title>
+      <title>{{ with .Title }}{{ . }} - {{ $siteTitle }}{{ else }}{{ $siteTitle }}{{ end }}</title>
     {{end}}
     <meta name="author" content="{{ .Site.Author.name }}">
     <meta name="keywords" content="{{ with .Keywords }}{{ delimit . ", " }}{{ end }}{{ if .Site.Params.keywords }}, {{ delimit .Site.Params.keywords ", " }}{{ end }}">
 
-    <meta property="og:title" content="{{if eq .Title $.Site.Title }}{{ .Title }}{{else}}{{ with .Title }}{{ . }} - {{$.Site.Title }}{{ else }}{{ .Site.Title }}{{ end }}{{end}}">
+    <meta property="og:title" content="{{if eq .Title $.Site.Title }}{{ $siteTitle }}{{else}}{{ with .Title }}{{ . }} - {{ $siteTitle }}{{ else }}{{ $siteTitle }}{{ end }}{{end}}">
     <meta property="og:description" content="This documentation offers comprehensive information on the Cumulocity platform both from a user and from a developer perspective. It reflects the latest state of the Cumulocity platform and is continuously updated to align with recent software updates.">
     <meta property="og:image" content="{{ "images/cumulocity-docs-web.jpg" | absURL}}">
     <meta property="og:url" content="https://cumulocity.com/docs/">

--- a/themes/c8ydocs/layouts/partials/header.html
+++ b/themes/c8ydocs/layouts/partials/header.html
@@ -63,28 +63,42 @@
         data-toggle="dropdown"
       >
 
-        <i class="c8y-icon c8y-icon-cumulocity-iot"></i> <span>Releases</span>
+        <i class="c8y-icon c8y-icon-cumulocity-iot"></i> <span>{{ if eq .Site.Data.date_settings.version "Latest" }}Latest version{{ else }}Release {{ .Site.Data.date_settings.version }}{{ end }}</span>
+        <div class="caret"></div>
       </button>
       <ul
         class="dropdown-menu"
         aria-labelledby="releasesLinks"
         role="listbox"
       >
-        {{ if site.Data.date_settings.yearly_release}}
-          <li class="text-normal"><a class="dd-link" href="//cumulocity.com/docs">Latest version</a></li>
-          <li>
-            {{ $siteDate := site.Data.date_settings.yearly_release_name }}
-            {{ if eq $siteDate "2025"}}
-            <li class="text-normal"><a class="dd-link" href="//cumulocity.com/docs/2024">Release 2024</a></li>
-            {{ else }}
-            <li class="text-normal"><a class="dd-link" href="//cumulocity.com/docs/2025">Release 2025</a></li>
-            {{ end }}
-          </li>
-        {{else}}
-          <li class="text-normal"><a class="dd-link" href="//cumulocity.com/docs/2025">Release 2025</a></li>
-          <li class="text-normal"><a class="dd-link" href="//cumulocity.com/docs/2024">Release 2024</a></li>
-        {{end}}
-        <li class="text-normal"><a class="dd-link" href="//cumulocity.com/docs/about_documentation/documentation-repository/">Previous versions</a></li>
+        {{ $currentVersion := .Site.Data.date_settings.version }}
+        <li class="text-normal">
+          <a class='icon-flex {{ if eq $currentVersion "Latest" }}p-l-4 {{else}} p-l-24 {{end}}' href="//cumulocity.com/docs">
+            {{ if eq $currentVersion "Latest" }}<i class="dlt-c8y-icon-check text-success"></i>{{ end }} 
+            <span>Latest version</span>
+          </a>
+        </li>
+        <li class="text-normal">
+          <a class='icon-flex {{ if eq $currentVersion "2026" }}p-l-4 {{else}} p-l-24 {{end}}' href="//cumulocity.com/docs/2026">
+            {{ if eq $currentVersion "2026" }}<i class="dlt-c8y-icon-check text-success"></i>{{ end }} 
+            <span>Release 2026</span> 
+          </a>
+        </li>
+        <li class="text-normal">
+          <a class='icon-flex {{ if eq $currentVersion "2025" }}p-l-4 {{else}} p-l-24 {{end}}' href="//cumulocity.com/docs/2025">
+            {{ if eq $currentVersion "2025" }}<i class="dlt-c8y-icon-check text-success"></i>{{ end }} 
+            <span>Release 2025</span> 
+          </a>
+        </li>
+        <li class="text-normal">
+          <a class='icon-flex {{ if eq $currentVersion "2024" }}p-l-4 {{else}} p-l-24 {{end}}' href="//cumulocity.com/docs/2024">
+            {{ if eq $currentVersion "2024" }}<i class="dlt-c8y-icon-check text-success"></i>{{ end }} 
+            <span>Release 2024</span> 
+          </a>
+        </li>
+        <li class="text-normal"><a class="icon-flex p-l-24" href="//cumulocity.com/docs/about_documentation/documentation-repository/">
+          <span>Previous versions</span>
+        </a></li>
       </ul>
     </div>
     <div class="dropdown version">
@@ -99,6 +113,7 @@
         data-toggle="dropdown"
       >
         <i class="dlt-c8y-icon-box-settings icon-20"></i> <span>Additional resources</span>
+        <div class="caret"></div>
       </button>
       <ul
         class="dropdown-menu dropdown-menu-right"
@@ -163,14 +178,29 @@
           </a>
         </li>
         <li class="dropdown-header separator-bottom p-t-8 p-b-8"><b>Releases</b></li>
+        {{ $currentVersion := .Site.Data.date_settings.version }}
         <li class="text-normal">
-          <a class="dd-link" href="//cumulocity.com/docs/2024"><i class="c8y-icon c8y-icon-cumulocity-iot"></i> Release 2024</a>
+          <a class="dd-link" href="//cumulocity.com/docs">
+            <i class="c8y-icon c8y-icon-cumulocity-iot"></i> Latest version {{ if eq $currentVersion "Latest" }}<i class="dlt-c8y-icon-check text-success"></i>{{ end }}
+          </a>
         </li>
         <li class="text-normal">
-          <a class="dd-link" href="//cumulocity.com/guides/welcome/intro-documentation/"><i class="c8y-icon c8y-icon-cumulocity-iot"></i> Release 10.18.0</a>
+          <a class="dd-link" href="//cumulocity.com/docs/2026">
+            <i class="c8y-icon c8y-icon-cumulocity-iot"></i> Release 2026 {{ if eq $currentVersion "2026" }}<i class="dlt-c8y-icon-check text-success"></i>{{ end }}
+          </a>
         </li>
         <li class="text-normal">
-          <a class="dd-link" href="//cumulocity.com/guides/10.17.0/welcome/intro-documentation/"> <i class="c8y-icon c8y-icon-cumulocity-iot"></i> Release 10.17.0</a>
+          <a class="dd-link" href="//cumulocity.com/docs/2025">
+            <i class="c8y-icon c8y-icon-cumulocity-iot"></i> Release 2025 {{ if eq $currentVersion "2025" }}<i class="dlt-c8y-icon-check text-success"></i>{{ end }}
+          </a>
+        </li>
+        <li class="text-normal">
+          <a class="dd-link" href="//cumulocity.com/docs/2024">
+            <i class="c8y-icon c8y-icon-cumulocity-iot"></i> Release 2024 {{ if eq $currentVersion "2024" }}<i class="dlt-c8y-icon-check text-success"></i>{{ end }}
+          </a>
+        </li>
+        <li class="text-normal">
+          <a class="dd-link" href="//cumulocity.com/docs/about_documentation/documentation-repository/"><i class="c8y-icon c8y-icon-cumulocity-iot"></i> Previous versions</a>
         </li>
         <li class="dropdown-header separator-bottom p-t-8 p-b-8"><b>Additional resources</b></li>
         {{ range $index, $resource := .Site.Params.additionalResources }}

--- a/themes/c8ydocs/layouts/partials/header.html
+++ b/themes/c8ydocs/layouts/partials/header.html
@@ -63,7 +63,7 @@
         data-toggle="dropdown"
       >
 
-        <i class="c8y-icon c8y-icon-cumulocity-iot"></i> <span>{{ if eq .Site.Data.date_settings.version "Latest" }}Latest version{{ else }}Release {{ .Site.Data.date_settings.version }}{{ end }}</span>
+        <i class="c8y-icon c8y-icon-cumulocity-iot"></i> <span>{{ if eq .Site.Data.date_settings.version "Latest" }}Latest release{{ else }}Release {{ .Site.Data.date_settings.version }}{{ end }}</span>
         <div class="caret"></div>
       </button>
       <ul
@@ -74,8 +74,8 @@
         {{ $currentVersion := .Site.Data.date_settings.version }}
         <li class="text-normal">
           <a class='icon-flex {{ if eq $currentVersion "Latest" }}p-l-4 {{else}} p-l-24 {{end}}' href="//cumulocity.com/docs">
-            {{ if eq $currentVersion "Latest" }}<i class="dlt-c8y-icon-check text-success"></i>{{ end }} 
-            <span>Latest version</span>
+            {{ if eq $currentVersion "Latest" }}<i class="dlt-c8y-icon-check text-success"></i>{{ end }}
+            <span>Latest release</span>
           </a>
         </li>
         <li class="text-normal">
@@ -181,7 +181,7 @@
         {{ $currentVersion := .Site.Data.date_settings.version }}
         <li class="text-normal">
           <a class="dd-link" href="//cumulocity.com/docs">
-            <i class="c8y-icon c8y-icon-cumulocity-iot"></i> Latest version {{ if eq $currentVersion "Latest" }}<i class="dlt-c8y-icon-check text-success"></i>{{ end }}
+            <i class="c8y-icon c8y-icon-cumulocity-iot"></i> Latest release {{ if eq $currentVersion "Latest" }}<i class="dlt-c8y-icon-check text-success"></i>{{ end }}
           </a>
         </li>
         <li class="text-normal">

--- a/themes/c8ydocs/layouts/partials/header.html
+++ b/themes/c8ydocs/layouts/partials/header.html
@@ -63,7 +63,7 @@
         data-toggle="dropdown"
       >
 
-        <i class="c8y-icon c8y-icon-cumulocity-iot"></i> <span>{{ if eq .Site.Data.date_settings.version "Latest" }}Latest release{{ else }}Release {{ .Site.Data.date_settings.version }}{{ end }}</span>
+        <i class="c8y-icon c8y-icon-cumulocity-iot"></i> <span>{{ if eq .Site.Data.date_settings.version "Latest" }}Latest version{{ else }}Release {{ .Site.Data.date_settings.version }}{{ end }}</span>
         <div class="caret"></div>
       </button>
       <ul
@@ -75,15 +75,17 @@
         <li class="text-normal">
           <a class='icon-flex {{ if eq $currentVersion "Latest" }}p-l-4 {{else}} p-l-24 {{end}}' href="//cumulocity.com/docs">
             {{ if eq $currentVersion "Latest" }}<i class="dlt-c8y-icon-check text-success"></i>{{ end }}
-            <span>Latest release</span>
+            <span>Latest version</span>
           </a>
         </li>
+        <!--
         <li class="text-normal">
           <a class='icon-flex {{ if eq $currentVersion "2026" }}p-l-4 {{else}} p-l-24 {{end}}' href="//cumulocity.com/docs/2026">
             {{ if eq $currentVersion "2026" }}<i class="dlt-c8y-icon-check text-success"></i>{{ end }} 
             <span>Release 2026</span> 
           </a>
         </li>
+      -->
         <li class="text-normal">
           <a class='icon-flex {{ if eq $currentVersion "2025" }}p-l-4 {{else}} p-l-24 {{end}}' href="//cumulocity.com/docs/2025">
             {{ if eq $currentVersion "2025" }}<i class="dlt-c8y-icon-check text-success"></i>{{ end }} 
@@ -181,7 +183,7 @@
         {{ $currentVersion := .Site.Data.date_settings.version }}
         <li class="text-normal">
           <a class="dd-link" href="//cumulocity.com/docs">
-            <i class="c8y-icon c8y-icon-cumulocity-iot"></i> Latest release {{ if eq $currentVersion "Latest" }}<i class="dlt-c8y-icon-check text-success"></i>{{ end }}
+            <i class="c8y-icon c8y-icon-cumulocity-iot"></i> Latest version {{ if eq $currentVersion "Latest" }}<i class="dlt-c8y-icon-check text-success"></i>{{ end }}
           </a>
         </li>
         <li class="text-normal">

--- a/themes/c8ydocs/layouts/partials/header.html
+++ b/themes/c8ydocs/layouts/partials/header.html
@@ -41,7 +41,7 @@
         title="Cumulocity website"
         href="https://www.cumulocity.com/"
       >
-        <i class="dlt-c8y-icon-communication-internet"></i> <span>Company website</span></a>
+        <i class="dlt-c8y-icon-communication-internet"></i> <span>Cumulocity website</span></a>
     </div>
         <div class="dropdown version">
       <a


### PR DESCRIPTION
This pull request updates the documentation site to improve how release versions are displayed and managed across the site. The changes introduce a new `version` field in the site data and refactor the way release information is shown in headers, dropdowns, and meta tags, making the release status clearer and more consistent for users.

* Added a `version` field to `data/date_settings.toml` to centrally manage the current release version.
* Refactored the main header and dropdown menus in `header.html` to dynamically show the current release version, highlight the active release, and improve navigation between releases. [[1]](diffhunk://#diff-950cb1743cb2c7c35c9483c1c1494630258245e4714c240d36e00b272009dbeaL66-R101) [[2]](diffhunk://#diff-950cb1743cb2c7c35c9483c1c1494630258245e4714c240d36e00b272009dbeaR181-R203)
* Updated the homepage (`index.html`) to display a label indicating whether the documentation is for the latest release or a specific version.

**Meta and SEO enhancements:**

* Modified the HTML `<title>` and Open Graph metadata in `head.html` to include the current release version, improving clarity for search engines and users.

**UI consistency:**

* Added missing caret icons to dropdown buttons for better visual cues in the navigation.

We need to cherry pick this to the other releases