### PR TITLE
Use correct microservice name for apama-ctrl-mt [no-issue]

### DIFF
--- a/content/change-logs/analytics/apama-in-c8y-20250206-The-Apama-ctrl-mt-4c-16g-microservice-now-supports-analytic-models.md
+++ b/content/change-logs/analytics/apama-in-c8y-20250206-The-Apama-ctrl-mt-4c-16g-microservice-now-supports-analytic-models.md
@@ -1,7 +1,7 @@
 ---
 date: '2025-02-13'
 title: >-
-  The multi-tenant apama-ctrl-mt microservice now supports analytic
+  The multi-tenant apama-ctrl-mt-4c-16g microservice now supports analytic
   models
 change_type:
   - value: change-2c7RdTdXo4
@@ -23,4 +23,4 @@ environment_availability:
   - label: us.cumulocity.com
   - label: cumulocity.com
 ---
-The multi-tenant **Apama-ctrl-mt** microservice now supports Analytic models. The **Analytics Builder** page is shown for tenants subscribed to the microservice, allowing users to create, deploy and manage analytic models.
+The multi-tenant **Apama-ctrl-mt-4c-16g** microservice now supports Analytic models. The **Analytics Builder** page is shown for tenants subscribed to the microservice, allowing users to create, deploy and manage analytic models.

--- a/content/change-logs/analytics/apama-in-c8y-20250206-The-Apama-ctrl-mt-4c-16g-microservice-now-supports-analytic-models.md
+++ b/content/change-logs/analytics/apama-in-c8y-20250206-The-Apama-ctrl-mt-4c-16g-microservice-now-supports-analytic-models.md
@@ -1,7 +1,7 @@
 ---
 date: '2025-02-13'
 title: >-
-  The multi-tenant apama-ctrl-mt-4c-16g microservice now supports analytic
+  The multi-tenant apama-ctrl-mt microservice now supports analytic
   models
 change_type:
   - value: change-2c7RdTdXo4
@@ -23,4 +23,4 @@ environment_availability:
   - label: us.cumulocity.com
   - label: cumulocity.com
 ---
-The multi-tenant **Apama-ctrl-mt-4c-16g** microservice now supports Analytic models. The **Analytics Builder** page is shown for tenants subscribed to the microservice, allowing users to create, deploy and manage analytic models.
+The multi-tenant **Apama-ctrl-mt** microservice now supports Analytic models. The **Analytics Builder** page is shown for tenants subscribed to the microservice, allowing users to create, deploy and manage analytic models.

--- a/content/streaming-analytics/analytics-builder-bundle/understanding-models.md
+++ b/content/streaming-analytics/analytics-builder-bundle/understanding-models.md
@@ -144,7 +144,7 @@ To upload an extension, the user specified in the `--username` argument must hav
 The Apama-ctrl microservice is restarted after running the above command. The user must have the ADMIN permission for "CEP management" to request a restart.
 
 {{< c8y-admon-info>}}
-When using the multi-tenant Apama-ctrl-mt-4c-16g microservice, only extensions uploaded to the tenant that owns the microservice will be used.
+When using the multi-tenant Apama-ctrl-mt microservice, only extensions uploaded to the tenant that owns the microservice will be used.
 {{< /c8y-admon-info>}}
 
 ### Wires {#wires}

--- a/content/streaming-analytics/analytics-customization-bundle/control-access.md
+++ b/content/streaming-analytics/analytics-customization-bundle/control-access.md
@@ -14,7 +14,7 @@ Which pages are available also depends on the variant of the Apama-ctrl microser
 and only a card with information about smart rules is shown on the home screen.
 - If the Apama-ctrl-starter microservice is running, the **EPL Apps** page is not shown (and cannot be enabled)
 as the EPL apps functionality is not available in Apama-ctrl-starter.
-- If the Apama-ctrl-mt-4c-16g microservice is running, the **Analytics Builder** page is shown for all subscribed tenants. The **EPL Apps** page is shown 
+- If the Apama-ctrl-mt microservice is running, the **Analytics Builder** page is shown for all subscribed tenants. The **EPL Apps** page is shown 
 on the tenant that owns the microservice, but not shown (and cannot be enabled) on the subtenants.
 - If the Apama-ctrl-smartrules or Apama-ctrl-smartrulesmt microservice is running, neither the **Analytics Builder** nor the **EPL Apps** page is shown (and cannot be enabled).
 In this case, only the card with information about smart rules is shown on the home screen.

--- a/content/streaming-analytics/analytics-customization-bundle/optimize-requests.md
+++ b/content/streaming-analytics/analytics-customization-bundle/optimize-requests.md
@@ -23,5 +23,5 @@ You can adjust the default number of client connections with the `client.numClie
 If you require a fully serial transport, set the value of `client.numClients` to 1.
 
 {{< c8y-admon-info >}}
-This does not apply to the Apama-ctrl-smartrules, Apama-ctrl-smartrulesmt, and Apama-ctrl-mt-4c-16g microservices. They have a fix value of 1 (that is, fully serial) for this option, which is not configurable.
+This does not apply to the Apama-ctrl-smartrules, Apama-ctrl-smartrulesmt, and Apama-ctrl-mt microservices. They have a fix value of 1 (that is, fully serial) for this option, which is not configurable.
 {{< /c8y-admon-info >}}

--- a/content/streaming-analytics/introduction-analytics-bundle/microservice-and-applications.md
+++ b/content/streaming-analytics/introduction-analytics-bundle/microservice-and-applications.md
@@ -26,7 +26,7 @@ If your tenant is subscribed to the Apama-ctrl-250mc-1g microservice (or one of 
 - Analytic models, EPL apps and smart rules are supported.
 - Custom blocks written with the Analytics Builder Block SDK can be used.
 
-If your tenant is subscribed to the Apama-ctrl-mt-4c-16g microservice, then the following applies:
+If your tenant is subscribed to the Apama-ctrl-mt microservice, then the following applies:
 - Multi-tenant support.
 - EPL apps are only enabled on the tenant that owns the microservice, but disabled on the subtenants.
 - Analytic models and smart rules are supported.


### PR DESCRIPTION
We renamed the microservice from `apama-ctrl-mt-4c-16g` to `apama-ctrl-mt` over the last year but forgot to update the doc.