### PR TITLE
CIE-5604 - configuring Edge operator

### DIFF
--- a/content/change-logs/edge/edge-2026.0.1-operator-config-cm-name-change.md
+++ b/content/change-logs/edge/edge-2026.0.1-operator-config-cm-name-change.md
@@ -1,0 +1,20 @@
+---
+date: 2026-01-02
+title: Renamed Edge operator ConfigMap to c8yedge-operator-config
+change_type:
+  - value: change-3BQrQ6adS
+    label: API change
+product_area: Edge
+component:
+  - value: component-g7hnfbu4J
+    label: Edge
+build_artifact:
+  - value: tc-nJH2U7g3u
+    label: edge
+ticket: CIE-5604
+version: 2026.0.1
+---
+
+The Kubernetes ConfigMap used to configure the Edge operator for proxy settings and trusted TLS certificates has been renamed from `custom-environment-variables` to `c8yedge-operator-config`.
+
+After upgrading Edge from earlier versions, create a new ConfigMap named `c8yedge-operator-config` and copy the existing configuration from `custom-environment-variables`. Then [restart the Edge operator](/edge/manage-edge/#restart-operator) to apply the changes.

--- a/content/edge/installing-edge-bundle/install-edge-with-edge-operator.md
+++ b/content/edge/installing-edge-bundle/install-edge-with-edge-operator.md
@@ -64,16 +64,16 @@ To configure proxy settings and trusted certificates, create or update a ConfigM
   - `https_proxy` - HTTPS proxy URL
   - `socks_proxy` - SOCKS proxy URL
   - `no_proxy` - Comma-separated list of domain suffixes, IP addresses, or CIDR ranges that bypass the proxy. This must include:
-      - {{< management-tenant >}} and the Edge tenant domain names
-      - Kubernetes Pod CIDR (Cluster pod IP address range)
-      - Kubernetes Service CIDR (Cluster service IP address range)
-      - Any additional domains, hosts or IP addresses that bypass the proxy
-      Example: 
-        `127.0.0.1,::1,localhost,.svc,.cluster.local,cumulocity,<edge domain names, e.g. management-myown.iot.com,myown.iot.com>,<kubernetes cluster IP range, e.g. 10.43.0.0/16>`
+      - {{< management-tenant >}} and the Edge tenant domain names.
+      - Kubernetes Pod CIDR (Cluster pod IP address range).
+      - Kubernetes Service CIDR (Cluster service IP address range).
+      - Any additional domains, hosts or IP addresses that bypass the proxy.
   - `ca.crt` - One or more trusted TLS certificates in PEM format that the Edge operator and the Edge should trust in addition to publicly known certificate authorities. Multiple certificates can be provided by concatenating them into a single PEM bundle.
 
-#### Example c8yedge-operator-config ConfigMap
+#### Apply changes
+After creating or updating the ConfigMap, restart the Edge operator as described in [Restarting the Edge operator](/edge/manage-edge/#restart-operator)
 
+#### Sample ConfigMap
 ```yaml
 apiVersion: v1
 kind: ConfigMap
@@ -92,6 +92,3 @@ data:
   ca.crt: |
     <CERTIFICATES_TO_TRUST>
 ```
-
-#### Apply changes
-After creating or updating the ConfigMap, restart the Edge operator as described in [Restarting the Edge operator](/edge/manage-edge/#restart-operator)

--- a/content/edge/installing-edge-bundle/install-edge-with-edge-operator.md
+++ b/content/edge/installing-edge-bundle/install-edge-with-edge-operator.md
@@ -56,8 +56,8 @@ For more information about the structure and configuration options available in 
 ### Configuring the Edge operator with a proxy and trusted TLS certificates
 
 You can configure the Edge operator to:
-  - Route outbound traffic through a proxy server when deployed behind a proxy
-  - Trust additional TLS certificates for external endpoints
+  - Route outbound traffic through a proxy server when deployed behind a proxy.
+  - Trust additional TLS certificates for external endpoints.
 
 To configure proxy settings and trusted certificates, create or update a ConfigMap named `c8yedge-operator-config` in the `c8yedge` namespace (or the namespace where Edge is deployed) with the required configuration keys described below:
   - `http_proxy` - HTTP proxy URL

--- a/content/edge/installing-edge-bundle/install-edge-with-edge-operator.md
+++ b/content/edge/installing-edge-bundle/install-edge-with-edge-operator.md
@@ -69,7 +69,7 @@ To configure proxy settings and trusted certificates, create or update a ConfigM
       - Kubernetes Service CIDR (Cluster service IP address range)
       - Any additional domains, hosts or IP addresses that should bypass the proxy
       Example: `127.0.0.1,::1,localhost,.svc,.cluster.local,cumulocity,<edge domain names, e.g. management-myown.iot.com,myown.iot.com>,<kubernetes cluster IP range, e.g. 10.43.0.0/16>`
-  - `ca.crt` - One or more certificates in PEM format that the Edge operator and the Edge should trust in addition to the certificates already included in the system trust store. Multiple certificates can be provided by concatenating them into a single PEM bundle.
+  - `ca.crt` - One or more certificates in PEM format that the Edge operator and the Edge should trust in addition to publicly known certificate authorities. Multiple certificates can be provided by concatenating them into a single PEM bundle.
 
 The following example shows a ConfigMap with proxy settings and trusted certificates:
 

--- a/content/edge/installing-edge-bundle/install-edge-with-edge-operator.md
+++ b/content/edge/installing-edge-bundle/install-edge-with-edge-operator.md
@@ -53,40 +53,32 @@ This command will complete immediately, and the installation will proceed in the
 
 For more information about the structure and configuration options available in the Edge CR, see [Edge custom resource](/edge/edge-custom-resource-definition/).
 
-### Configuring the Edge operator with a proxy and trusted TLS/SSL certificates
+### Configuring the Edge operator with a proxy and trusted TLS certificates
 
 You can configure the Edge operator to:
-  - route outbound internet traffic through a proxy server when it is deployed behind a proxy
-  - trust the TLS/SSL certificates presented by external endpoints
+  - Route outbound traffic through a proxy server when deployed behind a proxy
+  - Trust additional TLS certificates for external endpoints
 
-To configure proxy settings and trusted certificates, create or update a ConfigMap in the `c8yedge` namespace (or the namespace where Edge is deployed) with the required configuration keys described below:
-  - `http_proxy` - URL of the HTTP proxy server
-  - `https_proxy` - URL of the HTTPS proxy server
-  - `socks_proxy` - URL of the SOCKS proxy server
-  - `no_proxy` - Comma-separated list of domain suffixes, IP addresses, or CIDR ranges that should bypass the proxy. This list must include:
+To configure proxy settings and trusted certificates, create or update a ConfigMap named `c8yedge-operator-config` in the `c8yedge` namespace (or the namespace where Edge is deployed) with the required configuration keys described below:
+  - `http_proxy` - HTTP proxy URL
+  - `https_proxy` - HTTPS proxy URL
+  - `socks_proxy` - SOCKS proxy URL
+  - `no_proxy` - Comma-separated list of domain suffixes, IP addresses, or CIDR ranges that bypass the proxy. This must include:
       - {{< management-tenant >}} and the Edge tenant domain names
       - Kubernetes Pod CIDR (Cluster pod IP address range)
       - Kubernetes Service CIDR (Cluster service IP address range)
-      - Any additional domains, hosts or IP addresses that should bypass the proxy
-      Example: `127.0.0.1,::1,localhost,.svc,.cluster.local,cumulocity,<edge domain names, e.g. management-myown.iot.com,myown.iot.com>,<kubernetes cluster IP range, e.g. 10.43.0.0/16>`
-  - `ca.crt` - One or more certificates in PEM format that the Edge operator and the Edge should trust in addition to publicly known certificate authorities. Multiple certificates can be provided by concatenating them into a single PEM bundle.
+      - Any additional domains, hosts or IP addresses that bypass the proxy
+      Example: 
+        `127.0.0.1,::1,localhost,.svc,.cluster.local,cumulocity,<edge domain names, e.g. management-myown.iot.com,myown.iot.com>,<kubernetes cluster IP range, e.g. 10.43.0.0/16>`
+  - `ca.crt` - One or more trusted TLS certificates in PEM format that the Edge operator and the Edge should trust in addition to publicly known certificate authorities. Multiple certificates can be provided by concatenating them into a single PEM bundle.
 
-The following example shows a ConfigMap with proxy settings and trusted certificates:
+#### Example c8yedge-operator-config ConfigMap
 
 ```yaml
-##
-## Optional ConfigMap used to configure:
-##   - Proxy settings for accessing external endpoints
-##   - Additional trusted TLS/SSL certificates
-##
-
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  # Name of the ConfigMap
   name: c8yedge-operator-config
-  
-  # Namespace where the Edge operator is installed
   namespace: c8yedge
 data:
   http_proxy: <HTTP Proxy URL>
@@ -96,21 +88,10 @@ data:
   # Comma-separated list of domain suffixes, IP addresses, or CIDR ranges that should bypass the proxy
   no_proxy: 127.0.0.1,::1,localhost,.svc,.cluster.local,cumulocity,<edge domain names, e.g. management-myown.iot.com,myown.iot.com>,<kubernetes cluster IP range, e.g. 10.43.0.0/16>
 
-  # Trusted TLS/SSL certificates in PEM format
+  # Trusted TLS certificates in PEM format
   ca.crt: |
-    <CA_CERTIFICATES_TO_TRUST>
+    <CERTIFICATES_TO_TRUST>
 ```
 
-After creating or updating the ConfigMap, configure the Edge operator to use it by setting the `operatorConfigCMName` Helm value during installation or upgrade:
-```shell
-helm registry login registry.c8y.io --username="<Edge registry username>" --password="<Edge registry password>"
-
-helm upgrade --install c8yedge-operator oci://registry.c8y.io/edge/helm-charts/cumulocity-iot-edge-operator \
-    --version={{< c8y-edge-current-version >}} \
-    --namespace c8yedge \
-    --create-namespace \
-    --set imageCredentials.username="<Edge registry username>" \
-    --set imageCredentials.password="<Edge registry password>" \
-    --set operatorConfigCMName="c8yedge-operator-config" \
-    --wait
-```
+#### Apply changes
+After creating or updating the ConfigMap, restart the Edge operator as described in [Restarting the Edge operator](/edge/manage-edge/#restart-operator)

--- a/content/edge/installing-edge-bundle/install-edge-with-edge-operator.md
+++ b/content/edge/installing-edge-bundle/install-edge-with-edge-operator.md
@@ -55,8 +55,8 @@ For more information about the structure and configuration options available in 
 
 ### Configuring the Edge operator with a proxy and trusted TLS/SSL certificates
 
-You can configure {{< product-c8y-iot >}} Edge operator to:
-  - route outbound internet traffic through the proxy server, when it is deployed behind a proxy server
+You can configure the Edge operator to:
+  - route outbound internet traffic through a proxy server when it is deployed behind a proxy
   - trust the TLS/SSL certificates presented by external endpoints
 
 To configure proxy settings and trusted certificates, create or update a ConfigMap in the `c8yedge` namespace (or the namespace where Edge is deployed) with the required configuration keys described below:
@@ -69,7 +69,7 @@ To configure proxy settings and trusted certificates, create or update a ConfigM
       - Kubernetes Service CIDR (Cluster service IP address range)
       - Any additional domains, hosts or IP addresses that should bypass the proxy
       Example: `127.0.0.1,::1,localhost,.svc,.cluster.local,cumulocity,<edge domain names, e.g. management-myown.iot.com,myown.iot.com>,<kubernetes cluster IP range, e.g. 10.43.0.0/16>`
-  - `ca.crt` - One or more certificates in PEM format that the Edge should trust in addition to the certificates already included in the system trust store. Multiple certificates can be provided by concatenating them into a single PEM bundle.
+  - `ca.crt` - One or more certificates in PEM format that the Edge operator and the Edge should trust in addition to the certificates already included in the system trust store. Multiple certificates can be provided by concatenating them into a single PEM bundle.
 
 The following example shows a ConfigMap with proxy settings and trusted certificates:
 

--- a/content/edge/installing-edge-bundle/install-edge-with-edge-operator.md
+++ b/content/edge/installing-edge-bundle/install-edge-with-edge-operator.md
@@ -84,7 +84,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   # Name of the ConfigMap
-  name: edge-operator-config
+  name: c8yedge-operator-config
   
   # Namespace where the Edge operator is installed
   namespace: c8yedge
@@ -111,6 +111,6 @@ helm upgrade --install c8yedge-operator oci://registry.c8y.io/edge/helm-charts/c
     --create-namespace \
     --set imageCredentials.username="<Edge registry username>" \
     --set imageCredentials.password="<Edge registry password>" \
-    --set operatorConfigCMName="edge-operator-config" \
+    --set operatorConfigCMName="c8yedge-operator-config" \
     --wait
 ```

--- a/content/edge/installing-edge-bundle/install-edge-with-edge-operator.md
+++ b/content/edge/installing-edge-bundle/install-edge-with-edge-operator.md
@@ -55,9 +55,11 @@ For more information about the structure and configuration options available in 
 
 ### Configuring the Edge operator with a proxy and trusted TLS/SSL certificates
 
-When {{< product-c8y-iot >}} Edge is deployed behind a proxy server, the Edge operator must be configured to route outbound internet traffic through the proxy and to trust the TLS/SSL certificates presented by external endpoints.
+You can configure {{< product-c8y-iot >}} Edge operator to:
+  - route outbound internet traffic through the proxy server, when it is deployed behind a proxy server
+  - trust the TLS/SSL certificates presented by external endpoints
 
-To configure proxy settings and additional trusted certificates, create or update a ConfigMap in the `c8yedge` namespace (or the namespace where Edge is deployed) with the required configuration keys:
+To configure proxy settings and trusted certificates, create or update a ConfigMap in the `c8yedge` namespace (or the namespace where Edge is deployed) with the required configuration keys described below:
   - `http_proxy` - URL of the HTTP proxy server
   - `https_proxy` - URL of the HTTPS proxy server
   - `socks_proxy` - URL of the SOCKS proxy server
@@ -65,11 +67,9 @@ To configure proxy settings and additional trusted certificates, create or updat
       - {{< management-tenant >}} and the Edge tenant domain names
       - Kubernetes Pod CIDR (Cluster pod IP address range)
       - Kubernetes Service CIDR (Cluster service IP address range)
-      - any other domains, hosts or IP addresses that should not use the proxy
-      ```shell
-      127.0.0.1,::1,localhost,.svc,.cluster.local,cumulocity,<edge domain names, e.g. management-myown.iot.com,myown.iot.com>,<kubernetes cluster IP range, e.g. 10.43.0.0/16>
-      ```
-To configure additional trusted certificates, add the key `ca.crt` to the same ConfigMap. The value must contain one or more certificates in PEM format that Edge should trust in addition to the certificates already included in the system trust store. Multiple certificates can be provided by concatenating them into a single PEM bundle.
+      - Any additional domains, hosts or IP addresses that should bypass the proxy
+      Example: `127.0.0.1,::1,localhost,.svc,.cluster.local,cumulocity,<edge domain names, e.g. management-myown.iot.com,myown.iot.com>,<kubernetes cluster IP range, e.g. 10.43.0.0/16>`
+  - `ca.crt` - One or more certificates in PEM format that the Edge should trust in addition to the certificates already included in the system trust store. Multiple certificates can be provided by concatenating them into a single PEM bundle.
 
 The following example shows a ConfigMap with proxy settings and trusted certificates:
 

--- a/content/edge/installing-edge-bundle/install-edge-with-edge-operator.md
+++ b/content/edge/installing-edge-bundle/install-edge-with-edge-operator.md
@@ -53,54 +53,64 @@ This command will complete immediately, and the installation will proceed in the
 
 For more information about the structure and configuration options available in the Edge CR, see [Edge custom resource](/edge/edge-custom-resource-definition/).
 
-### Configuring proxy
+### Configuring the Edge operator with a proxy and trusted TLS/SSL certificates
 
-When {{< product-c8y-iot >}} Edge is deployed behind a proxy, it must be configured to communicate with external endpoints over the internet through the proxy server.
-To configure Edge to use a proxy, you must create or update a ConfigMap named `custom-environment-variables` in the c8yedge namespace (or the one you deployed Edge into) with the required proxy settings. The keys `http_proxy`, `https_proxy` and `socks_proxy` must be set to the URLs of the HTTP, HTTPS and Socks proxies, respectively. The key `no_proxy` must be set to specify a comma-separated list of domain suffixes, IP addresses, or CIDR ranges that Edge should bypass the proxy server for.
+When {{< product-c8y-iot >}} Edge is deployed behind a proxy server, the Edge operator must be configured to route outbound internet traffic through the proxy and to trust the TLS/SSL certificates presented by external endpoints.
 
-Here is an example of a ConfigMap with proxy settings:
+To configure proxy settings and additional trusted certificates, create or update a ConfigMap in the `c8yedge` namespace (or the namespace where Edge is deployed) with the required configuration keys:
+  - `http_proxy` - URL of the HTTP proxy server
+  - `https_proxy` - URL of the HTTPS proxy server
+  - `socks_proxy` - URL of the SOCKS proxy server
+  - `no_proxy` - Comma-separated list of domain suffixes, IP addresses, or CIDR ranges that should bypass the proxy. This list must include:
+      - {{< management-tenant >}} and the Edge tenant domain names
+      - Kubernetes Pod CIDR (Cluster pod IP address range)
+      - Kubernetes Service CIDR (Cluster service IP address range)
+      - any other domains, hosts or IP addresses that should not use the proxy
+      ```shell
+      127.0.0.1,::1,localhost,.svc,.cluster.local,cumulocity,<edge domain names, e.g. management-myown.iot.com,myown.iot.com>,<kubernetes cluster IP range, e.g. 10.43.0.0/16>
+      ```
+To configure additional trusted certificates, add the key `ca.crt` to the same ConfigMap. The value must contain one or more certificates in PEM format that Edge should trust in addition to the certificates already included in the system trust store. Multiple certificates can be provided by concatenating them into a single PEM bundle.
+
+The following example shows a ConfigMap with proxy settings and trusted certificates:
 
 ```yaml
 ##
-## An optional ConfigMap to configure the Edge operator with
-##    - Proxy details when accessing external endpoints through a Proxy
-##    - TLS/SSL certificates to trust
-##
-## http_proxy, https_proxy and optionally socks_proxy must be configured with the relevant URLs.
-## no_proxy must be configured with a comma-separated list of addresses or domains for which the proxy should be bypassed.
+## Optional ConfigMap used to configure:
+##   - Proxy settings for accessing external endpoints
+##   - Additional trusted TLS/SSL certificates
 ##
 
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  ## The name is fixed and cannot be changed.
-  name: custom-environment-variables
-  ## Namespace name into which you installed the Edge operator.
+  # Name of the ConfigMap
+  name: edge-operator-config
+  
+  # Namespace where the Edge operator is installed
   namespace: c8yedge
 data:
   http_proxy: <HTTP Proxy URL>
   https_proxy: <HTTPS Proxy URL>
   socks_proxy: <SOCKS Proxy URL>
 
-  ## A comma-separated list of addresses or domains for which the proxy will be bypassed.
-  ## This must be configured with the specified entries, Edge domain name, Kubernetes Pod CIDR (Cluster Pod IP Address Range), 
-  ## Kubernetes Service CIDR (Cluster Service IP Address Range) and any other domains, hosts or IPs 
-  ## you want to bypass the proxy when accessed.
-  no_proxy: 127.0.0.1,::1,localhost,.svc,.cluster.local,cumulocity,<edge domain name, for example, myown.iot.com>,<kubernetes cluster IP range, for example, 10.43.0.0/16>
+  # Comma-separated list of domain suffixes, IP addresses, or CIDR ranges that should bypass the proxy
+  no_proxy: 127.0.0.1,::1,localhost,.svc,.cluster.local,cumulocity,<edge domain names, e.g. management-myown.iot.com,myown.iot.com>,<kubernetes cluster IP range, e.g. 10.43.0.0/16>
 
-  ## TLS/SSL certificates in PEM format that the Edge operator can trust, in addition to those included in the default system trust store.
-  ## You can provide multiple TLS/SSL certificates for trust by combining them into a single string.
-  ca.crt: <CA-CERTIFICATES TO TRUST>
+  # Trusted TLS/SSL certificates in PEM format
+  ca.crt: |
+    <CA_CERTIFICATES_TO_TRUST>
 ```
 
-By configuring Edge with the appropriate proxy settings, you ensure that it can seamlessly communicate with external endpoints through the proxy server, allowing it to function effectively in environments where proxy usage is mandated.
+After creating or updating the ConfigMap, configure the Edge operator to use it by setting the `operatorConfigCMName` Helm value during installation or upgrade:
+```shell
+helm registry login registry.c8y.io --username="<Edge registry username>" --password="<Edge registry password>"
 
-The table below provides more information:
-
-|<div style="width:150px">Field</div>|Required|<div style="width:115px">Type</div>|Default|Description|
-|:---|:---|:---|:---|:---|
-|http_proxy|No|String||Specifies the URL of the HTTP proxy to be used for network connections.|
-|https_proxy|No|String||Specifies the URL of the HTTPS proxy to be used for secure network connections.|
-|socks_proxy|No|String||Specifies the URL of a SOCKS proxy.|
-|no_proxy|No|String||Specifies a comma-separated list of addresses or domains for which the proxy will be bypassed. This is configured with the specified entries, Edge domain name, Kubernetes Pod CIDR (Cluster Pod IP Address Range), Kubernetes Service CIDR (Cluster Service IP Address Range) and any other domains, hosts or IPs you want to bypass the proxy when accessed.|
-|ca.crt|No|String||TLS/SSL certificates in PEM format that the Edge operator can trust, in addition to those included in the default system trust store.<br>You can provide multiple TLS/SSL certificates for trust by combining them into a single string.|
+helm upgrade --install c8yedge-operator oci://registry.c8y.io/edge/helm-charts/cumulocity-iot-edge-operator \
+    --version={{< c8y-edge-current-version >}} \
+    --namespace c8yedge \
+    --create-namespace \
+    --set imageCredentials.username="<Edge registry username>" \
+    --set imageCredentials.password="<Edge registry password>" \
+    --set operatorConfigCMName="edge-operator-config" \
+    --wait
+```

--- a/content/edge/manage-edge-bundle/registry-password.md
+++ b/content/edge/manage-edge-bundle/registry-password.md
@@ -8,7 +8,7 @@ sector:
 
 At some point the credentials you use for the registry might change. In that case, Edge needs to be updated so that it can access the artifacts for any future upgrade.
 
-These credentials are stored as a Kubernetes Secret, and can be updated using `kubectl` command:
+These credentials are stored as a Kubernetes Secret, and can be updated using the `kubectl` command:
 {{< c8y-admon-caution >}}
 Replace the value of the `--docker-server` flag in the command below with your private registry hostname if you installed Edge using a custom registry.
 {{< /c8y-admon-caution >}}

--- a/content/edge/manage-edge-bundle/registry-password.md
+++ b/content/edge/manage-edge-bundle/registry-password.md
@@ -10,7 +10,7 @@ At some point the credentials you use for the registry might change. In that cas
 
 These credentials are stored as a Kubernetes Secret, and can be updated using `kubectl` command:
 {{< c8y-admon-caution >}}
-Replace the value of the --docker-server flag in the command below with your private registry hostname if you installed Edge using a custom registry.
+Replace the value of the `--docker-server` flag in the command below with your private registry hostname if you installed Edge using a custom registry.
 {{< /c8y-admon-caution >}}
 
 ```shell

--- a/content/edge/manage-edge-bundle/registry-password.md
+++ b/content/edge/manage-edge-bundle/registry-password.md
@@ -8,13 +8,17 @@ sector:
 
 At some point the credentials you use for the registry might change. In that case, Edge needs to be updated so that it can access the artifacts for any future upgrade.
 
-These credentials are stored as a secret within the Kubernetes cluster, and can be modified with `kubectl` commands on the environment in which Edge is installed:
+These credentials are stored as a Kubernetes Secret, and can be updated using `kubectl` command:
+{{< c8y-admon-caution >}}
+Replace the value of the --docker-server flag in the command below with your private registry hostname if you installed Edge using a custom registry.
+{{< /c8y-admon-caution >}}
 
 ```shell
-kubectl create secret docker-registry c8yedge-operator-regcred --namespace=c8yedge \
-  --docker-server=registry1.stage.c8y.io \
-  --docker-username=a \
-  --docker-password=b \
+kubectl create secret docker-registry c8yedge-operator-regcred 
+  --namespace=c8yedge \
+  --docker-server=registry.c8y.io \
+  --docker-username=<registry username> \
+  --docker-password=<registry password> \
   --dry-run=client -o yaml | kubectl apply -f -
 ```
 

--- a/content/edge/manage-edge-bundle/registry-password.md
+++ b/content/edge/manage-edge-bundle/registry-password.md
@@ -11,6 +11,11 @@ At some point the credentials you use for the registry might change. In that cas
 These credentials are stored as a secret within the Kubernetes cluster, and can be modified with `kubectl` commands on the environment in which Edge is installed:
 
 ```shell
-kubectl delete secret docker-registry c8yedge-operator-regcred --namespace=c8yedge
-kubectl create secret docker-registry c8yedge-operator-regcred --docker-server=registry.c8y.io --docker-username=<registry username> --docker-password=<registry password> --namespace=c8yedge
+kubectl create secret docker-registry c8yedge-operator-regcred --namespace=c8yedge \
+  --docker-server=registry1.stage.c8y.io \
+  --docker-username=a \
+  --docker-password=b \
+  --dry-run=client -o yaml | kubectl apply -f -
 ```
+
+After updating the secret, restart the Edge operator as described in [Restarting the Edge operator](/edge/manage-edge/#restart-operator)

--- a/static/files/edge/c8yedge.yaml
+++ b/static/files/edge/c8yedge.yaml
@@ -59,23 +59,6 @@ stringData:
   # MONGODB_DATABASE_ADMIN_USER: databaseAdmin
   # MONGODB_DATABASE_ADMIN_PASSWORD: <DB-ADMIN-PASSWORD>
 
----
-##
-## For details, see https://cumulocity.com/docs/2026/edge/installing-edge/#configuring-proxy
-##
-
-# apiVersion: v1
-# kind: ConfigMap
-# metadata:
-  # name: custom-environment-variables
-  # namespace: c8yedge
-# data:
-  # http_proxy: <HTTP Proxy URL>
-  # https_proxy: <HTTPS Proxy URL>
-  # socks_proxy: <SOCKS Proxy URL>
-  # no_proxy: 127.0.0.1,::1,localhost,.svc,.cluster.local,cumulocity,<edge domain name, for example, myown.iot.com>,<kubernetes cluster IP range, for example, 10.43.0.0/16>
-  # ca.crt: <CA-CERTIFICATES TO TRUST>
-
 
 ########################################################################################################################
 ##                                        Defines Edge Custom Resource                                                ##


### PR DESCRIPTION
Update the configuring Edge operator section of the "Edge installation" in a self-managed k8s with the renamed `c8yedge-operator-config`.
As this rename of the ConfigMap is a breaking changes, a release notes is added (though we are almost certain that very few - TSA and may be Edwards use this option currently) for the customers to note when they upgrade Edge to `2026.0.1`.