### PR TITLE
[issue-4517] Fixed link to `messages` header which is now suffixed with `-v1`

### DIFF
--- a/content/service-terms/license-metrics-bundle/v2.md
+++ b/content/service-terms/license-metrics-bundle/v2.md
@@ -11,7 +11,7 @@ These license metrics are valid for April 1st, 2026 onwards.
 
 ### Differences from previous versions {#differences-v2}
 
-Version 2 updates the [messages](#messages) definition. MQTT Service messages are now metered in terms of 4KiB "billable messages", and MQTT client connection time is metered in terms of an equivalent number of billable messages. In all other respects, version 2 is identical to version 1.
+Version 2 updates the [messages](#messages-v1) definition. MQTT Service messages are now metered in terms of 4KiB "billable messages", and MQTT client connection time is metered in terms of an equivalent number of billable messages. In all other respects, version 2 is identical to version 1.
 
 ### Deployment {#deployment-v2}
 


### PR DESCRIPTION
Detected in https://github.com/Cumulocity-IoT/c8y-docs/issues/4517 (develop) and https://github.com/Cumulocity-IoT/c8y-docs/issues/4516 (y2026).

Addresses:
```
https://cumulocity.com/docs/service-terms/license-metrics#messages:
Error: An element with id or name = "messages" should exist in HTML or frames: expected false to be true
```