### PR TITLE
CIE-5524 - Temporarily direct Edge 2026 doc back to 2025 until release

### DIFF
--- a/content/sector/edge/_index.md
+++ b/content/sector/edge/_index.md
@@ -1,7 +1,8 @@
 ---
 title: Edge
 icon: "c8y-icon c8y-icon-cumulocity-iot"
-type: root
+type: new-tab
+external: "https://cumulocity.com/docs/2025/edge-kubernetes/"
 layout: redirect
 bundlefolder: edge
 audience:
@@ -11,7 +12,6 @@ audience:
 sector:
   - edge
 weight: 60
-pdf: true
 ---
 
-{{< product-c8y-iot >}} Edge is the onsite solution of {{< product-c8y-iot >}} intended to run as a local software application on industrial PCs or local servers.
+{{< product-c8y-iot >}} Edge is the onsite solution of {{< product-c8y-iot >}} intended to run as a local software application on industrial PCs or local servers.<p>Clicking here opens the documentation of the {{< c8y-edge-version-major >}} release.</p>

--- a/content/sector/edge/_index.md
+++ b/content/sector/edge/_index.md
@@ -14,4 +14,4 @@ sector:
 weight: 60
 ---
 
-{{< product-c8y-iot >}} Edge is the onsite solution of {{< product-c8y-iot >}} intended to run as a local software application on industrial PCs or local servers.<p>Clicking here opens the documentation of the {{< c8y-edge-version-major >}} release.</p>
+{{< product-c8y-iot >}} Edge is the onsite solution of {{< product-c8y-iot >}} intended to run as a local software application on industrial PCs or local servers.<p>Clicking here opens the documentation of the 2025 release.</p>


### PR DESCRIPTION
The 2026 doc set is due to become publicly visible soon, but Edge 2026 isn't quite released. So let's 'hide' it for a bit longer.