### PR TITLE
MTM-65373 New license metrics for the MQTT Service

### DIFF
--- a/content/service-terms/license-metrics-bundle/v1.md
+++ b/content/service-terms/license-metrics-bundle/v1.md
@@ -9,7 +9,7 @@ This agreement is made between {{< company-c8y >}} ("Provider") and the customer
 
 These license metrics are valid for April 1st, 2025 onwards.
 
-### Deployment
+### Deployment {#deployment-v1}
 
 A unique instance of the hosted software ("Software") provided by the supplier ("Supplier") and made accessible to the Customer. Deployments can be "Dedicated Cloud" instances or "Public Cloud" instances.
 * Dedicated Cloud deployments have dedicated resources provided for a single Customer.
@@ -17,7 +17,7 @@ A unique instance of the hosted software ("Software") provided by the supplier (
 
 {{< product-c8y-iot >}} Dedicated Cloud deployments can be used for development or testing ("Non-Production") purposes but are restricted in the scope of their usage. In this case, the Dedicated Cloud deployment may not be used for the processing of live production data or any purposes other than development or testing purposes only. A Non-Production Dedicated Cloud deployment may be subject to separate fees as written in the contract between {{< company-c8y >}} and the Customer. Note that {{< product-c8y-iot >}} Public Cloud deployments are always rated at the same rate regardless of instance type.
 
-### Messages
+### Messages {#messages-v1}
 
 The messages usage metric for a given billing period (calendar month) is determined as the maximum of:
 1. The total count of all data transactions to and in the {{< product-c8y-iot >}} platform, or
@@ -31,7 +31,7 @@ All counted transactions and messages are subject to the quotes listed in [Servi
 
 For each billing period, the sum of daily MQTT message counts and the total count of data transactions are separately calculated. The greater of the two values is used as the final invoiced metric, rounded up to the nearest 100,000 units. In the case that one of the values is unable to be computed, the other value will be used for billing purposes.
 
-#### Example
+#### Example {#messages-example-v1}
 
 During a billing period, the sum of the daily values for each of the referenced components are as follows:
 
@@ -53,19 +53,19 @@ _1,192,000 / 100,000 = 11.92_
 
 11.92 rounds up to **12 billable units** of messages for the billing period.
 
-### GiB for Operational Data Store
+### GiB for Operational Data Store {#data-store-gib-v1}
 
 The total volume of data stored in the Operational Data Store of the {{< product-c8y-iot >}} platform within a given billing period (calendar month). Data stored in the Operational Data Store is counted and exposed via the [Usage Statistics API](https://{{< domain-c8y >}}/api/core/#tag/Usage-statistics) provided by the platform. The maximum daily value taken during the billing period will be used for invoicing purposes and is rounded up to the nearest gibibyte (GiB).
 
-### Tenant
+### Tenant {#tenant-v1}
 
 Tenants are physically separated data spaces with a separate address (URL), with a specific set of users, a separate application management, and other individual functionality. Users in a single tenant share the same URL and the same data space. Add-ons that use the per-tenant billing metric will be invoiced based on the number of tenants that have the add-on deployed.
 
-### {{< product-c8y-iot >}} Compute Unit (CCU)
+### {{< product-c8y-iot >}} Compute Unit (CCU) {#ccu-v1}
 
 A {{< product-c8y-iot >}} Compute Unit (CCU) represents a standardized measure of computational resources consumed by microservices developed and deployed by the Customer, where 1 CCU is equivalent to 1 CPU core and 4 gibibytes (GiB) of memory. CCUs are calculated monthly by computing the daily average CPU resources allocated and daily average memory resources allocated (in bundles of 4 GiB) and taking the larger of the two values. This unit will be rounded up if fractional CPU cores or multiples of 4 GiB RAM are used. For example, 1.5 cores and 6 GiB RAM would be considered 2x compute units. Resource usage is first aggregated across all tenants before calculating the CCUs. A complete service description for Customer microservices can be found in the [Service terms section](/service-terms/service-level/#microservices-sla) of the {{< product-c8y-iot >}} documentation.
 
-#### Example
+#### Example {#ccu-example-v1}
 
 The following aggregate metrics are calculated by summing up the daily resource limits for each custom microservice over the billing period (details on the `resources` field in the microservice manifest files can be found in the [{{< product-c8y-iot >}} documentation](/microservice-sdk/general-aspects/#settings). Custom microservices from all tenants across the Customer's deployments are included in this calculation. {{< company-c8y >}} provided microservices are not counted as part of the custom CCU calculation.
 * Aggregate CPU = 582,933
@@ -92,17 +92,17 @@ Then, the larger of the two values is rounded up to form the CCU billable metric
 
 19.43 rounds up to **20 billable units** of CCUs in the billing period.
 
-### DataHub - GiB of data queried
+### DataHub - GiB of data queried {#datahub-gib-v1}
 
 Gibibyte (GiB) of data read from data lakes or other supported data sources by the licensed Software. Queries that fall below 10 MB will be rounded up to the minimum size of 10 MB. For invoicing purposes, any fractional values are rounded up to the nearest gibibyte.
 
-### DataHub - Memory unit
+### DataHub - Memory unit {#datahub-memory-v1}
 
 The total amount of memory available for use by DataHub nodes. A node is a physical or virtual machine or a container within the DataHub cluster that operates as either a co-ordinator node and/or an executor node. Both coordinator and executor nodes are required to run the DataHub add-on. A DataHub node must be deployed with no less than 16 GiB of memory. The memory allocation will be split between coordinator and executor nodes as determined necessary by the Cloud Services, with a minimum of 16 GiB for each node. The first unit will include 32 gibibytes (GiB) of memory. Subsequent units will be billed in increments of 16 GiB. For invoicing purposes, any fractional values are rounded up to the nearest 16 GiB unit.  
 
-### Virtual Private Connection
+### Virtual Private Connection {#vpc-v1}
 
 Use by the Customer of the Cloud Services whose license metric is indicated as “Virtual Private Connection” above allows the creation of a total number of said connections via a redundant pair of site-to-site ("S2S") tunnels between the Customer and the Supplier which does not exceed the licensed number indicated above. The reference to “Virtual Private Connection” refers to the use of a single redundant virtual private connection into the underlying instance of the Cloud Services operated by the Supplier at its hosting partners.
 
-### Database replica set
+### Database replica set {#database-replica-v1}
 A Database replica set is for use with upscaling the Operational Store (database) of a single {{< product-c8y-iot >}} instance. A “replica set” includes up to 3 data-bearing nodes. A node can be deployed in a virtual machine, physical server, or container.

--- a/content/service-terms/license-metrics-bundle/v2.md
+++ b/content/service-terms/license-metrics-bundle/v2.md
@@ -9,19 +9,15 @@ This agreement is made between {{< company-c8y >}} ("Provider") and the customer
 
 These license metrics are valid for April 1st, 2026 onwards.
 
-### Differences from version 1 {#differences-v1}
+### Differences from previous versions {#differences-v2}
 
 Version 2 updates the [messages](#messages) definition. MQTT Service messages are now metered in terms of 4KiB "billable messages", and MQTT client connection time is metered in terms of an equivalent number of billable messages. In all other respects, version 2 is identical to version 1.
 
-### Deployment {#deployment}
+### Deployment {#deployment-v2}
 
-A unique instance of the hosted software ("Software") provided by the supplier ("Supplier") and made accessible to the Customer. Deployments can be "Dedicated Cloud" instances or "Public Cloud" instances.
-* Dedicated Cloud deployments have dedicated resources provided for a single Customer.
-* Public Cloud deployments have shared resources provided for Customers. A Public Cloud deployment will not have data shared between Customers.
+See [version 1](#deployment-v1)
 
-{{< product-c8y-iot >}} Dedicated Cloud deployments can be used for development or testing ("Non-Production") purposes but are restricted in the scope of their usage. In this case, the Dedicated Cloud deployment may not be used for the processing of live production data or any purposes other than development or testing purposes only. A Non-Production Dedicated Cloud deployment may be subject to separate fees as written in the contract between {{< company-c8y >}} and the Customer. Note that {{< product-c8y-iot >}} Public Cloud deployments are always rated at the same rate regardless of instance type.
-
-### Messages {#messages}
+### Messages {#messages-v2}
 
 The messages usage metric for a given billing period (calendar month) is determined as the maximum of:
 1. The total count of all data transactions to and in the {{< product-c8y-iot >}} platform, or
@@ -38,7 +34,7 @@ All counted transactions and messages are subject to the quotas listed in [Servi
 
 For each billing period, the sum of daily MQTT connection-minutes (after conversion to billable messages) count, MQTT billable message count, and the total count of data transactions are separately calculated. The greater of the three values is used as the final invoiced metric, rounded up to the nearest 100,000 units. If one of the values cannot be computed, the other values are used for billing purposes.
 
-#### Examples {#messages-examples}
+#### Examples {#messages-examples-v2}
 
 During a billing period, the sum of the daily values for each of the referenced components is as follows:
 
@@ -89,57 +85,30 @@ _5,245,000 / 100,000 = 52.45_
 
 52.45 rounds up to **53 billable units** of messages for the billing period.
 
-### GiB for Operational Data Store {#data-store-gib}
+### GiB for Operational Data Store {#data-store-gib-v2}
 
-The total volume of data stored in the Operational Data Store of the {{< product-c8y-iot >}} platform within a given billing period (calendar month). Data stored in the Operational Data Store is counted and exposed via the [Usage Statistics API](https://{{< domain-c8y >}}/api/core/#tag/Usage-statistics) provided by the platform. The maximum daily value taken during the billing period will be used for invoicing purposes and is rounded up to the nearest gibibyte (GiB).
+See [version 1](#data-store-gib-v1)
 
-### Tenant {#tenant}
+### Tenant {#tenant-v2}
 
-Tenants are physically separated data spaces with a separate address (URL), with a specific set of users, a separate application management, and other individual functionality. Users in a single tenant share the same URL and the same data space. Add-ons that use the per-tenant billing metric will be invoiced based on the number of tenants that have the add-on deployed.
+See [version 1](#tenant-v1)
 
-### {{< product-c8y-iot >}} Compute Unit (CCU) {#ccu}
+### {{< product-c8y-iot >}} Compute Unit (CCU) {#ccu-v2}
 
-A {{< product-c8y-iot >}} Compute Unit (CCU) represents a standardized measure of computational resources consumed by microservices developed and deployed by the Customer, where 1 CCU is equivalent to 1 CPU core and 4 gibibytes (GiB) of memory. CCUs are calculated monthly by computing the daily average CPU resources allocated and daily average memory resources allocated (in bundles of 4 GiB) and taking the larger of the two values. This unit will be rounded up if fractional CPU cores or multiples of 4 GiB RAM are used. For example, 1.5 cores and 6 GiB RAM would be considered 2x compute units. Resource usage is first aggregated across all tenants before calculating the CCUs. A complete service description for Customer microservices can be found in the [Service terms section](/service-terms/service-level/#microservices-sla) of the {{< product-c8y-iot >}} documentation.
+See [version 1](#ccu-v1)
 
-#### Example {#ccu-example}
+### DataHub - GiB of data queried {#datahub-gib-v2}
 
-The following aggregate metrics are calculated by summing up the daily resource limits for each custom microservice over the billing period (details on the `resources` field in the microservice manifest files can be found in the [{{< product-c8y-iot >}} documentation](/microservice-sdk/general-aspects/#settings). Custom microservices from all tenants across the Customer's deployments are included in this calculation. {{< company-c8y >}} provided microservices are not counted as part of the custom CCU calculation.
-* Aggregate CPU = 582,933
-  * This metric is the total CPU time in millicores that is enabled for custom microservices. The metric is determined by the resource limits as written in the microservice manifest and the active subscription time of the microservice.
-* Aggregate Memory = 596,951
-  * This metric is the total RAM allocation in megabytes that is enabled for custom microservices, as determined by the resource limits in the microservice manifest.
+See [version 1](#datahub-gib-v1)
 
-To calculate the CCU billing metric, these values are converted to daily average. For the purposes of this example, the billing period has 30 days.
+### DataHub - Memory unit {#datahub-memory-v2}
 
-* _AvgCPU = (582,933 millicores / 30 days) = **19,431.1 millicores/day**_
-* _AvgRAM = (596,951 MB/ 30 days) = **19,898.37 MB/day**_
+See [version 1](#datahub-memory-v1)
 
-These daily average values are then put in the proper units aligned with the billable metric (CPU cores and GiB, respectively).
+### Virtual Private Connection {#vpc-v2}
 
-* _ccuCPU = (19,431.1 millicores/day) / (1000 millicores) = **19.43 CPU/day**_
-  * where 1000 millicores = 1 core
+See [version 1](#vpc-v1)
 
-* _ccuRAM = (19,898.37 MB/day) / (4294.97 MB) = **4.63 4GiB bundles/day**_
-  * where 1 Gibibyte (GiB) = 1024 Mebibytes (MiB) = 1073.74 Megabytes (MB)
-  * 4 GiB = 4 * (1073.74 MB) = 4294.87 MB
+### Database replica set {#database-replica-v2}
 
-Then, the larger of the two values is rounded up to form the CCU billable metric.
-*_ccuCPU = **19.43** > **4.63** = ccuRAM_
-
-19.43 rounds up to **20 billable units** of CCUs in the billing period.
-
-### DataHub - GiB of data queried {#datahub-gib}
-
-Gibibyte (GiB) of data read from data lakes or other supported data sources by the licensed Software. Queries that fall below 10 MB will be rounded up to the minimum size of 10 MB. For invoicing purposes, any fractional values are rounded up to the nearest gibibyte.
-
-### DataHub - Memory unit {#datahub-memory}
-
-The total amount of memory available for use by DataHub nodes. A node is a physical or virtual machine or a container within the DataHub cluster that operates as either a co-ordinator node and/or an executor node. Both coordinator and executor nodes are required to run the DataHub add-on. A DataHub node must be deployed with no less than 16 GiB of memory. The memory allocation will be split between coordinator and executor nodes as determined necessary by the Cloud Services, with a minimum of 16 GiB for each node. The first unit will include 32 gibibytes (GiB) of memory. Subsequent units will be billed in increments of 16 GiB. For invoicing purposes, any fractional values are rounded up to the nearest 16 GiB unit.  
-
-### Virtual Private Connection {#vpc}
-
-Use by the Customer of the Cloud Services whose license metric is indicated as “Virtual Private Connection” above allows the creation of a total number of said connections via a redundant pair of site-to-site ("S2S") tunnels between the Customer and the Supplier which does not exceed the licensed number indicated above. The reference to “Virtual Private Connection” refers to the use of a single redundant virtual private connection into the underlying instance of the Cloud Services operated by the Supplier at its hosting partners.
-
-### Database replica set {#database-replica}
-
-A Database replica set is for use with upscaling the Operational Store (database) of a single {{< product-c8y-iot >}} instance. A “replica set” includes up to 3 data-bearing nodes. A node can be deployed in a virtual machine, physical server, or container.
+See [version 1](#database-replica-v1)

--- a/content/service-terms/license-metrics-bundle/v2.md
+++ b/content/service-terms/license-metrics-bundle/v2.md
@@ -1,15 +1,19 @@
 ---
-title: Version 1
+title: Version 2
 layout: bundle
-weight: 30
+weight: 20
 
 ---
 
 This agreement is made between {{< company-c8y >}} ("Provider") and the customer ("Customer") who utilizes the Provider's hosted software solutions and services. The following license metrics define the usage measurements and calculations that form the basis for billing and invoicing of {{< company-c8y >}} services.
 
-These license metrics are valid for April 1st, 2025 onwards.
+These license metrics are valid for April 1st, 2026 onwards.
 
-### Deployment
+### Differences from version 1 {#differences-v1}
+
+Version 2 updates the [messages](#messages) definition. MQTT Service messages are now metered in terms of 4KiB "billable messages", and MQTT client connection time is metered in terms of an equivalent number of billable messages. In all other respects, version 2 is identical to version 1.
+
+### Deployment {#deployment}
 
 A unique instance of the hosted software ("Software") provided by the supplier ("Supplier") and made accessible to the Customer. Deployments can be "Dedicated Cloud" instances or "Public Cloud" instances.
 * Dedicated Cloud deployments have dedicated resources provided for a single Customer.
@@ -17,23 +21,26 @@ A unique instance of the hosted software ("Software") provided by the supplier (
 
 {{< product-c8y-iot >}} Dedicated Cloud deployments can be used for development or testing ("Non-Production") purposes but are restricted in the scope of their usage. In this case, the Dedicated Cloud deployment may not be used for the processing of live production data or any purposes other than development or testing purposes only. A Non-Production Dedicated Cloud deployment may be subject to separate fees as written in the contract between {{< company-c8y >}} and the Customer. Note that {{< product-c8y-iot >}} Public Cloud deployments are always rated at the same rate regardless of instance type.
 
-### Messages
+### Messages {#messages}
 
 The messages usage metric for a given billing period (calendar month) is determined as the maximum of:
 1. The total count of all data transactions to and in the {{< product-c8y-iot >}} platform, or
-2. The total count of messages processed through the MQTT Service.
+2. The total count of billable messages processed through the MQTT Service, or
+3. The total count of connection-minutes to the MQTT Service.
 
 A data transaction is defined as any authenticated API request with the intention to create, update, or process data within the {{< product-c8y-iot >}} domain model, including inventory objects, operations, measurements, events, and alarms. Transactions are counted regardless of the processing mode, the details of which can be found in [HTTP usage](https://{{< domain-c8y >}}/api/core/#section/REST-implementation/HTTP-usage). Transactions originate from both internal and external sources, including other {{< product-c8y-iot >}} applications, and are recorded via the platform’s [Usage Statistics API](https://{{< domain-c8y >}}/api/core/#tag/Usage-statistics).
 
-The total count of MQTT messages is metered daily via the MQTT Service, with each day's count contributing to the cumulative total for the billing period.
+A billable message is an MQTT PUBLISH message published to or received from the MQTT Service, where each 4KiB (4 kibibytes or 4,096 bytes) of message is counted as one message for billing purposes, rounding up to the next 4KiB boundary. For example, a 3KiB PUBLISH message is billed as one message, and a 6KiB PUBLISH message is billed as two messages. The message size includes both header and payload. The system meters the total count of MQTT billable messages daily via the MQTT Service, with each day's count contributing to the cumulative total for the billing period.
 
-All counted transactions and messages are subject to the quotes listed in [Service quotas](/service-terms/quotas/). Usage that exceeds the listed limits may result in additional charges to ensure platform stability and prevent abuse.
+A connection-minute is an MQTT client connected to the MQTT Service for one minute. Every 10 connection-minutes equals one billable message. For example, a single MQTT client connected for one hour (60 minutes) counts as six messages, and 1,000 MQTT clients connected for one minute each count as 100 messages. The total count of connection-minutes is metered daily via the MQTT Service, with each day's count contributing to the cumulative total for the billing period.
 
-For each billing period, the sum of daily MQTT message counts and the total count of data transactions are separately calculated. The greater of the two values is used as the final invoiced metric, rounded up to the nearest 100,000 units. In the case that one of the values is unable to be computed, the other value will be used for billing purposes.
+All counted transactions and messages are subject to the quotas listed in [Service quotas](/service-terms/quotas/). Usage that exceeds the listed limits may result in additional charges to ensure platform stability and prevent abuse.
 
-#### Example
+For each billing period, the sum of daily MQTT connection-minutes (after conversion to billable messages) count, MQTT billable message count, and the total count of data transactions are separately calculated. The greater of the three values is used as the final invoiced metric, rounded up to the nearest 100,000 units. If one of the values cannot be computed, the other values are used for billing purposes.
 
-During a billing period, the sum of the daily values for each of the referenced components are as follows:
+#### Examples {#messages-examples}
+
+During a billing period, the sum of the daily values for each of the referenced components is as follows:
 
 * Data transactions = **1,192,000**
   * Measurements created = 1,000,000
@@ -45,27 +52,56 @@ During a billing period, the sum of the daily values for each of the referenced 
   * Operations updated = 1,000
   * Inventories created = 100,000
   * Inventories updated = 50,000
-* MQTT messages = **200,000**
+* MQTT billable messages = **202,000**
+  * Inbound billable messages = 200,000
+  * Outbound billable messages = 2,000
+* MQTT connection-minute equivalent messages = **6,000**
+  * Actual connection minutes = 60,000
 
-The total data transactions value is higher than that of the MQTT messages and therefore will be used as the final invoicing metric. To calculate the billable units, the total data transactions is rounded up to the nearest 100,000 units:
+The total data transactions value is higher than that of the MQTT billable messages or connection-minutes and therefore will be used as the final invoicing metric. To calculate the billable units, the total data transactions is rounded up to the nearest 100,000 units:
 
 _1,192,000 / 100,000 = 11.92_
 
 11.92 rounds up to **12 billable units** of messages for the billing period.
 
-### GiB for Operational Data Store
+Similarly, in a different billing period the sum of the daily values for each of the referenced components is as follows:
+
+* Data transactions = **1,192,000**
+  * Measurements created = 1,000,000
+  * Events created = 20,000
+  * Events updated = 5,000
+  * Alarms created = 10,000
+  * Alarms updated = 5,000
+  * Operations created = 1,000
+  * Operations updated = 1,000
+  * Inventories created = 100,000
+  * Inventories updated = 50,000
+* MQTT billable messages = **5,245,000**
+  * Inbound billable messages = 5,045,000
+  * Outbound billable messages = 200,000
+* MQTT connection-minute equivalent messages = **12,000**
+  * Actual connection minutes = 120,000
+
+In this case, the MQTT billable message count is higher than the MQTT connection-minutes or data transactions values, so billable messages will be used as the final invoicing metric.
+First the billable messages are rounded up to the nearest 100,000 units:
+
+_5,245,000 / 100,000 = 52.45_
+
+52.45 rounds up to **53 billable units** of messages for the billing period.
+
+### GiB for Operational Data Store {#data-store-gib}
 
 The total volume of data stored in the Operational Data Store of the {{< product-c8y-iot >}} platform within a given billing period (calendar month). Data stored in the Operational Data Store is counted and exposed via the [Usage Statistics API](https://{{< domain-c8y >}}/api/core/#tag/Usage-statistics) provided by the platform. The maximum daily value taken during the billing period will be used for invoicing purposes and is rounded up to the nearest gibibyte (GiB).
 
-### Tenant
+### Tenant {#tenant}
 
 Tenants are physically separated data spaces with a separate address (URL), with a specific set of users, a separate application management, and other individual functionality. Users in a single tenant share the same URL and the same data space. Add-ons that use the per-tenant billing metric will be invoiced based on the number of tenants that have the add-on deployed.
 
-### {{< product-c8y-iot >}} Compute Unit (CCU)
+### {{< product-c8y-iot >}} Compute Unit (CCU) {#ccu}
 
 A {{< product-c8y-iot >}} Compute Unit (CCU) represents a standardized measure of computational resources consumed by microservices developed and deployed by the Customer, where 1 CCU is equivalent to 1 CPU core and 4 gibibytes (GiB) of memory. CCUs are calculated monthly by computing the daily average CPU resources allocated and daily average memory resources allocated (in bundles of 4 GiB) and taking the larger of the two values. This unit will be rounded up if fractional CPU cores or multiples of 4 GiB RAM are used. For example, 1.5 cores and 6 GiB RAM would be considered 2x compute units. Resource usage is first aggregated across all tenants before calculating the CCUs. A complete service description for Customer microservices can be found in the [Service terms section](/service-terms/service-level/#microservices-sla) of the {{< product-c8y-iot >}} documentation.
 
-#### Example
+#### Example {#ccu-example}
 
 The following aggregate metrics are calculated by summing up the daily resource limits for each custom microservice over the billing period (details on the `resources` field in the microservice manifest files can be found in the [{{< product-c8y-iot >}} documentation](/microservice-sdk/general-aspects/#settings). Custom microservices from all tenants across the Customer's deployments are included in this calculation. {{< company-c8y >}} provided microservices are not counted as part of the custom CCU calculation.
 * Aggregate CPU = 582,933
@@ -92,17 +128,18 @@ Then, the larger of the two values is rounded up to form the CCU billable metric
 
 19.43 rounds up to **20 billable units** of CCUs in the billing period.
 
-### DataHub - GiB of data queried
+### DataHub - GiB of data queried {#datahub-gib}
 
 Gibibyte (GiB) of data read from data lakes or other supported data sources by the licensed Software. Queries that fall below 10 MB will be rounded up to the minimum size of 10 MB. For invoicing purposes, any fractional values are rounded up to the nearest gibibyte.
 
-### DataHub - Memory unit
+### DataHub - Memory unit {#datahub-memory}
 
 The total amount of memory available for use by DataHub nodes. A node is a physical or virtual machine or a container within the DataHub cluster that operates as either a co-ordinator node and/or an executor node. Both coordinator and executor nodes are required to run the DataHub add-on. A DataHub node must be deployed with no less than 16 GiB of memory. The memory allocation will be split between coordinator and executor nodes as determined necessary by the Cloud Services, with a minimum of 16 GiB for each node. The first unit will include 32 gibibytes (GiB) of memory. Subsequent units will be billed in increments of 16 GiB. For invoicing purposes, any fractional values are rounded up to the nearest 16 GiB unit.  
 
-### Virtual Private Connection
+### Virtual Private Connection {#vpc}
 
 Use by the Customer of the Cloud Services whose license metric is indicated as “Virtual Private Connection” above allows the creation of a total number of said connections via a redundant pair of site-to-site ("S2S") tunnels between the Customer and the Supplier which does not exceed the licensed number indicated above. The reference to “Virtual Private Connection” refers to the use of a single redundant virtual private connection into the underlying instance of the Cloud Services operated by the Supplier at its hosting partners.
 
-### Database replica set
+### Database replica set {#database-replica}
+
 A Database replica set is for use with upscaling the Operational Store (database) of a single {{< product-c8y-iot >}} instance. A “replica set” includes up to 3 data-bearing nodes. A node can be deployed in a virtual machine, physical server, or container.

--- a/content/service-terms/license-metrics-bundle/v2.md
+++ b/content/service-terms/license-metrics-bundle/v2.md
@@ -15,7 +15,7 @@ Version 2 updates the [messages](#messages) definition. MQTT Service messages ar
 
 ### Deployment {#deployment-v2}
 
-See [version 1](#deployment-v1)
+See [version 1](#deployment-v1).
 
 ### Messages {#messages-v2}
 
@@ -87,28 +87,28 @@ _5,245,000 / 100,000 = 52.45_
 
 ### GiB for Operational Data Store {#data-store-gib-v2}
 
-See [version 1](#data-store-gib-v1)
+See [version 1](#data-store-gib-v1).
 
 ### Tenant {#tenant-v2}
 
-See [version 1](#tenant-v1)
+See [version 1](#tenant-v1).
 
 ### {{< product-c8y-iot >}} Compute Unit (CCU) {#ccu-v2}
 
-See [version 1](#ccu-v1)
+See [version 1](#ccu-v1).
 
 ### DataHub - GiB of data queried {#datahub-gib-v2}
 
-See [version 1](#datahub-gib-v1)
+See [version 1](#datahub-gib-v1).
 
 ### DataHub - Memory unit {#datahub-memory-v2}
 
-See [version 1](#datahub-memory-v1)
+See [version 1](#datahub-memory-v1).
 
 ### Virtual Private Connection {#vpc-v2}
 
-See [version 1](#vpc-v1)
+See [version 1](#vpc-v1).
 
 ### Database replica set {#database-replica-v2}
 
-See [version 1](#database-replica-v1)
+See [version 1](#database-replica-v1).

--- a/content/service-terms/license-metrics-bundle/v2.md
+++ b/content/service-terms/license-metrics-bundle/v2.md
@@ -21,8 +21,8 @@ See [version 1](#deployment-v1).
 
 The messages usage metric for a given billing period (calendar month) is determined as the maximum of:
 1. The total count of all data transactions to and in the {{< product-c8y-iot >}} platform, or
-2. The total count of billable messages processed through the MQTT Service, or
-3. The total count of connection-minutes to the MQTT Service.
+2. the total count of billable messages processed through the MQTT Service, or
+3. the total count of connection-minutes to the MQTT Service.
 
 A data transaction is defined as any authenticated API request with the intention to create, update, or process data within the {{< product-c8y-iot >}} domain model, including inventory objects, operations, measurements, events, and alarms. Transactions are counted regardless of the processing mode, the details of which can be found in [HTTP usage](https://{{< domain-c8y >}}/api/core/#section/REST-implementation/HTTP-usage). Transactions originate from both internal and external sources, including other {{< product-c8y-iot >}} applications, and are recorded via the platform’s [Usage Statistics API](https://{{< domain-c8y >}}/api/core/#tag/Usage-statistics).
 


### PR DESCRIPTION
Adds a new licence metrics version 2 that supersedes the existing version 1. The only changes are to the "messages" section:
* MQTT Service messages are now metered in terms of 4KiB "billable messages"
* MQTT Service "connection-minutes" are metered, with every 10 minutes equivalent 1 billable message

Otherwise version 2 is identical to version 1. I considered making the v2 section include *only* the differences from v1, but decided that would be too hard for the reader to keep track of - especially if/when we add more versions in the future.

Open questions, mainly for @tydunne and @BeateRixen:
* Are we OK with structuring it this way, repeating all the unchanged text from one version to the next?
* The v2 start date is a bit arbitrary... I guess we should set it to the actual GA date for the MQTT Service?
* Should we add anything to v1 to be clear that it does not apply to new contracts after the v2 start date?

Obviously anything else you think should be changed, just let me know in the comments.