### PR TITLE
[MTM-65958] Release notes: Single Registration with Certificate Enrol…

### DIFF
--- a/content/change-logs/platform-services/cumulocity-2026-64-0-single-device-registration-with-cer-fix.md
+++ b/content/change-logs/platform-services/cumulocity-2026-64-0-single-device-registration-with-cer-fix.md
@@ -1,0 +1,22 @@
+---
+date: ''
+title: Fix for Single Device Registration Process Using C8y CA Certificates
+change_type:
+  - value: change-2c7RdTdXo4
+    label: Improvement
+product_area: Platform services
+component:
+  - value: component-OG_650_b2
+    label: Core platform
+build_artifact:
+  - value: tc-QHwMfWtBk7
+    label: cumulocity
+ticket: MTM-65958
+version: 2026.64.0
+
+---
+Resolved an issue affecting the initial group assignment during [single device registration](https://cumulocity.com/docs/device-management-application/registering-devices/#single-device-registration) when using the “create device certificates during device registration” option with {{< product-c8y-iot >}} CA certificates.
+
+Previously, devices registered individually were not correctly added to their designated initial device group upon first connection.
+
+With this update, when a single device is registered and an initial device group is specified, the device is now properly assigned to the target group upon its first connection.

--- a/content/change-logs/platform-services/cumulocity-2026-64-0-single-device-registration-with-cer-fix.md
+++ b/content/change-logs/platform-services/cumulocity-2026-64-0-single-device-registration-with-cer-fix.md
@@ -1,6 +1,6 @@
 ---
 date: ''
-title: Fix for Single Device Registration Process Using C8y CA Certificates
+title: Fix for Single Device Registration Process Using Platform CA Certificates
 change_type:
   - value: change-2c7RdTdXo4
     label: Improvement

--- a/content/change-logs/platform-services/cumulocity-2026-64-0-single-device-registration-with-cer-fix.md
+++ b/content/change-logs/platform-services/cumulocity-2026-64-0-single-device-registration-with-cer-fix.md
@@ -1,6 +1,6 @@
 ---
 date: ''
-title: Fix for Single Device Registration Process Using Platform CA Certificates
+title: Devices are now correctly added to initial device group
 change_type:
   - value: change-2c7RdTdXo4
     label: Improvement

--- a/content/change-logs/platform-services/cumulocity-2026-64-0-single-device-registration-with-cer-fix.md
+++ b/content/change-logs/platform-services/cumulocity-2026-64-0-single-device-registration-with-cer-fix.md
@@ -15,7 +15,7 @@ ticket: MTM-65958
 version: 2026.64.0
 
 ---
-Resolved an issue affecting the initial group assignment during [single device registration](https://cumulocity.com/docs/device-management-application/registering-devices/#single-device-registration) when using the “create device certificates during device registration” option with {{< product-c8y-iot >}} CA certificates.
+An issue has been resolved affecting the initial group assignment during [single device registration](/device-management-application/registering-devices/#single-device-registration) when using the “create device certificates during device registration” option with {{< product-c8y-iot >}} CA certificates.
 
 Previously, devices registered individually were not correctly added to their designated initial device group upon first connection.
 


### PR DESCRIPTION
Release notes: Single Registration with Certificate Enrollment and Group Assignment

Backend context:
<details>
<summary>problem description</summary>
The issue occurs during the Basic device single registration process with <strong>certs</strong> 

In the standard Basic device flow, the following steps take place:

1. A single registration is created
2. The bootstrap connects using the selected clientId
3. The administrator approves the registration
4. The bootstrap requests the password

At this stage, a user is created together with a NewDeviceAssignment, which contains information about the group the user/device should be assigned to

Later, when the device connects for the first time and creates the Managed Object (MO) representation of the device, the system reads the NewDeviceAssignment from the user and assigns the device to the appropriate group.

In the case of single registration with certificate-based users, the process differs:

1. A single registration is created
2. The device performs a simple enrollment using OTP(one time password)
3. A certificate is issued

At this stage:
- The NewDeviceRequest is removed
- The user is not yet created
- The only evidence of this step is an audit log entry indicating that the certificate was signed

The user is created only during the first connection using the obtained certificate, and only after that can the Managed Object of the device be created.
<strong>
Because of this flow, during single registration with certificate generation, there is no point in the process where the initial group assignment (NewDeviceAssignment) can be processed.</strong>
</details>

As a solution to this issue, I am changing the single registration flow for devices that use **certificates**. A user will be created during the first enrollment (when the certificate is obtained), and at that stage, a NewDeviceAssignment with group information will be assigned to the user.

The generated certificate will be assigned to the user upon the first connection.
Functional test:
https://github.com/Cumulocity-IoT/cumulocity-quality/pull/3599/changes