### PR TITLE
MTM-66199 Add a date so the change log is visible!

### DIFF
--- a/content/change-logs/platform-services/mqtt-service-0.9.x-required-role-announcement.md
+++ b/content/change-logs/platform-services/mqtt-service-0.9.x-required-role-announcement.md
@@ -1,5 +1,5 @@
 ---
-date:
+date: 2026-03-11
 title: MQTT Service will require an explicit role for basic authentication
 change_type:
   - value: change-inv-3bw8e


### PR DESCRIPTION
Not sure how we missed this. The Announcement needs a date to be visible in the change log list, and we don't need to wait for the change to be fully rolled out - the point was to pre-announce it!