### PR TITLE
Refactor ordering structure for complex property definitions

### DIFF
--- a/content/change-logs/application-enablement/dtm-1024-1-0-changed-the-structure-of-storing-ordering-information-of-complex-property-definitions-existing-property-definitions-are-migrated-to-the-new-structure.md
+++ b/content/change-logs/application-enablement/dtm-1024-1-0-changed-the-structure-of-storing-ordering-information-of-complex-property-definitions-existing-property-definitions-are-migrated-to-the-new-structure.md
@@ -17,4 +17,4 @@ environment_availability:
   - label: eu-latest.cumulocity.com
     date: '2026-02-19'
 ---
-Previously, the field ordering information for complex property definitions was stored in the `c8y_Order` array. With this update, the ordering is defined directly within each field using the `Order` property in the JSON schema. Existing property definitions are automatically migrated to the new structure when the subscribed microservice is updated.
+Previously, the field ordering information for complex property definitions was stored in the `c8y_Order` array. With this update, the ordering is defined directly within each field using the `order` property in the JSON schema. Existing property definitions are automatically migrated to the new structure when the subscribed microservice is updated.

--- a/content/change-logs/application-enablement/dtm-1024-1-0-changed-the-structure-of-storing-ordering-information-of-complex-property-definitions-existing-property-definitions-are-migrated-to-the-new-structure.md
+++ b/content/change-logs/application-enablement/dtm-1024-1-0-changed-the-structure-of-storing-ordering-information-of-complex-property-definitions-existing-property-definitions-are-migrated-to-the-new-structure.md
@@ -17,4 +17,4 @@ environment_availability:
   - label: eu-latest.cumulocity.com
     date: '2026-02-19'
 ---
-Previously, the field ordering information for complex property definitions was stored in the c8y_Order array. With this update, the ordering is defined directly within each field using the order property in the JSON schema. Existing property definitions are automatically migrated to the new structure when the subscribed microservice is updated
+Previously, the field ordering information for complex property definitions was stored in the `c8y_Order` array. With this update, the ordering is defined directly within each field using the `Order` property in the JSON schema. Existing property definitions are automatically migrated to the new structure when the subscribed microservice is updated

--- a/content/change-logs/application-enablement/dtm-1024-1-0-changed-the-structure-of-storing-ordering-information-of-complex-property-definitions-existing-property-definitions-are-migrated-to-the-new-structure.md
+++ b/content/change-logs/application-enablement/dtm-1024-1-0-changed-the-structure-of-storing-ordering-information-of-complex-property-definitions-existing-property-definitions-are-migrated-to-the-new-structure.md
@@ -17,8 +17,4 @@ environment_availability:
   - label: eu-latest.cumulocity.com
     date: '2026-02-19'
 ---
-Previously, the field ordering information of complex property definitions
-was stored in the `c8y_Order` array. With this change, the order is
-stored in the `order` property within each field of the JSON schema.
-Existing property definitions are migrated to the new structure when the
-microservice is subscribed.
+Previously, the field ordering information for complex property definitions was stored in the c8y_Order array. With this update, the ordering is defined directly within each field using the order property in the JSON schema. Existing property definitions are automatically migrated to the new structure when the subscribed microservice is updated

--- a/content/change-logs/application-enablement/dtm-1024-1-0-changed-the-structure-of-storing-ordering-information-of-complex-property-definitions-existing-property-definitions-are-migrated-to-the-new-structure.md
+++ b/content/change-logs/application-enablement/dtm-1024-1-0-changed-the-structure-of-storing-ordering-information-of-complex-property-definitions-existing-property-definitions-are-migrated-to-the-new-structure.md
@@ -17,4 +17,4 @@ environment_availability:
   - label: eu-latest.cumulocity.com
     date: '2026-02-19'
 ---
-Previously, the field ordering information for complex property definitions was stored in the `c8y_Order` array. With this update, the ordering is defined directly within each field using the `Order` property in the JSON schema. Existing property definitions are automatically migrated to the new structure when the subscribed microservice is updated
+Previously, the field ordering information for complex property definitions was stored in the `c8y_Order` array. With this update, the ordering is defined directly within each field using the `Order` property in the JSON schema. Existing property definitions are automatically migrated to the new structure when the subscribed microservice is updated.


### PR DESCRIPTION
Updated the structure for storing ordering information of complex property definitions. Existing property definitions are automatically migrated to the new structure upon microservice update.