### PR TITLE
[issue-4551] Added new exception for broken links script

### DIFF
--- a/broken-links-script/cypress/support/e2e.js
+++ b/broken-links-script/cypress/support/e2e.js
@@ -108,5 +108,8 @@ Cypress.on('uncaught:exception', (err) => {
     if (err.message.includes("Cannot read properties of undefined (reading 'quick')")) {
       return false;
     }
+    if (err.message.includes("Unexpected token '&'")) {
+      return false;
+    }
   });
   


### PR DESCRIPTION
Addresses:

```
1) Link and Routing Validation - Individual URL Checks
       should validate URL: https://support.gainsight.com/PX/Administration/General/User_and_Account_Model#Custom_Attributes:
     SyntaxError: The following error originated from your application code, not from Cypress.

  > Unexpected token '&'
```

detected in https://github.com/Cumulocity-IoT/c8y-docs/issues/4551 and https://github.com/Cumulocity-IoT/c8y-docs/issues/4550.