### PR TITLE
MTM-65382 Pulsar clients can publish messages to SmartREST topics

### DIFF
--- a/content/device-integration/mqtt-service-bundle/implementation.md
+++ b/content/device-integration/mqtt-service-bundle/implementation.md
@@ -281,6 +281,7 @@ All message publication and subscription on these topics is assumed to be for Co
 * `event/events/`
 * `measurement/measurements/`
 * `inventory/managedObjects/`
+* `error`
 * `devicecontrol/notifications`
 
 #### Connect-time behaviour {#core-mqtt-connections}

--- a/content/device-integration/mqtt-service-bundle/pulsar-client.md
+++ b/content/device-integration/mqtt-service-bundle/pulsar-client.md
@@ -332,13 +332,14 @@ An alarm will be raised in the {{< product-c8y-iot >}} tenant when one of these 
 The rate of alarm sending is limited to avoid overloading the tenant with redundant alarms alerting about the same error on different messages.
 The following alarms are raised for invalid messages on the Pulsar `to-device` topic:
 
-| Alarm type                               | Description                                                       |
-|------------------------------------------|-------------------------------------------------------------------|
-| `c8y_MqttService_ToDevice_NoKey`         | The message key is not set.                                       |
-| `c8y_MqttService_ToDevice_InvalidKey`    | The message key is set but does not match the client id or topic. |
-| `c8y_MqttService_ToDevice_EmptyClientId` | The `clientID` property is set but has an empty value.            |
-| `c8y_MqttService_ToDevice_MissingTopic`  | The `topic` property is not set.                                  |
-| `c8y_MqttService_ToDevice_EmptyTopic`    | The `topic` property is set but has an empty value.               |
+| Alarm type                               | Description                                                            |
+|------------------------------------------|------------------------------------------------------------------------|
+| `c8y_MqttService_ToDevice_NoKey`         | The message key is not set.                                            |
+| `c8y_MqttService_ToDevice_InvalidKey`    | The message key is set but does not match the `clientID` or `topic`.   |
+| `c8y_MqttService_ToDevice_EmptyClientId` | The `clientID` property is set but has an empty value.                 |
+| `c8y_MqttService_ToDevice_MissingTopic`  | The `topic` property is not set.                                       |
+| `c8y_MqttService_ToDevice_EmptyTopic`    | The `topic` property is set but has an empty value.                    |
+| `c8y_MqttService_ToDevice_InvalidTopic`  | The `topic` property is invalid, for example, SmartREST topic is used. |
 
 A message with a non-empty `clientID` property referring to an MQTT device that is not currently connected is **not** considered to be invalid.
 However, this message will not be delivered to the device, even if it connects later, because of the requirement for devices to use a _clean session_ when connecting.


### PR DESCRIPTION
In fact all alarms that are created have a slightly different format (no last underscore), for example `c8y_MqttService_ToDeviceNoKey`, but what we have documented is more readable. I will rise PR in the MQTT Service to address this.

`error` is not related to the alarm changes, but it was missing in comparison to the [original version](https://cumulocity.com/docs/device-integration/mqtt-service/#implementation), and it should be listed as it is restricted JSON over MQTT topic.
