### PR TITLE
docs(change-logs): DM-6238 [Fix] Retry LwM2M data forwarding when publish fails

### DIFF
--- a/content/change-logs/device-management/lwm2m-agent-1022-1-8-retry-failed-mqtt-publishes.md
+++ b/content/change-logs/device-management/lwm2m-agent-1022-1-8-retry-failed-mqtt-publishes.md
@@ -1,6 +1,6 @@
 ---
 date: ''
-title: Improved reliability of LWM2M data forwarding to MQTT service
+title: Improved reliability of LWM2M data forwarding to the MQTT Service
 product_area: Device management & connectivity
 change_type:
   - value: change-VSkj2iV9m

--- a/content/change-logs/device-management/lwm2m-agent-1022-1-8-retry-failed-mqtt-publishes.md
+++ b/content/change-logs/device-management/lwm2m-agent-1022-1-8-retry-failed-mqtt-publishes.md
@@ -12,13 +12,6 @@ build_artifact:
   - value: tc-ggH2M4hf3
     label: lwm2m-agent
 ticket: DM-6238
-version: 1022.1.8
-environment_availability:
-  - label: eu-latest.cumulocity.com
-  - label: apj.cumulocity.com
-  - label: jp.cumulocity.com
-  - label: emea.cumulocity.com
-  - label: us.cumulocity.com
-  - label: cumulocity.com
+version: 
 ---
 Previously, when the LWM2M service forwarded device data to MQTT service and the publish failed (for example, when the messaging backend was unavailable or quota-limited), the message was dropped and never retried. Failed publishes are now buffered and retried on a scheduled interval, reducing message loss during transient backend outages. The retry queue size, per-message retry cap, and retry interval are configurable.

--- a/content/change-logs/device-management/lwm2m-agent-1022-1-8-retry-failed-mqtt-publishes.md
+++ b/content/change-logs/device-management/lwm2m-agent-1022-1-8-retry-failed-mqtt-publishes.md
@@ -14,4 +14,4 @@ build_artifact:
 ticket: DM-6238
 version: 
 ---
-Previously, when the LWM2M service forwarded device data to MQTT service and the publish failed (for example, when the messaging backend was unavailable or quota-limited), the message was dropped and never retried. Failed publishes are now buffered and retried on a scheduled interval, reducing message loss during transient backend outages. The retry queue size, per-message retry cap, and retry interval are configurable.
+Previously, when the LWM2M service forwarded device data to the MQTT Service and the publish failed (for example, when the messaging backend was unavailable or quota-limited), the message was dropped and never retried. Failed publishes are now buffered and retried on a scheduled interval, reducing message loss during transient backend outages. The retry queue size, per-message retry cap, and retry interval are configurable.

--- a/content/change-logs/device-management/lwm2m-agent-1022-1-8-retry-failed-mqtt-publishes.md
+++ b/content/change-logs/device-management/lwm2m-agent-1022-1-8-retry-failed-mqtt-publishes.md
@@ -1,0 +1,24 @@
+---
+date: ''
+title: Improved reliability of LWM2M data forwarding to MQTT service
+product_area: Device management & connectivity
+change_type:
+  - value: change-VSkj2iV9m
+    label: Fix
+component:
+  - value: component-1KLUzmqfe
+    label: LWM2M
+build_artifact:
+  - value: tc-ggH2M4hf3
+    label: lwm2m-agent
+ticket: DM-6238
+version: 1022.1.8
+environment_availability:
+  - label: eu-latest.cumulocity.com
+  - label: apj.cumulocity.com
+  - label: jp.cumulocity.com
+  - label: emea.cumulocity.com
+  - label: us.cumulocity.com
+  - label: cumulocity.com
+---
+Previously, when the LWM2M service forwarded device data to MQTT service and the publish failed (for example, when the messaging backend was unavailable or quota-limited), the message was dropped and never retried. Failed publishes are now buffered and retried on a scheduled interval, reducing message loss during transient backend outages. The retry queue size, per-message retry cap, and retry interval are configurable.


### PR DESCRIPTION
## Summary
- Adds a change log entry for the LWM2M agent v1022.1.8 fix that retries failed MQTT publishes (DM-6238). Date intentionally left empty pending release scheduling.

Companion to https://github.com/Cumulocity-IoT/c8y-lwm2m/pull/589.

🤖 Generated with [Claude Code](https://claude.com/claude-code)