### PR TITLE
Enable auto-link checking for maintenance branches

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -96,8 +96,7 @@ jobs:
 
     - name: Check for broken links
       # On by default, but allow bypassing because this is (currently) a new part of the workflow that hasn't been battle-tested
-      # Only for 'develop', because we expect that maintenance branches are (currently) not pristine w.r.t. broken links
-      if: ${{ !contains(github.event.pull_request.labels.*.name, 'bypass-link-check') && github.event.pull_request.state != 'closed' && github.event.pull_request.base.ref == 'develop' }}
+      if: ${{ !contains(github.event.pull_request.labels.*.name, 'bypass-link-check') && github.event.pull_request.state != 'closed' }}
       run: |
         # Do a full build and serve _locally_ because it's faster to spider than the Surge site
         BASEURL=http://127.0.0.1:8000


### PR DESCRIPTION
We're now at the stage where we expect 2026 to be 'pristine' and publishable, so there's no need to disable for maintenance branches.