### PR TITLE
DM-5703: Device parameter integration documentation for y2026

### DIFF
--- a/content/device-integration/fragment-library-bundle/device-parameter.md
+++ b/content/device-integration/fragment-library-bundle/device-parameter.md
@@ -48,7 +48,7 @@ POST /event/events
 
 When a user or microservice initiates a remote parameter modification, the platform creates an operation containing the ```c8y_ParameterUpdate``` fragment marker. This operation directs the device agent to apply specific key-value modifications to its local memory.
 
-To enable this functionality, devices must include the 
+To enable updating parameters remotely, devices must include the ```c8y_ParameterUpdate``` in their ```c8y_SupportedOperations```. Additionally each respective parameter must be modeled as asset property definitions in the Digital Twin Manager application with the context "Operation".
 ```json
 {
    "deviceId": "12345",
@@ -77,7 +77,7 @@ When the device receives the ```c8y_ParameterUpdate``` operation, it is expected
 
 {{< product-c8y-iot >}} provides the 532 static response template to receive parameter update operations. This template is designed to accommodate a variable number of parameters using a repeating 3-set sequence of name (representing the fragment path), type, and value:
 
-1. Receive the 
+1. Receive the ```c8y_ParameterUpdate``` operation via the 532 static response template <br>
    `532,DeviceSerial,c8y_RelayStatus.left,b,false,c8y_RelayStatus.right,b,true`
 2. Set the operation status to EXECUTING <br>
    `501,c8y_ParameterUpdate`
@@ -87,6 +87,5 @@ When the device receives the ```c8y_ParameterUpdate``` operation, it is expected
 5. Set the operation status to SUCCESSFUL <br>
    `503,c8y_ParameterUpdate`
 
-The following example shows a payload received by the device:
 
 

--- a/content/device-integration/fragment-library-bundle/device-parameter.md
+++ b/content/device-integration/fragment-library-bundle/device-parameter.md
@@ -77,14 +77,14 @@ When the device receives the ```c8y_ParameterUpdate``` operation, it is expected
 
 {{< product-c8y-iot >}} provides the 532 static response template to receive parameter update operations. This template is designed to accommodate a variable number of parameters using a repeating 3-set sequence of name (representing the fragment path), type, and value:
 
-1. Receive the ```c8y_ParameterUpdate``` operation via the 532 static response template <br>
+1. Receive the 
    `532,DeviceSerial,c8y_RelayStatus.left,b,false,c8y_RelayStatus.right,b,true`
-2. Set the operation status to EXECUTING <br>
+2. Set the operation status to EXECUTING. <br>
    `501,c8y_ParameterUpdate`
 3. Apply the specific parameter configurations to the physical hardware or internal software layer.
 4. Report the new status. Use the 408 template to report the new status to the cloud. <br>
    `408,,,true,c8y_RelayStatus.left,BOOLEAN,false,c8y_RelayStatus.right,BOOLEAN,true`
-5. Set the operation status to SUCCESSFUL <br>
+5. Set the operation status to SUCCESSFUL. <br>
    `503,c8y_ParameterUpdate`
 
 

--- a/content/device-integration/fragment-library-bundle/device-parameter.md
+++ b/content/device-integration/fragment-library-bundle/device-parameter.md
@@ -8,7 +8,7 @@ sector:
 
 The **Device parameter** tab allows users to modify granular, atomic state variables on a connected device without transmitting an entire monolithic configuration file. The data structures are expressed as fragments that manage discrete parameters, such as Modbus register numbers, filtering times, or polling intervals.
 
-This functionality is automatically enabled for all devices where their communicated parameters match asset property definitions configured in the Digital Twin Manager application.
+This functionality is automatically enabled for all devices whose communicated parameters match asset property definitions configured in the Digital Twin Manager application.
 
 ### Parameter status {#parameter-status}
 

--- a/content/device-integration/fragment-library-bundle/device-parameter.md
+++ b/content/device-integration/fragment-library-bundle/device-parameter.md
@@ -1,0 +1,92 @@
+---
+weight: 190
+title: Device parameter
+layout: bundle
+sector:
+  - device_management
+---
+
+The **Device parameter** tab allows users to modify granular, atomic state variables on a connected device without transmitting an entire monolithic configuration file. The data structures are expressed as fragments that manage discrete parameters, such as Modbus register numbers, filtering times, or polling intervals.
+
+This functionality is automatically enabled for all devices where their communicated parameters match asset property definitions configured in Digital Twin Manager.
+
+### Parameter status {#parameter-status}
+
+Devices are responsible for communicating their current parameter status to the platform. To establish an auditable, time-series-based ledger of parameter shifts, devices must emit an event whenever a local parameter changes. The platform automatically intercepts events of this specific type and asynchronously mirrors the parameters directly into the device's managed object representation in the inventory.
+
+```http
+POST /event/events
+```
+```json
+{
+   "source": {
+       "id": "12345"
+   },
+   "type": "c8y_ParameterUpdate",
+   "text": "Relay status updated",
+   "time": "2021-10-07T12:00:00.000Z",
+   "c8y_RelayStatus": {
+       "left": true,
+       "right": false
+   }
+}
+```
+|Name|Data type|Mandatory|Description|
+|----|----|----|----|
+|type|string|Yes|The event type must be strictly defined as ```c8y_ParameterUpdate``` to trigger the platform's internal state-mirroring engine.|
+|text|string|Yes|A human-readable description of the event, for example, "Relay status updated".|
+|time|string|Yes|The ISO-8601 formatted timestamp of the event occurrence.|
+|[Custom Fragments]|object|No|The actual parameters that were updated, structured as individual fragments or nested objects reflecting the device's data model, for example, ```c8y_RelayStatus```.|
+
+#### SmartREST example {#smartrest-example-status}
+
+{{< product-c8y-iot >}} provides the static SmartREST template 408 to create device parameter update events. This template enforces the event type as ```c8y_ParameterUpdate``` and features a change detection functionality. This means events are created only if the reported state differs from the currently known state in the inventory.
+
+`408,,,,c8y_RelayStatus.left,BOOLEAN,true,c8y_RelayStatus.right,BOOLEAN,false`
+
+### Parameter update {#parameter-update}
+
+When a user or microservice initiates a remote parameter modification, the platform creates an operation containing the ```c8y_ParameterUpdate``` fragment marker. This operation directs the device agent to apply specific key-value modifications to its local memory.
+
+To enable this functionality, devices must include the ```c8y_ParameterUpdate``` fragment in their supported operations, and the respective parameter must be modeled as asset property definitions in Digital Twin Manager with the context "Operation".
+```json
+{
+   "deviceId": "12345",
+   "c8y_RelayStatus": {
+       "left": false,
+       "right": true
+   },
+   "c8y_ParameterUpdate": {},
+   "c8y_ParameterUpdate_c8y_RelayStatus": {}
+}
+```
+|Name|Data type|Mandatory|Description|
+|----|----|----|----|
+|[Custom Fragment]|object|Yes|The actual configuration fragment containing the updated key-value parameters, for example, ```c8y_RelayStatus```.|
+|c8y_ParameterUpdate|object|Yes|An empty marker fragment identifying the targeted parameter modification request.|
+|c8y_ParameterUpdate_<fragment>|object|Yes|An empty marker fragment identifying the specific configuration fragment being updated, for example, ```c8y_ParameterUpdate_c8y_RelayStatus```.|
+
+When the device receives the ```c8y_ParameterUpdate``` operation, it is expected to perform the following actions:
+
+1. Set the operation status to EXECUTING.
+2. Apply the specific parameter configurations to the physical hardware or internal software layer.
+3. Update the parameter status in the platform by sending a parameter update event.
+4. Set the operation status to SUCCESSFUL or FAILED if the configuration cannot be applied.
+
+#### SmartREST example {#smartrest-example-update}
+
+{{< product-c8y-iot >}} provides the 532 static response template to receive parameter update operations. This template is designed to accommodate a variable number of parameters using a repeating 3-set sequence of name (representing the fragment path), type, and value:
+
+1. Receive ```c8y_ParameterUpdate``` (image) operation <br>
+   `532,DeviceSerial,c8y_RelayStatus.left,b,false,c8y_RelayStatus.right,b,true`
+2. Set operation status to EXECUTING <br>
+   `501,c8y_ParameterUpdate`
+3. Apply the specific parameter configurations to the physical hardware or internal software layer.
+4. Report the new status - Use the 408 template to report the new status to the cloud. <br>
+   `408,,,true,c8y_RelayStatus.left,BOOLEAN,false,c8y_RelayStatus.right,BOOLEAN,true`
+5. Set operation status to SUCCESSFUL <br>
+   `503,c8y_ParameterUpdate`
+
+The following example shows a payload received by the device:
+
+

--- a/content/device-integration/fragment-library-bundle/device-parameter.md
+++ b/content/device-integration/fragment-library-bundle/device-parameter.md
@@ -8,7 +8,7 @@ sector:
 
 The **Device parameter** tab allows users to modify granular, atomic state variables on a connected device without transmitting an entire monolithic configuration file. The data structures are expressed as fragments that manage discrete parameters, such as Modbus register numbers, filtering times, or polling intervals.
 
-This functionality is automatically enabled for all devices where their communicated parameters match asset property definitions configured in Digital Twin Manager.
+This functionality is automatically enabled for all devices where their communicated parameters match asset property definitions configured in the Digital Twin Manager application.
 
 ### Parameter status {#parameter-status}
 
@@ -48,7 +48,7 @@ POST /event/events
 
 When a user or microservice initiates a remote parameter modification, the platform creates an operation containing the ```c8y_ParameterUpdate``` fragment marker. This operation directs the device agent to apply specific key-value modifications to its local memory.
 
-To enable this functionality, devices must include the ```c8y_ParameterUpdate``` fragment in their supported operations, and the respective parameter must be modeled as asset property definitions in Digital Twin Manager with the context "Operation".
+To enable this functionality, devices must include the 
 ```json
 {
    "deviceId": "12345",
@@ -77,14 +77,14 @@ When the device receives the ```c8y_ParameterUpdate``` operation, it is expected
 
 {{< product-c8y-iot >}} provides the 532 static response template to receive parameter update operations. This template is designed to accommodate a variable number of parameters using a repeating 3-set sequence of name (representing the fragment path), type, and value:
 
-1. Receive ```c8y_ParameterUpdate``` (image) operation <br>
+1. Receive the 
    `532,DeviceSerial,c8y_RelayStatus.left,b,false,c8y_RelayStatus.right,b,true`
-2. Set operation status to EXECUTING <br>
+2. Set the operation status to EXECUTING <br>
    `501,c8y_ParameterUpdate`
 3. Apply the specific parameter configurations to the physical hardware or internal software layer.
-4. Report the new status - Use the 408 template to report the new status to the cloud. <br>
+4. Report the new status. Use the 408 template to report the new status to the cloud. <br>
    `408,,,true,c8y_RelayStatus.left,BOOLEAN,false,c8y_RelayStatus.right,BOOLEAN,true`
-5. Set operation status to SUCCESSFUL <br>
+5. Set the operation status to SUCCESSFUL <br>
    `503,c8y_ParameterUpdate`
 
 The following example shows a payload received by the device:

--- a/content/smartrest/mqtt-static-templates.md
+++ b/content/smartrest/mqtt-static-templates.md
@@ -73,6 +73,7 @@ If a parameter is in square brackets, it is optional.
 <li><a href="#401">401,latitude,longitude,altitude,accuracy[,time]</a></li>
 <li><a href="#402">402,latitude,longitude,altitude,accuracy[,time] (incl. inv. update)</a></li>
 <li><a href="#407">407,eventType,fragmentToBeRemoved1,fragment2,...</a></li>
+<li><a href="#408">408,[text],[time],[change detect],parameterPath1,parameterType1,parameterValue1[,path2,type2,value2,]...</a></li>
 </ul>
 
 <strong><a href="#operation-templates">Operation templates</a></strong>
@@ -105,12 +106,7 @@ If a parameter is in square brackets, it is optional.
 <li><a href="#529">529,serial,softwareToBeUpdated1,version1,type1,url1,action1,sw2,ver2,type2,url2,action2,...</a></li>
 <li><a href="#530">530,serial,hostname,port,connectionKey</a></li>
 <li><a href="#531">531,serial,firmwareMarker,name,version,url,isPatch,dependency,softwareMarker,name,version,type,url,action,configurationMarker,url,type</a></li>
-<li><a href="#532">532,serial,PARAM_DEF_0,PARAM_DEF_1,...,PARAM_DEF_N</a></li>
-</ul>
-
-<strong><a href="#device-parameter-templates">Device parameter templates</a></strong>
-<ul>
-<li><a href="#408">408,[text],[time],[change detect],path1,type1,value1[,path2,type2,value2,]...</a></li>
+<li><a href="#532">532,serial,parameterPath1,parameterType1,parameterValue1[,path2,type2,value2,]...</a></li>
 </ul>
 
 <strong><a href="#platform-capabilites-templates">Platform capabilities templates</a></strong>


### PR DESCRIPTION
Cherry-picked commit from DM-5703-device-parameter-integration-docs branch.\n\nThis PR includes documentation for device parameter integration and updates to MQTT static templates.