### PR TITLE
[MTM-65573] Release notes for Enhanced Traceability for Support User …

### DIFF
--- a/content/change-logs/platform-services/cumulocity-2026-141-0-audit-record-for-anonymous-support-user.md
+++ b/content/change-logs/platform-services/cumulocity-2026-141-0-audit-record-for-anonymous-support-user.md
@@ -1,6 +1,6 @@
 ---
 date: ''
-title: Enhanced Traceability for Support User Logins in Audit Logs
+title: Enhanced traceability for support user logins in audit logs
 product_area: Platform services
 change_type:
   - value: change-2c7RdTdXo4

--- a/content/change-logs/platform-services/cumulocity-2026-141-0-audit-record-for-anonymous-support-user.md
+++ b/content/change-logs/platform-services/cumulocity-2026-141-0-audit-record-for-anonymous-support-user.md
@@ -14,7 +14,7 @@ build_artifact:
 ticket: MTM-65573
 version: 2026.141.0
 ---
-Improvements have been made to the audit logging logic for **User login** actions to ensure full visibility during sub-tenant access.
+The audit logging logic for **User login** actions has been improved to ensure full visibility during subtenant access.
 
 When a support user logs into a sub-tenant, the audit log entry now consistently records the specific target user being accessed. Previously, if the system used only the `<managementTenantUserId>$` identifier, the audit log would omit the impersonated user's identity.
 

--- a/content/change-logs/platform-services/cumulocity-2026-141-0-audit-record-for-anonymous-support-user.md
+++ b/content/change-logs/platform-services/cumulocity-2026-141-0-audit-record-for-anonymous-support-user.md
@@ -1,0 +1,21 @@
+---
+date: ''
+title: Enhanced Traceability for Support User Logins in Audit Logs
+product_area: Platform services
+change_type:
+  - value: change-2c7RdTdXo4
+    label: Improvement
+component:
+  - value: q3kclF6pO
+    label: Authentication
+build_artifact:
+  - value: tc-QHwMfWtBk7
+    label: cumulocity
+ticket: MTM-65573
+version: 2026.141.0
+---
+Improvements have been made to the audit logging logic for **User login** actions to ensure full visibility during sub-tenant access.
+
+When a support user logs into a sub-tenant, the audit log entry now consistently records the specific target user being accessed. Previously, if the system used only the `<managementTenantUserId>$` identifier, the audit log would omit the impersonated user's identity.
+
+This has been corrected to ensure that even when the primary administrator account (anonymous user) is utilized, the audit trail explicitly captures and displays the identity of the chosen target user within the sub-tenant.

--- a/content/change-logs/platform-services/cumulocity-2026-141-0-audit-record-for-anonymous-support-user.md
+++ b/content/change-logs/platform-services/cumulocity-2026-141-0-audit-record-for-anonymous-support-user.md
@@ -16,6 +16,6 @@ version: 2026.141.0
 ---
 The audit logging logic for **User login** actions has been improved to ensure full visibility during subtenant access.
 
-When a support user logs into a sub-tenant, the audit log entry now consistently records the specific target user being accessed. Previously, if the system used only the `<managementTenantUserId>$` identifier, the audit log would omit the impersonated user's identity.
+When a support user logs into a subtenant, the audit log entry now consistently records the specific target user being accessed. Previously, if the system used only the `<managementTenantUserId>$` identifier, the audit log would omit the impersonated user's identity.
 
 This has been corrected to ensure that even when the primary administrator account (anonymous user) is utilized, the audit trail explicitly captures and displays the identity of the chosen target user within the sub-tenant.

--- a/content/change-logs/platform-services/cumulocity-2026-141-0-audit-record-for-anonymous-support-user.md
+++ b/content/change-logs/platform-services/cumulocity-2026-141-0-audit-record-for-anonymous-support-user.md
@@ -18,4 +18,4 @@ The audit logging logic for **User login** actions has been improved to ensure f
 
 When a support user logs into a subtenant, the audit log entry now consistently records the specific target user being accessed. Previously, if the system used only the `<managementTenantUserId>$` identifier, the audit log would omit the impersonated user's identity.
 
-This has been corrected to ensure that even when the primary administrator account (anonymous user) is utilized, the audit trail explicitly captures and displays the identity of the chosen target user within the sub-tenant.
+This has been corrected to ensure that even when the primary administrator account (anonymous user) is utilized, the audit trail explicitly captures and displays the identity of the chosen target user within the subtenant.


### PR DESCRIPTION
## Overview
Improved the **User login** audit logging to ensure full traceability when a support user accesses a sub-tenant. 

## Changes
- Updated audit logic to always include the **target user identity**.
- Fixed an issue where logins via the primary admin (anonymous user) omitted the impersonated user's ID.

---

## Comparison

### Before
Audit entries only displayed the `<managementTenantUserId>$`, missing the context of which sub-tenant user was accessed.
> <img width="2116" height="87" alt="image" src="https://github.com/user-attachments/assets/85eb1bfd-a0d5-475b-8494-a3675f67628b" />

### After
Audit entries now explicitly record the identity of the chosen target user, ensuring a complete audit trail.
> 
<img width="2121" height="100" alt="image" src="https://github.com/user-attachments/assets/031dab1f-2666-403f-890b-cba7523dc445" />


