### PR TITLE
[MTM-65970] Correct the documentation for widgets-collection/#map

### DIFF
--- a/content/cockpit/widgets-collection.md
+++ b/content/cockpit/widgets-collection.md
@@ -291,7 +291,7 @@ Click a device icon, to open a popup with the following information:
 
 **Parameters to configure**
 
-* Target assets or devices: Select which devices are shown on the map. If a group is selected, all devices in that group (but not in any subgroups) are visible.
+* Target assets or devices: Select which devices are shown on the map. If a group is selected, all devices in that group, including those in subgroups, are visible.
 * Marker icon: Icon of the marker on the map.
 * Zoom level: Default zoom level of the map.
 * Center bound: The default map coordinates.


### PR DESCRIPTION
https://cumulocity.atlassian.net/browse/MTM-65970


Affected System: -

Documentation for [Widgets collection - Cumulocity documentation](https://cumulocity.com/docs/cockpit/widgets-collection/#map) 

Description of the request: -

NTT pointed out to correct some documentation as below.

In the following link (https://cumulocity.com/docs/cockpit/widgets-collection/#map), the description currently states:

"Target assets or devices: Select which devices are shown on the map. If a group is selected, all devices in that group (but not in any subgroups) are visible."

Since this description contradicts the recent functional update at https://cumulocity.com/docs/change-logs/#ui-c8y-1022-28-0-show-all-children-of-a-group-including-grand-children-on-maps, could you please update this document?