### PR TITLE
Fix with internal and environment availability

### DIFF
--- a/themes/c8ydocs/assets/scss/_change-logs.scss
+++ b/themes/c8ydocs/assets/scss/_change-logs.scss
@@ -111,22 +111,58 @@
     > label{
       flex: 0 0 auto;
     }
-    .metadata {
-      flex-grow: 1;
+  }
+  &__details{
+    margin-bottom: 1rem;
+    margin-top: -.5rem;
+    display: block;
+    .collapse-btn{
+      font-size: 11px;
+      text-transform: uppercase;
+      font-weight: 600;
+      color: currentColor;
+      background: var(--c8y-palette-gray-100);
+      padding: .3rem .5rem;
+      border-radius: .25rem;
+      border: 1px solid var(--c8y-root-component-border-color);
+      margin-bottom: 2px;
       display: flex;
-      gap: 1rem;
+      align-items: center;
+      gap: 4px;
+      > i{
+        transition: rotate 0.3s ease;
+        rotate: -180deg;
+      }
+      &.collapsed > i{
+        rotate: 0deg;
+      }
+    }
+   .metadata{
+      background-color: var(--c8y-palette-gray-100);
+      &:last-child{
+        border-bottom-left-radius: 1rem;
+        border-bottom-right-radius: 1rem;
+      }
       > div, .btn-metadata{
-        flex: 0 1 33%;
-        font-size: $font-size-sm;
-        border: 1px solid var(--c8y-root-component-separator-color);
-        padding: 0 .5rem .5rem;
-        border-radius: .25rem;
-        p{
-          font-weight: bold;
-          line-height: 1;
-          font-size: 85%;
-          color: var(--c8y-palette-gray-30);
-        }
+        background-color: var(--c8y-palette-high);
+      }
+    }
+  }
+  .metadata {
+    flex-grow: 1;
+    display: flex;
+    gap: 1rem;
+    > div, .btn-metadata{
+      flex: 0 1 33%;
+      font-size: $font-size-sm;
+      border: 1px solid var(--c8y-root-component-separator-color);
+      padding: 0 .5rem .5rem;
+      border-radius: .25rem;
+      p{
+        font-weight: bold;
+        line-height: 1;
+        font-size: 85%;
+        color: var(--c8y-palette-gray-30);
       }
     }
   }

--- a/themes/c8ydocs/layouts/partials/change-log-filters.html
+++ b/themes/c8ydocs/layouts/partials/change-log-filters.html
@@ -43,15 +43,13 @@
         {{ end }}
       {{else}}
         {{ range sort site.Data.changetype.options "option" "asc" }}
-          {{ if ne .option "Fix"}}
-            <label class="c8y-checkbox m-b-4">
-              <input type="checkbox" class="filter-btn" name="change-type-{{.option | urlize}}">
-              <span></span>
-              <span>
-                {{.option}}
-              </span>
-            </label>
-          {{ end }}
+          <label class='c8y-checkbox m-b-4 {{ if eq .option "Fix"}} hidden {{end}}' {{ if eq .option "Fix"}} data-internal {{end}}>
+            <input type="checkbox" class="filter-btn" name="change-type-{{.option | urlize}}">
+            <span></span>
+            <span>
+              {{.option}}
+            </span>
+          </label>
         {{ end }}
       {{ end }}
     </fieldset>
@@ -98,7 +96,7 @@
       </label>
       {{ end }}
     </fieldset>
-    <fieldset class="filter-fieldset c8y-fieldset {{ if not site.Data.date_settings.yearly_release}} hidden {{end}}" data-internal data-filter-group="technicalcomponent">
+    <fieldset class="filter-fieldset c8y-fieldset" data-filter-group="technicalcomponent">
       <legend>Build artifact</legend>
       {{ range sort site.Data.buildartifact.options "option" "asc"}}
       <label class="c8y-checkbox m-b-4">

--- a/themes/c8ydocs/layouts/partials/change-logs-list.html
+++ b/themes/c8ydocs/layouts/partials/change-logs-list.html
@@ -67,16 +67,23 @@
       {{ $dateLimit := site.Data.date_settings.date }}
 
       {{ range where $reusablePages "Date" "ge" $dateLimit}}
+
+      {{/*  ====================  */}}
+      {{/*  DEPRECATED 
+       * now displaying all change types is handled by  the yearly release 
+       and / or by the "internal=true" url parameter
+      */}}
+        
       {{/*  Based on the yearly release boolean, retrives 
           * yearly_release: true -  show all entries
           * yearly_release: false - don't show "Fix" entries
          */}}
       {{$classes := slice}}
-      {{ if site.Data.date_settings.yearly_release}}
       {{ $currentDate.Set "out" ""}}
+      {{/*  {{ if site.Data.date_settings.yearly_release}}
       {{else}}
       {{ $currentDate.Set "out" "Fix"}}
-      {{end}}
+      {{end}}  */}}
 
       {{ if ne (index .Params.change_type 0).label ($currentDate.Get "out")}}
 
@@ -110,9 +117,24 @@
       {{end}}
 
       {{ if or (not site.Data.date_settings.yearly_release) site.Data.date_settings.yearly_release_preview }}
