### PR TITLE
Added change-note about vulnerability

### DIFF
--- a/content/change-logs/application-enablement/ui-c8y-1021.22.145-css-vulnerability.md
+++ b/content/change-logs/application-enablement/ui-c8y-1021.22.145-css-vulnerability.md
@@ -14,4 +14,4 @@ build_artifact:
 ticket: MTM-659915
 version: 1021.22.145
 ---
-A CSS injection vulnerability has been identified and fixed in the Web SDK component. Custom applications and plugins built with affected versions of the Web SDK smust be updated to version 1021.22.145 or higher to ensure they are protected.
+A CSS injection vulnerability has been identified and fixed in the Web SDK component. Custom applications and plugins built with affected versions of the Web SDK must be updated to version 1021.22.145 or higher to ensure they are protected.

--- a/content/change-logs/application-enablement/ui-c8y-1021.22.145-css-vulnerability.md
+++ b/content/change-logs/application-enablement/ui-c8y-1021.22.145-css-vulnerability.md
@@ -1,0 +1,17 @@
+---
+date: 
+title: Fixed security vulnerability in WebSDK
+product_area: Application enablement & solutions
+change_type:
+  - value: change-VSkj2iV9m
+    label: Fix
+component:
+  - value: component-YbYJ3gLU_
+    label: Web SDK
+build_artifact:
+  - value: tc-pjJiURv9Y
+    label: ui-c8y
+ticket: MTM-659915
+version: 1021.22.145
+---
+A CSS injection vulnerability has been identified and fixed in the WebSDK component. Custom applications and plugins built with affected versions of the WebSDK should be updated to version 1021.22.145 or higher to ensure they are protected.

--- a/content/change-logs/application-enablement/ui-c8y-1021.22.145-css-vulnerability.md
+++ b/content/change-logs/application-enablement/ui-c8y-1021.22.145-css-vulnerability.md
@@ -1,6 +1,6 @@
 ---
 date: 
-title: Fixed security vulnerability in WebSDK
+title: Fixed security vulnerability in Web SDK
 product_area: Application enablement & solutions
 change_type:
   - value: change-VSkj2iV9m
@@ -14,4 +14,4 @@ build_artifact:
 ticket: MTM-659915
 version: 1021.22.145
 ---
-A CSS injection vulnerability has been identified and fixed in the WebSDK component. Custom applications and plugins built with affected versions of the WebSDK should be updated to version 1021.22.145 or higher to ensure they are protected.
+A CSS injection vulnerability has been identified and fixed in the Web SDK component. Custom applications and plugins built with affected versions of the Web SDK smust be updated to version 1021.22.145 or higher to ensure they are protected.


### PR DESCRIPTION
@BeateRixen A official communication should follow later, but @Michael-Gesmann mentioned that we should add it to the change log (espacially also on the 2025-20 release). Do I then need to backgraft this?

@saran-govindarajan Do you think the text is fine this way?