### PR TITLE
Feature/backport y2026/dm 4971/opcua and thin edge proxy

### DIFF
--- a/content/change-logs/device-management/opcua-1022-0-14-opcua-and-thinedge-proxy.md
+++ b/content/change-logs/device-management/opcua-1022-0-14-opcua-and-thinedge-proxy.md
@@ -12,7 +12,7 @@ build_artifact:
   - value: tc-MLn0oFRX-
     label: opcua
 ticket: DM-4971
-version: 1023.1.0
+version: 1022.0.14
 ---
 The OPC UA gateway now connects to {{< product-c8y-iot >}} through the local [{{< product-c8y-iot >}} thin-edge.io proxy](https://thin-edge.github.io/thin-edge.io/references/cumulocity-proxy/).
 Consequently, OPC UA gateway thin-edge.io usage without the {{< product-c8y-iot >}} proxy is now deprecated and will be removed in a future version.

--- a/content/change-logs/device-management/opcua-1023-1-0-opcua-and-thinedge-proxy.md
+++ b/content/change-logs/device-management/opcua-1023-1-0-opcua-and-thinedge-proxy.md
@@ -15,5 +15,5 @@ ticket: DM-4971
 version: 1023.1.0
 ---
 The OPC UA gateway now connects to {{< product-c8y-iot >}} through the local [{{< product-c8y-iot >}} thin-edge.io proxy](https://thin-edge.github.io/thin-edge.io/references/cumulocity-proxy/).
-Consequently, OPC UA gateway thin-edge.io usage without the {{< product-c8y-iot >}} proxy is now deprecated.
+Consequently, OPC UA gateway thin-edge.io usage without the {{< product-c8y-iot >}} proxy is now deprecated and will be removed in a future version.
 Please update your gateway configuration to use this local proxy model corresponding to our [revised documentation](/device-integration/opcua/#thinedge-recommended-config).

--- a/content/change-logs/device-management/opcua-1023-1-0-opcua-and-thinedge-proxy.md
+++ b/content/change-logs/device-management/opcua-1023-1-0-opcua-and-thinedge-proxy.md
@@ -15,5 +15,5 @@ ticket: DM-4971
 version: 1023.1.0
 ---
 The OPC UA gateway now connects to {{< product-c8y-iot >}} through the local [{{< product-c8y-iot >}} thin-edge.io proxy](https://thin-edge.github.io/thin-edge.io/references/cumulocity-proxy/).
-Consequently, OPC UA gateway thin-edge.io usages without the {{< product-c8y-iot >}} proxy is now deprecated.
+Consequently, OPC UA gateway thin-edge.io usage without the {{< product-c8y-iot >}} proxy is now deprecated.
 Please update your gateway configuration to use this local proxy model corresponding to our [revised documentation](/device-integration/opcua/#thinedge-recommended-config).

--- a/content/change-logs/device-management/opcua-1023-1-0-opcua-and-thinedge-proxy.md
+++ b/content/change-logs/device-management/opcua-1023-1-0-opcua-and-thinedge-proxy.md
@@ -1,0 +1,19 @@
+---
+date: ""
+title: OPC UA gateway with the thin-edge.io proxy support
+product_area: Device management & connectivity
+change_type:
+  - value: change-inv-3bw8e
+    label: Announcement
+component:
+  - value: component-Tf05_KQ-B
+    label: OPC UA
+build_artifact:
+  - value: tc-MLn0oFRX-
+    label: opcua
+ticket: DM-4971
+version: 1023.1.0
+---
+The OPC UA gateway now connects to {{< product-c8y-iot >}} through the local [{{< product-c8y-iot >}} thin-edge.io proxy](https://thin-edge.github.io/thin-edge.io/references/cumulocity-proxy/).
+Consequently, OPC UA gateway thin-edge.io usages without the {{< product-c8y-iot >}} proxy is now deprecated.
+Please update your gateway configuration to use this local proxy model corresponding to our [revised documentation](/device-integration/opcua/#thinedge-recommended-config).

--- a/content/device-integration/opcua-bundle/gateway-configuration-and-registration.md
+++ b/content/device-integration/opcua-bundle/gateway-configuration-and-registration.md
@@ -72,12 +72,12 @@ gateway:
 
 With the configuration `gateway.thinEdge.enabled: true` you switch to the thin-edge.io mode. This means that the authentication and registration to the platform will be done via thin-edge.io. The OPC UA gateway is automatically registered and created as a subdevice under the thin-edge.io device defined with `gateway.thinEdge.deviceId`.
 
-`gateway.thinEdge.useHttpProxy` is switch to make opcua-device-gateway to fully use thin-edge.io proxy also for the authentication to the platform. It requires `C8Y.baseUrl` to be set to the thin-edge.io proxy URL.
+`gateway.thinEdge.useHttpProxy` is a switch that makes the opcua-device-gateway fully use the thin-edge.io proxy, including authentication to the platform. It requires `C8Y.baseUrl` to be set to the thin-edge.io proxy URL.
 
 
 ##### Example legacy thin-edge.io configuration (deprecated) {#example-legacy-config}
 
-The legacy thin-edge.io mode recreates the authentication credentials for the thin-edge.io connection. This mode is now deprecated and will be removed in the future.
+The legacy thin-edge.io mode recreates the authentication credentials for the thin-edge.io connection. This mode is now deprecated.
 
 ```yaml
 C8Y:

--- a/content/device-integration/opcua-bundle/gateway-configuration-and-registration.md
+++ b/content/device-integration/opcua-bundle/gateway-configuration-and-registration.md
@@ -25,7 +25,8 @@ gateway:
     identifier: Gateway_Device
     name: Gateway_Device
     db:
-# The gateway uses the local database to store platform credentials and local cache. This parameter shows the location in which the local data should be stored.
+        # The gateway uses the local database to store platform credentials and local cache.
+        # This parameter shows the location in which the local data should be stored.
         baseDir: C:/Users/<<userName>>/.opcua/data
 ```
 
@@ -37,6 +38,47 @@ Windows OS is used for the example.
 
 The OPC UA gateway can also be registered and operated via [thin-edge.io](https://thin-edge.io/). In contrast to the standalone mode, `thinEdge` configurations must be added to the YAML file:
 
+
+#### Recommended configuration using the thin-edge.io {{< product-c8y-iot >}} proxy {#thinedge-recommended-config}
+
+{{< c8y-admon-info >}}
+This requires to be run with the thin-edge.io version 1.7.1 or higher.
+{{< /c8y-admon-info >}}
+
+The recommended mode of integration uses
+the [thin-edge.io proxy](https://thin-edge.github.io/thin-edge.io/references/cumulocity-proxy/). The local
+proxy of thin-edge.io exposes the {{< product-c8y-iot >}} API. By default, the proxy is available at
+`http://localhost:8001/c8y`.
+
+##### Example configuration for the thin-edge.io proxy {#example-localproxy-thin-edge-config}
+
+```yaml
+C8Y:
+    baseUrl: http://localhost:8001/c8y/ # Points to the thin-edge.io proxy
+gateway:
+    bootstrap:
+        tenantId: <<yourTenantId>>
+    identifier: Gateway_Device
+    name: Gateway_Device
+    db:
+        # The gateway uses the local database to store platform credentials and local cache.
+        # This parameter shows the location in which the local data should be stored.
+        baseDir: C:/Users/<<userName>>/.opcua/data
+    thinEdge:
+        enabled: true
+        useHttpProxy: true
+        deviceId: Thin-Edge_Device
+```
+
+With the configuration `gateway.thinEdge.enabled: true` you switch to the thin-edge.io mode. This means that the authentication and registration to the platform will be done via thin-edge.io. The OPC UA gateway is automatically registered and created as a subdevice under the thin-edge.io device defined with `gateway.thinEdge.deviceId`.
+
+`gateway.thinEdge.useHttpProxy` is switch to make opcua-device-gateway to fully use thin-edge.io proxy also for the authentication to the platform. It requires `C8Y.baseUrl` to be set to the thin-edge.io proxy URL.
+
+
+##### Example legacy thin-edge.io configuration (deprecated) {#example-legacy-config}
+
+The legacy thin-edge.io mode recreates the authentication credentials for the thin-edge.io connection. This mode is now deprecated and will be removed in the future.
+
 ```yaml
 C8Y:
     baseUrl: https://<<yourTenant>>.{{< domain-c8y >}}
@@ -46,15 +88,19 @@ gateway:
     identifier: Gateway_Device
     name: Gateway_Device
     db:
-# The gateway uses the local database to store platform credentials and local cache. This parameter shows the location in which the local data should be stored.
+        # The gateway uses the local database to store platform credentials and local cache.
+        # This parameter shows the location in which the local data should be stored.
         baseDir: C:/Users/<<userName>>/.opcua/data
     thinEdge:
         enabled: true
+        # URL for the MQTT client to connect to the local thin-edge.io MQTT broker.
         mqttServerURL: tcp://<<thinEdge MQTT broker>>
         deviceId: Thin-Edge_Device
 ```
 
-With the configuration `gateway.thinEdge.enabled: true` you switch to the thin-edge.io mode. This means that the authentication and registration to the platform will be done via thin-edge.io. The OPC UA gateway is automatically registered and created as a subdevice under the thin-edge.io device. `gateway.thinEdge.mqttServerURL` and `gateway.thinEdge.deviceId` are the connection information for the MQTT client to connect to the local thin-edge.io MQTT broker.
+
+
+
 
 {{< c8y-admon-preview-feature >}}
 
@@ -66,21 +112,23 @@ The MQTT Forwarding mode uses the existing `thinEdge` configuration and introduc
 
 ```yaml
 C8Y:
-    baseUrl: https://<<yourTenant>>.{{< domain-c8y >}}
+    baseUrl: http://localhost:8001/c8y/
 gateway:
     bootstrap:
         tenantId: <<yourTenantId>>
     identifier: Gateway_Device
     name: Gateway_Device
     db:
-# The gateway uses the local database to store platform credentials and local cache. This parameter shows the location in which the local data should be stored.
+        # The gateway uses the local database to store platform credentials and local cache.
+        # This parameter shows the location in which the local data should be stored.
         baseDir: C:/Users/<<userName>>/.opcua/data
     mappings:
-      mergeCyclicRead: false
-      mergedEventType: c8y_OpcuaEvent
-      mergedMeasurementType: c8y_OpcuaMeasurement
+        mergeCyclicRead: false
+        mergedEventType: c8y_OpcuaEvent
+        mergedMeasurementType: c8y_OpcuaMeasurement
     thinEdge:
         enabled: true
+        useHttpProxy: true
         mqttServerURL: tcp://<<thinEdge MQTT broker>>
         deviceId: Thin-Edge_Device
         useForDataForwarding: true
@@ -93,6 +141,7 @@ gateway:
 
 The configuration `gateway.thinEdge.useForDataForwarding` controls if MQTT Forwarding mode is enabled. The following configurations are optional and control the behavior of the MQTT client:
 
+* `gateway.thinEdge.mqttServerURL` (default: tcp://127.0.0.1:1883) - URL for the MQTT client to connect to the local thin-edge.io MQTT broker.
 * `gateway.thinEdge.mqttAutomaticReconnect` (default:true) - controls if the MQTT client will reconnect in case it looses connection to the MQTT server.
 * `gateway.thinEdge.mqttCleanSession` (default:true) - controls if the MQTT client should remember state across sessions or start with a clean session.
 * `gateway.thinEdge.mqttConnectionTimeout` (default: 30) - connection timeout in seconds.

--- a/content/device-integration/opcua-bundle/gateway-configuration-and-registration.md
+++ b/content/device-integration/opcua-bundle/gateway-configuration-and-registration.md
@@ -54,7 +54,7 @@ proxy of thin-edge.io exposes the {{< product-c8y-iot >}} API. By default, the p
 
 ```yaml
 C8Y:
-    baseUrl: http://localhost:8001/c8y/ # Points to the thin-edge.io proxy
+    baseUrl: http://localhost:8001/c8y # Points to the thin-edge.io proxy
 gateway:
     bootstrap:
         tenantId: <<yourTenantId>>
@@ -112,7 +112,7 @@ The MQTT Forwarding mode uses the existing `thinEdge` configuration and introduc
 
 ```yaml
 C8Y:
-    baseUrl: http://localhost:8001/c8y/
+    baseUrl: http://localhost:8001/c8y
 gateway:
     bootstrap:
         tenantId: <<yourTenantId>>


### PR DESCRIPTION
Backport of https://github.com/Cumulocity-IoT/c8y-docs/pull/4129 to 2026 yearly release