+        {{- /* 1) Detect if there is any OTHER change-type-* class */ -}}
+        {{- $hasOtherChangeType := false -}}
+        {{- range $classes }}
+          {{- if and (hasPrefix . "change-type-") (ne . "change-type-fix") -}}
+            {{- $hasOtherChangeType = true -}}
+          {{- end -}}
+        {{- end -}}
+
         <div
-          id="cl-{{$listDate | urlize }}"
-          class="page-section change-log__date {{range $classes}}{{.}} {{end}}"
+          id="cl-{{ $listDate | urlize }}"
+          class='page-section change-log__date 
+          {{ range $classes }}
+            {{- if and (eq . "change-type-fix") (not $hasOtherChangeType) -}}
+              change-type-fix hidden {{ else }} {{ . }} {{ end }}
+          {{- end -}}'
+          {{- if and (in $classes "change-type-fix") (not $hasOtherChangeType) -}}
+            data-internal
+          {{- end -}}
         >
           <h5>{{$listDate}}</h5>
         </div>
@@ -134,8 +156,9 @@
 
       <section
         id='{{(replace .Name ".md" "") | urlize }}'
-        class="page-section change-type-{{(index .Params.change_type 0).label | urlize}} component-{{ (index .Params.component 0).label | urlize }}  productarea-{{.Params.product_area | urlize}} technicalcomponent-{{(index .Params.build_artifact 0).label | urlize}}"
+        class="page-section change-type-{{(index .Params.change_type 0).label | urlize}} component-{{ (index .Params.component 0).label | urlize }}  productarea-{{.Params.product_area | urlize}} technicalcomponent-{{(index .Params.build_artifact 0).label | urlize}} {{if and (not site.Data.date_settings.yearly_release) (eq ((index .Params.change_type 0).label | urlize) "fix") }} hidden {{end}}"
         data-date="{{.Date}}"
+        {{if and (not site.Data.date_settings.yearly_release) (eq ((index .Params.change_type 0).label | urlize) "fix") }} data-internal {{end}}
       >
         <div class="article-content change-log">
           <div class="change-log__header">
@@ -162,44 +185,40 @@
                 <small class="text-muted">Component</small>
                 <p>{{(index .Params.component 0).label}}</p>
               </button>
-              {{/*  Display the build artifact and version only in yearly releases  or setting the `internal` url parameter to `true` */}}
-                <button class="btn-metadata {{ if not site.Data.date_settings.yearly_release}} hidden {{end}}" data-internal data-tag="technicalcomponent-{{(index .Params.build_artifact 0).label | urlize}}">
+            </div>
+          </div>
+          {{- .Content | replaceRE `<script[\s\S]*?</script>` "" | replaceRE `\s+on\w+\s*=\s*"[^"]*"` "" | replaceRE `\s+on\w+\s*=\s*'[^']*'` "" | safeHTML -}}
+          <div class="change-log__details">
+            <button class="collapse-btn btn-clean collapsed d-flex a-i-center" data-toggle="collapse" data-target="#collapse-{{(replace .Title "var-product-c8y-iot" .Site.Params.product_c8y_iot) | urlize }}">
+              Show details
+              <i class="dlt-c8y-icon-chevron-down "></i>
+            </button>
+            <div id="collapse-{{(replace .Title "var-product-c8y-iot" .Site.Params.product_c8y_iot) | urlize }}" class="collapse">
+              <div class="metadata p-16">
+                <button class="btn-metadata " data-tag="technicalcomponent-{{(index .Params.build_artifact 0).label | urlize}}">
                   <small class="text-muted">Build artifact {{ if .Params.version}}/ version{{end}}</small>
                   <p>{{(index .Params.build_artifact 0).label}}
                   {{ if .Params.version}} - {{ .Params.version}}{{end}}
                   </p>
                 </button>
-              {{ if .Params.ticket }}
-                <div class="p-t-4 {{ if not site.Data.date_settings.yearly_release}} hidden {{end}}" data-internal>
-                  <small class="text-muted">Ticket</small>
-                  <p><strong>{{.Params.ticket}}</strong></p>
+                {{ if .Params.ticket }}
+                <!-- {{ if not site.Data.date_settings.yearly_release}} hidden {{end}} -->
+                  <div class="p-t-4 ">
+                    <small class="text-muted">Ticket</small>
+                    <p><strong>{{.Params.ticket}}</strong></p>
+                  </div>
+                {{end}}
+              </div>
+              {{ if .Params.environment_availability}}
+                <div class="metadata p-l-16 p-r-16 p-b-16">
+                  <div class="p-t-4" style="flex-basis:auto;">
+                    <small class="text-muted">Environment availability</small>
+                    <p>{{ range $i, $env:= .Params.environment_availability }}{{ if $i }}, {{end}}{{- $env.label -}}{{end}}</p>
+                  </div>
                 </div>
               {{end}}
             </div>
           </div>
