### PR TITLE
fix change logs frontmatter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ static/releases.json
 .hugo_build.lock
 pdf-generator/tmp/
 pdf-generator/node_modules/
+CLAUDE.md

--- a/content/change-logs/_index.md
+++ b/content/change-logs/_index.md
@@ -1,7 +1,9 @@
 ---
 title: Change logs
+layout: change-logs
 outputs:
   - html
+  - json
 ---
 
 These change logs document all relevant changes for the {{< product-c8y-iot >}} cloud deployments.


### PR DESCRIPTION
This pull request makes a minor update to the `content/change-logs/_index.md` file, due to the hugo version update specifying additional output formats and a new layout for the change logs page.

- Frontmatter updates:
  * Added `layout: change-logs` to specify a custom layout for the page.
  * Included `json` as an output format in addition to `html`.