### PR TITLE
MTM-53765 Clarify that 1-way TLS is always enabled

### DIFF
--- a/content/device-integration/mqtt-bundle/implementation.md
+++ b/content/device-integration/mqtt-bundle/implementation.md
@@ -22,7 +22,10 @@ Port 80 is deactivated in cloud systems.
 {{< /c8y-admon-info >}}
 
 Port 8883 supports two types of SSL: two-way SSL using certificates for client authorization and one-way SSL using username and password for client authorization.
-The two-way SSL support is enabled by default. To disable it please contact [product support](/additional-resources/contacting-support/).
+Both methods are always enabled, and the one that will be used depends on whether the client provides a certificate at connection time.
+If the client provides a certificate, it will be used to authenticate the client.
+Otherwise, the client is expected to provide a username and password for authentication, in the MQTT `CONNECT` packet.
+See [MQTT authentication](#mqtt-authentication) and [device certificates](/device-certificate-authentication/#device-certificates) for more details.
 
 {{< c8y-admon-info >}}
 To use WebSockets you must connect to the path <kbd>/mqtt</kbd> and follow the [MQTT standard](http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/os/mqtt-v3.1.1-os.html#_Toc398718127) for WebSocket communication.


### PR DESCRIPTION
Fixing minor user doc issues for the Data in Motion Quality Afternoon:
* [MTM-53765](https://cumulocity.atlassian.net/browse/MTM-53765) Improve MQTT SSL documentation: A customer was confused about whether 1-way SSL was available. Clarified that both 1-way and 2-way SSL are always enabled, and the one used simply depends on whether the client provides a certificate or not.


[MTM-53765]: https://cumulocity.atlassian.net/browse/MTM-53765?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