### PR TITLE
[issue-4516] Graft missing known exception from `develop`

### DIFF
--- a/broken-links-script/cypress/support/e2e.js
+++ b/broken-links-script/cypress/support/e2e.js
@@ -93,6 +93,8 @@ Cypress.on('uncaught:exception', (err) => {
     if (err.message.includes("bootstrap is not defined")) {
       return false;
     }
-    
+    if (err.message.includes("window.clarity is not a function")) {
+      return false;
+    }
   });
   


### PR DESCRIPTION
Addresses:

```
window.clarity is not a function
```

exception occurring at:
- https://azure.microsoft.com/en-US/products/vpn-gateway
- https://azure.microsoft.com/en-US/products/expressroute

detected in https://github.com/Cumulocity-IoT/c8y-docs/issues/4516