-          <!-- 
-          <div class="change-log__version">
-            {{ if site.Data.date_settings.yearly_release}}
-                {{ if .Params.version}}
-                  <div class="d-flex gap-4">
-                    <small class="text-muted">Version</small>
-                    <strong class="small">{{.Params.version}}</strong>
-                  </div>
-                {{end}}
-              {{end}}
-              {{ if .Params.ticket }}
-                <div class="d-flex gap-4">
-                  <small class="text-muted">Ticket</small>
-                  <strong class="small">{{.Params.ticket}}</strong>
-                </div>
-              {{end}}
-          </div>
-           -->
-            {{- .Content
-             | replaceRE `<script[\s\S]*?</script>` ""
-             | replaceRE `\s+on\w+\s*=\s*"[^"]*"` ""
-             | replaceRE `\s+on\w+\s*=\s*'[^']*'` ""
-             | safeHTML -}}
         </div>
       </section>
       {{ end }}

--- a/themes/c8ydocs/layouts/partials/change-logs-list.html
+++ b/themes/c8ydocs/layouts/partials/change-logs-list.html
@@ -190,7 +190,7 @@
           {{- .Content | replaceRE `<script[\s\S]*?</script>` "" | replaceRE `\s+on\w+\s*=\s*"[^"]*"` "" | replaceRE `\s+on\w+\s*=\s*'[^']*'` "" | safeHTML -}}
           <div class="change-log__details">
             <button class="collapse-btn btn-clean collapsed d-flex a-i-center" data-toggle="collapse" data-target="#collapse-{{(replace .Title "var-product-c8y-iot" .Site.Params.product_c8y_iot) | urlize }}">
-              Show details
+              Technical details
               <i class="dlt-c8y-icon-chevron-down "></i>
             </button>
             <div id="collapse-{{(replace .Title "var-product-c8y-iot" .Site.Params.product_c8y_iot) | urlize }}" class="collapse">

--- a/themes/c8ydocs/static/js/main.js
+++ b/themes/c8ydocs/static/js/main.js
@@ -182,7 +182,7 @@ function buildToc() {
               month = curMonth;
             }
           }
-          tocLinks += `<div class="list-group-item"><a class="toc-link" href="#${target.id}" data-refid="${h2.parentNode.id}" title="${h2.textContent}">${h2.textContent}</a></div>`;
+          tocLinks += `<div class="list-group-item"><a class="toc-link ${h2.parentNode.hasAttribute('data-internal') ? 'hidden' : ''}" ${h2.parentNode.hasAttribute('data-internal') ? 'data-internal' : ''} href="#${target.id}" data-refid="${h2.parentNode.id}" title="${h2.textContent}">${h2.textContent}</a></div>`;
         }
       });
 


### PR DESCRIPTION
This pull request refactors how "Fix" change types and technical details are displayed in the change logs, especially in relation to yearly releases and internal visibility. It introduces a collapsible technical details section, refines filtering and visibility logic for "Fix" entries, and improves the handling of metadata and environment availability.

**Change log display and filtering improvements:**

* Refactored logic so that "Fix" change types are hidden unless the yearly release is active or the `internal=true` URL parameter is set; this affects both the main change log list and the filter UI. [[1]](diffhunk://#diff-740bc02424a0c7ea3b8b156bc735680e1a4cef35382acc96a1c39c7a3bb42289R70-R86) [[2]](diffhunk://#diff-740bc02424a0c7ea3b8b156bc735680e1a4cef35382acc96a1c39c7a3bb42289L137-R161) [[3]](diffhunk://#diff-8e9300dfd6ea5b2b443ce911085dc3a818cbda419a39647d2e4b6a4d9da3ac94L46-R46) [[4]](diffhunk://#diff-8e9300dfd6ea5b2b443ce911085dc3a818cbda419a39647d2e4b6a4d9da3ac94L56)
* Updated the table of contents generation to hide entries marked as "internal" by adding the `hidden` class and `data-internal` attribute when appropriate.

**Technical details section enhancements:**

* Introduced a new, collapsible `.change-log__details` section in the change log entries, which groups technical metadata (build artifact, version, ticket, and environment availability) and improves their styling and presentation. [[1]](diffhunk://#diff-41ccc00f3e5a8aa03f363e56788392afab757ae863763b6d6186d753db02ab12R114-R150) [[2]](diffhunk://#diff-41ccc00f3e5a8aa03f363e56788392afab757ae863763b6d6186d753db02ab12L132) [[3]](diffhunk://#diff-740bc02424a0c7ea3b8b156bc735680e1a4cef35382acc96a1c39c7a3bb42289L165-L202)

**Filter and metadata UI adjustments:**

* Adjusted filter fieldsets and checkboxes to align with the new logic for showing/hiding "Fix" entries and technical components, removing conditional hiding based on yearly release for technical component filters.
* Improved metadata styling by updating SCSS for `.change-log__details` and `.metadata` classes, enhancing the visual grouping and clarity of technical information.

**Code cleanup and documentation:**

* Removed deprecated logic and added comments to clarify that the display of all change types is now managed by the yearly release setting or the `internal=true` parameter.

These changes collectively improve the clarity, maintainability, and user experience of the change log display, especially for distinguishing between public and internal entries.