### PR TITLE
MTM-66137 Documentation for MQTT Service limits

### DIFF
--- a/content/device-integration/mqtt-service-bundle/implementation.md
+++ b/content/device-integration/mqtt-service-bundle/implementation.md
@@ -183,7 +183,7 @@ The content of a message payload will not have any effect on the behaviour of th
 There is a per-tenant hard quota on the maximum size of an MQTT message.
 The message size calculation includes the message header as well as the payload.
 Message header size can vary significantly, particularly for MQTT version 5.0 devices, but it will always be at least 2 bytes, and usually more.
-See the [Service Quotas](/service-terms/quotas#mqtt-service) section for details of the current quota values.
+See the [Service quotas](/service-terms/quotas#mqtt-service) section for details of the current quota values.
 
 ### Error reporting {#mqtt-error-reporting}
 

--- a/content/device-integration/mqtt-service-bundle/implementation.md
+++ b/content/device-integration/mqtt-service-bundle/implementation.md
@@ -180,11 +180,10 @@ The MQTT Service does not impose any specific message payload format.
 Message payloads are treated as opaque sequences of bytes that are delivered exactly as they were received.
 The content of a message payload will not have any effect on the behaviour of the MQTT Service.
 
-There is a system-wide hard limit on the maximum size of an MQTT message, and a per-tenant soft quota that will be set lower than the hard limit by default.
-See the [Service Quotas](/service-terms/quotas#mqtt-service) section for details of these limits.
-The soft quota can be increased up to the hard limit on request, although this may incur additional costs for the tenant.
-The message size used by these limits includes the message header as well as the payload.
+There is a per-tenant hard quota on the maximum size of an MQTT message.
+The message size calculation includes the message header as well as the payload.
 Message header size can vary significantly, particularly for MQTT version 5.0 devices, but it will always be at least 2 bytes, and usually more.
+See the [Service Quotas](/service-terms/quotas#mqtt-service) section for details of the current quota values.
 
 ### Error reporting {#mqtt-error-reporting}
 

--- a/content/service-terms/quotas.md
+++ b/content/service-terms/quotas.md
@@ -65,15 +65,23 @@ The quotas listed here reflect the maximum values for the cloud subscriptions un
 
 ### MQTT Service {#mqtt-service}
 
-| Quota                                                                                                    | Type |     Value |
-| -------------------------------------------------------------------------------------------------------- | ---- | --------: |
-| [MQTT client identifier length](/device-integration/mqtt-service/#client-id)                             | Hard | 128 bytes |
-| [MQTT topic name length](/device-integration/mqtt-service/#mqtt-topics)                                  | Hard | 256 bytes |
-| [MQTT message size](/device-integration/mqtt-service/#payload-restrictions) system-wide limit            | Hard |   128 KiB |
-| [MQTT message size](/device-integration/mqtt-service/#payload-restrictions) per-tenant quota             | Soft |   ??? KiB |
-| [MQTT topics per tenant](/device-integration/mqtt-service/#topic-limit)                                  |      | Unlimited |
-| [Message backlog](/device-integration/mqtt-service/#message-backlog-quota) total for **all** MQTT topics | Hard |     1 GiB |
-| [Message time-to-live](/device-integration/mqtt-service/#topic-limit)                                    | Hard |  36 hours |
+| Quota                                                                                                                  | Type |            Value |
+| ---------------------------------------------------------------------------------------------------------------------- | ---- | ---------------: |
+| [Client identifier length](/device-integration/mqtt-service/#client-id)                                                | Hard |        128 bytes |
+| [Topic name length](/device-integration/mqtt-service/#mqtt-topics)                                                     | Hard |        256 bytes |
+| [Topics](/device-integration/mqtt-service/#mqtt-topics)                                                                |      |        Unlimited |
+| [Concurrent client connections](/device-integration/mqtt-service/#mqtt-device-quotas-limits) (per tenant)[^1]          | Hard | 1000 connections |
+| [Client connection rate](/device-integration/mqtt-service/#mqtt-device-quotas-limits) (per tenant)                     | Hard |   100 per second |
+| [Inbound message publishing rate](/device-integration/mqtt-service/#mqtt-device-quotas-limits) (per tenant)            | Hard |  1000 per second |
+| [Inbound message publishing rate](/device-integration/mqtt-service/#mqtt-device-quotas-limits) (per client)            | Soft |   100 per second |
+| [Outbound message publishing rate](/device-integration/mqtt-service/#mqtt-device-quotas-limits) (per tenant)           | Hard |   100 per second |
+| [Maximum message size](/device-integration/mqtt-service/#mqtt-payloads) (per tenant)                                   | Hard |          128 KiB |
+| Maximum aggregate throughput (per tenant, connected clients x message size x publishing rate)                          | Soft | 1 MiB per second |
+| [Message backlog](/device-integration/mqtt-service/#message-backlog-quota) (per tenant, total for **all** MQTT topics) | Hard |            1 GiB |
+| [Message time-to-live](/device-integration/mqtt-service/#message-time-to-live) (per tenant)                            | Hard |         36 hours |
+
+These default quotas are set to support reliable operation on {{< product-c8y-iot >}}'s shared cloud environments.
+Significantly higher quotas can be configured for dedicated environments.
 
 ### Applications and services
 
@@ -100,7 +108,7 @@ The quotas listed here reflect the maximum values for the cloud subscriptions un
 | Number of active offloaders per tenant                                                           | Soft |     100 |
 | Number of offloadings per tenant per hour                                                        | Soft |      20 |
 | [Offloading frequency](/datahub/working-with-datahub/#configure-additional-settings)             | Hard |  hourly |
-| Offloaded leaf properties[^1]                                                                    | Soft |    6400 |
+| Offloaded leaf properties[^2]                                                                    | Soft |    6400 |
 | Query time out                                                                                   | Soft |   4 min |
 | Query job retention                                                                              | Hard |   1 day |
 | [Rows in a query job](https://cumulocity.com/api/datahub/#operation/getJobResultsApiResource)    | Hard | 1000000 |
@@ -109,4 +117,5 @@ The quotas listed here reflect the maximum values for the cloud subscriptions un
 
 Additional [quotas from the Dremio engine](https://docs.dremio.com/current/help-support/limits/) may apply for DataHub customers.
 
-[^1]: *Leaf properties* are properties with elementary types (text, number, boolean). The total count of leaf properties offloaded into the same table should not exceed the limit.
+[^1]: MQTT Service hard quotas documented as *per tenant* can be increased if necessary to support your use case, with any additional usage charged for.
+[^2]: *Leaf properties* are properties with elementary types (text, number, boolean). The total count of leaf properties offloaded into the same table should not exceed the limit.


### PR DESCRIPTION
Document all of the quotas that will apply for the MQTT Service when it reaches GA status. Copilot review before opening the PR didn't find anything in the areas I changed, although it did suggest some improvements to the Service Quotas page overall.

Notes:
* I decided to remove the documentation for the global hard limit on packet size as this isn't something users need to care about. It is relevant for operators/admins and will be covered in the Helm chart documentation and operations guide.
* The "maximum aggregate throughput" soft quota is an attempt to indicate that you can't hit all the hard limits at the same time, e.g. expecting to have 1000 clients all sending 128KiB messages at a rate of 1000/s is definitely not going to work. The 1MiB/s soft quota isn't something we have measured directly but it should be achievable based on the testing we _have_ done. That said, if reviewers are not comfortable with having a specific number, I'd be fine with removing it and just having a statement that you can't expect to reach all the limits at the same time. Honestly I could go either way on that.