### PR TITLE
[MTM-66206] Release notes for external IAM tokens with user scope beans.

### DIFF
--- a/content/change-logs/platform-services/cumulocity-2026-14-0-External-Jwt-token-with-user-scope-API-beans.md
+++ b/content/change-logs/platform-services/cumulocity-2026-14-0-External-Jwt-token-with-user-scope-API-beans.md
@@ -1,0 +1,20 @@
+---
+date: ''
+title: Improved Java SDK support for external IAM tokens with user scope API beans 
+product_area: Application enablement & solutions
+change_type:
+  - value: change-2c7RdTdXo4
+    label: Improvement
+component:
+  - value: QWPx3rFfn
+    label: Java SDK
+build_artifact:
+  - value: tc-QHwMfWtBk7
+    label: cumulocity
+ticket: MTM-66206
+version: 2026.14.0
+
+---
+Previously, when users authenticated in the Java SDK using [external IAM JWT tokens](/authentication/sso/#configuring-access-tokens) together with [API service beans](/microservice-sdk/java/#api-service-beans) configured with the Qualifier for user scope, the authentication process could fail to correctly identify the tenant and user.
+With this improvement, service beans using the Qualifier for user scope can now authenticate correctly when external IAM JWT tokens are used. Their behavior is now consistent with other supported authentication methods.
+

--- a/content/change-logs/platform-services/cumulocity-2026-14-0-External-Jwt-token-with-user-scope-API-beans.md
+++ b/content/change-logs/platform-services/cumulocity-2026-14-0-External-Jwt-token-with-user-scope-API-beans.md
@@ -15,6 +15,6 @@ ticket: MTM-66206
 version: 2026.14.0
 
 ---
-Previously, when users authenticated in the Java SDK using [external IAM JWT tokens](/authentication/sso/#configuring-access-tokens) together with [API service beans](/microservice-sdk/java/#api-service-beans) configured with the Qualifier for user scope, the authentication process could fail to correctly identify the tenant and user.
-With this improvement, service beans using the Qualifier for user scope can now authenticate correctly when external IAM JWT tokens are used. Their behavior is now consistent with other supported authentication methods.
+Previously, when users authenticated in the Java SDK using [external IAM JWT tokens](/authentication/sso/#configuring-access-tokens) together with [API service beans](/microservice-sdk/java/#api-service-beans) configured with the qualifier for user scope, the authentication process could fail to identify the tenant and user correctly.
+With this improvement, service beans using the qualifier for user scope can now authenticate correctly when external IAM JWT tokens are used. Their behavior is now consistent with other supported authentication methods.
 


### PR DESCRIPTION
Main changes: https://github.com/Cumulocity-IoT/cumulocity-clients-java-internal/pull/390
Backend context: 
Java SDK providing access to Cumulocity API using services:
https://cumulocity.com/docs/microservice-sdk/java/#api-service-beans
in two scopes: tenant one, and a specific user.

It turns out that API beans, which is suposed to store user context does not work with external IAM tokens.
This bugfix resolves it.