### PR TITLE
MTM-64641 - Fix misleading "Fragments to filter" description in data broker docs

### DIFF
--- a/content/data-broker/data-broker-application-bundle/data-connectors.md
+++ b/content/data-broker/data-broker-application-bundle/data-connectors.md
@@ -96,7 +96,7 @@ If the source tenant has been suspended all its data broker connectors will be s
 	 </tr>
 	 <tr>
 	 <td style="text-align:left">Fragments to filter</td>
-	 <td style="text-align:left">The fragments that must be present in a device to be forwarded.</td>
+	 <td style="text-align:left">The fragments that must be present in the message payload for it to be forwarded.</td>
 	 </tr>
 	 <tr>
 	 <td style="text-align:left">Fragments to copy</td>


### PR DESCRIPTION
The "Fragments to filter" row in the data connector filter table incorrectly stated that fragments must be present in "a device" to be forwarded.

The actual runtime behaviour checks the message payload (alarm, event, measurement, or managed object) — not the associated device managed object.

The description has been updated to reflect this accurately.

### Changes:
- Updated the "Fragments to filter" table cell in `data-connectors.md` from "must be present in a device" to "must be present in the message payload" to correctly describe what is checked at runtime.