### PR TITLE
Move dataprep card to third tile [no-issue]

### DIFF
--- a/content/data-preparation-card.md
+++ b/content/data-preparation-card.md
@@ -8,7 +8,8 @@ sector:
   - device_management
 audience:
   - Users
-weight: 100
+  - Developers
+weight: 50
 outputs:
 - html
 ---

--- a/content/device-integration-card.md
+++ b/content/device-integration-card.md
@@ -8,7 +8,7 @@ audience:
   - Developers
 sector:
   - device_management
-weight: 50
+weight: 40
 ---
 
 Read about device integration options such as REST or MQTT, or using one of the supported device protocols, for example, LWM2M or OPCUA.


### PR DESCRIPTION
- Move Data Preparation Card to third tile inside Device Management
- Audience changed from 'Users' to 'Users, Developers'