### PR TITLE
docs: add valueAsText placeholder for OPC UA custom actions

### DIFF
--- a/content/change-logs/device-management/opcua-1023-1-4-add-valueAsText-placeholder.md
+++ b/content/change-logs/device-management/opcua-1023-1-4-add-valueAsText-placeholder.md
@@ -1,0 +1,17 @@
+---
+date: '2026-04-17'
+title: New valueAsText placeholder for OPC UA custom actions
+product_area: Device management & connectivity
+change_type:
+  - value: change-2c7RdTdXo4
+    label: Improvement
+component:
+  - value: component-Tf05_KQ-B
+    label: OPC UA
+build_artifact:
+  - value: tc-MLn0oFRX-
+    label: opcua
+ticket: DM-591
+version: 1023.1.4
+---
+A new `${valueAsText}` placeholder is now available in the body template for OPC UA custom actions. Unlike the existing `${value}` placeholder which inserts the JSON-serialized value, `${valueAsText}` provides a plain text representation of the node value. This is useful for embedding values directly in strings without JSON formatting. The placeholder is available for both HTTP POST custom actions and MQTT forwarding custom actions.

--- a/content/change-logs/device-management/opcua-1023-1-4-add-valueAsText-placeholder.md
+++ b/content/change-logs/device-management/opcua-1023-1-4-add-valueAsText-placeholder.md
@@ -1,5 +1,5 @@
 ---
-date: 
+date: '2026-04-21'
 title: New valueAsText placeholder for OPC UA custom actions
 product_area: Device management & connectivity
 change_type:

--- a/content/change-logs/device-management/opcua-1023-1-4-add-valueAsText-placeholder.md
+++ b/content/change-logs/device-management/opcua-1023-1-4-add-valueAsText-placeholder.md
@@ -1,5 +1,5 @@
 ---
-date: '2026-04-17'
+date: 
 title: New valueAsText placeholder for OPC UA custom actions
 product_area: Device management & connectivity
 change_type:

--- a/content/device-integration/opcua-bundle/device-protocols.md
+++ b/content/device-integration/opcua-bundle/device-protocols.md
@@ -109,9 +109,10 @@ Thereafter, the exception is handled by validating the existence of the source. 
 
 Custom actions are HTTP POST requests which the gateway will send to a defined custom URL. You can define custom headers and body template with the following placeholders available:
 
-- ${value}: value of specific node
-- ${receivedTimestampInMs}: Timestamp when the node value is received by the OPC UA device gateway in milliseconds
-- ${serverId}: ID of OPC-UA server
+- ${value}: JSON-serialized value of specific node
+- ${valueAsText}: plain text representation of the node value, useful for embedding values directly in strings without JSON formatting
+- ${receivedTimestampInMs}: timestamp when the node value is received by the OPC UA device gateway in milliseconds
+- ${serverId}: ID of OPC UA server
 - ${nodeId}: ID of source node
 - ${deviceId}: ID of source device
 

--- a/content/device-integration/opcua-bundle/device-protocols.md
+++ b/content/device-integration/opcua-bundle/device-protocols.md
@@ -110,8 +110,8 @@ Thereafter, the exception is handled by validating the existence of the source. 
 Custom actions are HTTP POST requests which the gateway will send to a defined custom URL. You can define custom headers and body template with the following placeholders available:
 
 - ${value}: JSON-serialized value of specific node
-- ${valueAsText}: plain text representation of the node value, useful for embedding values directly in strings without JSON formatting
-- ${receivedTimestampInMs}: timestamp when the node value is received by the OPC UA device gateway in milliseconds
+- ${valueAsText}: Plain text representation of the node value, useful for embedding values directly in strings without JSON formatting
+- ${receivedTimestampInMs}: Timestamp when the node value is received by the OPC UA device gateway in milliseconds
 - ${serverId}: ID of OPC UA server
 - ${nodeId}: ID of source node
 - ${deviceId}: ID of source device

--- a/content/device-integration/opcua-bundle/rest-api.md
+++ b/content/device-integration/opcua-bundle/rest-api.md
@@ -1284,7 +1284,7 @@ If <em>alarmStatusMappings</em> are defined, also the variables used in the expr
 <td>bodyTemplate</td>
 <td>string</td>
 <td>yes</td>
-<td>Template of the request body. This can be parameterized by the following placeholders:<br><code>${value}</code>: Data value of the OPC UA node.&nbsp;<br><code>${serverId}</code>: OPC UA server managed object ID.<br><code>${nodeId}</code>: ID of the node where the data is coming from.<br><code>${deviceId}</code>: Managed object ID of the source manage object.</td>
+<td>Template of the request body. This can be parameterized by the following placeholders:<br><code>${value}</code>: JSON-serialized data value of the OPC UA node.<br><code>${valueAsText}</code>: Plain text representation of the node value, useful for embedding values directly in strings without JSON formatting.<br><code>${serverId}</code>: OPC UA server managed object ID.<br><code>${nodeId}</code>: ID of the node where the data is coming from.<br><code>${deviceId}</code>: Managed object ID of the source managed object.<br><code>${receivedTimestampInMs}</code>: Timestamp when the node value is received by the OPC UA device gateway in milliseconds.</td>
 </tr>
 <tr>
 <td>retryEnabled</td>


### PR DESCRIPTION
## Summary

Add documentation for the new `${valueAsText}` placeholder available in OPC UA custom action body templates (DM-591).

Unlike the existing `${value}` placeholder which inserts JSON-serialized data, `${valueAsText}` provides a plain text representation of the node value, useful for embedding values directly in strings without JSON formatting.

## Changes

- **device-protocols.md**: Added `${valueAsText}` to the custom actions placeholder list
- **rest-api.md**: Added `${valueAsText}` (and the previously missing `${receivedTimestampInMs}`) to the `bodyTemplate` API reference
- **Changelog entry**: Added for version 1023.1.4

## Related PRs

- Backend: https://github.com/Cumulocity-IoT/c8y-opcua/pull/262
- UI: https://github.com/Cumulocity-IoT/cumulocity-ui/pull/11661