### PR TITLE
Soften Data Hub wording in Edge vs Core comparison table

### DIFF
--- a/content/edge/edge-introduction-bundle/edge-vs-core.md
+++ b/content/edge/edge-introduction-bundle/edge-vs-core.md
@@ -29,4 +29,4 @@ The following differences apply:
 |Streaming Analytics|Included|Optional
 |OPC UA|Included|Optional
 |Cloud Field Bus|Included|Optional
-|Data Hub|Not included in the standard Edge distribution; available as a custom engagement through Professional Services — contact your account team for options|Optional
+|Data Hub|On request via Professional Services|Optional

--- a/content/edge/edge-introduction-bundle/edge-vs-core.md
+++ b/content/edge/edge-introduction-bundle/edge-vs-core.md
@@ -29,4 +29,4 @@ The following differences apply:
 |Streaming Analytics|Included|Optional
 |OPC UA|Included|Optional
 |Cloud Field Bus|Included|Optional
-|Data Hub|No|Optional
+|Data Hub|Not included in the standard Edge distribution; available as a custom engagement through Professional Services — contact your account team for options|Optional


### PR DESCRIPTION
## Summary

- Replace the flat "No" in the Data Hub row of the Edge vs Core comparison table with wording that reflects current practice: Data Hub isn't in the standard Edge distribution, but Professional Services delivers it as a custom engagement, and readers should contact their account team for options.

## Why

The binary "No" was discouraging customers with a genuine Data Hub on Edge need, even though Professional Services actively delivers this today (e.g. Edwards Vacuum, Hammerstone Pty Ltd) and Edge PM/R&D have agreed to continue offering it. The row is kept so customers evaluating Edge can still find this information, but the wording no longer implies the capability is unavailable. Data Hub on Edge is **not** a productized add-on, so the copy deliberately avoids suggesting otherwise.

## Scope

- Only `content/edge/edge-introduction-bundle/edge-vs-core.md` needed editing — "Data Hub" is not mentioned in `edge-introduction.md` or `edge-operator.md`.
- Targeting `release/y2026` directly: the 2026 edge docs live only on this branch (no equivalent content on `develop`), so the README's auto-backport flow doesn't apply here.
- No other rows touched.

## Test plan

- [ ] Render the Edge introduction page locally (or preview) and confirm the Data Hub row still displays cleanly in the table.
- [ ] Confirm the anchor `#edge-vs-core` still resolves and the rest of the table is unchanged.