### PR TITLE
[MTM-61220] Java SDK improved error propagation for authenticated req…

### DIFF
--- a/content/change-logs/platform-services/cumulocity-2026-34-0-java-sdk-error-propagation-authencitaion-request.md
+++ b/content/change-logs/platform-services/cumulocity-2026-34-0-java-sdk-error-propagation-authencitaion-request.md
@@ -14,5 +14,5 @@ build_artifact:
 ticket: MTM-61220
 version: 2026.34.0
 ---
-Fixed an issue where unexpected exceptions during token-authenticated service calls were incorrectly mapped to 401 Unauthorized. The SDK now correctly propagates the original error status and metadata, ensuring accurate debugging and preventing misleading authentication alerts.
+Previously, unexpected exceptions during token-authenticated service calls were incorrectly mapped to "401 Unauthorized". This issue has been fixed. The Java SDK now correctly propagates the original error status and metadata, ensuring accurate debugging and preventing misleading authentication alerts.
 

--- a/content/change-logs/platform-services/cumulocity-2026-34-0-java-sdk-error-propagation-authencitaion-request.md
+++ b/content/change-logs/platform-services/cumulocity-2026-34-0-java-sdk-error-propagation-authencitaion-request.md
@@ -1,0 +1,18 @@
+---
+date: ''
+title: Java SDK improved error propagation for authenticated requests
+product_area: Application enablement & solutions
+change_type:
+  - value: change-2c7RdTdXo4
+    label: Improvement
+component:
+  - value: QWPx3rFfn
+    label: Java SDK
+build_artifact:
+  - value: tc-QHwMfWtBk7
+    label: cumulocity
+ticket: MTM-61220
+version: 2026.34.0
+---
+Fixed an issue where unexpected exceptions during token-authenticated service calls were incorrectly mapped to 401 Unauthorized. The SDK now correctly propagates the original error status and metadata, ensuring accurate debugging and preventing misleading authentication alerts.
+


### PR DESCRIPTION
# PR: Fix misleading 401 mapping for internal SDK exceptions

### Description
Resolved an issue where unexpected internal exceptions (e.g., parsing errors) were caught and incorrectly transformed into a `401 Unauthorized` error.

**Error previously thrown:** `org.springframework.security.authentication.AuthenticationServiceException: Error on login attempt`

### Key Changes:
- **Accurate Error Propagation:** Removed the catch-all block that masked internal failures as authentication issues.
- **Improved Observability:** The SDK now propagates the actual cause of the failure, allowing for faster debugging.
- **Reduced False Positives:** Developers will no longer be misled into investigating token/auth issues when the root cause is an internal service or e.g. parsing error.