### PR TITLE
[issue-4516] Excluded openjdk link due to time out (same as in develop)

### DIFF
--- a/broken-links-script/cypress/e2e/link-checker.cy.js
+++ b/broken-links-script/cypress/e2e/link-checker.cy.js
@@ -9,7 +9,10 @@ describe('Link and Routing Validation - Individual URL Checks', () => {
     "https://de.mathworks.com/help/predmaint/ug/remaining-useful-life-estimation-using-convolutional-neural-network.html",
 
     // Medium blog uses anti-bot protection, Cypress cannot reliably load it
-    "https://medium.com/@polanitzer/prediction-of-remaining-useful-life-of-an-engine-based-on-sensors-building-a-random-forest-in-ffad82c8a1c6"
+    "https://medium.com/@polanitzer/prediction-of-remaining-useful-life-of-an-engine-based-on-sensors-building-a-random-forest-in-ffad82c8a1c6",
+
+    // Always times out in the automated tests but loads fine in the browser
+    "https://openjdk.org/jeps/252",
   ];
 
 


### PR DESCRIPTION
Addresses:
```
https://openjdk.org/jeps/252:
  `cy.request()` timed out waiting `20000ms` for a response from your server.
```
detected in https://github.com/Cumulocity-IoT/c8y-docs/issues/4516