### PR TITLE
Define some messaging concepts for Cumulocity

### DIFF
--- a/content/glossary/c.md
+++ b/content/glossary/c.md
@@ -43,6 +43,13 @@ The child devices relationship is managed via the [Inventory API](https://cumulo
 {{< /c8y-details >}}
 
 
+### Client ID {#client-id}
+
+A unique identifier for a device, client, or gateway connecting to a [protocol adapter](#protocol-adapter).
+The client ID should be unique within a {{< product-c8y-iot >}} [tenant](#tenant).
+For example, devices connecting to the [MQTT Service](#mqtt-service) will use the MQTT client identifier as their client ID.
+
+
 ### Cockpit application {#cockpit-application}
 
 The Cockpit application is one of the default [applications](#application) of {{< product-c8y-iot >}}. It provides a self-service UI to manage and monitor IoT assets and data from a business perspective, like managing [assets](#asset), visualizing data, working with [dashboards](#dashboard) and managing [reports](#report).   

--- a/content/glossary/c.md
+++ b/content/glossary/c.md
@@ -45,7 +45,7 @@ The child devices relationship is managed via the [Inventory API](https://cumulo
 
 ### Client ID {#client-id}
 
-A unique identifier for a device, client, or gateway connecting to a [protocol adapter](#protocol-adapter).
+A client ID is a unique identifier for a device, client, or gateway connecting to a [protocol adapter](#protocol-adapter).
 The client ID must be unique within a {{< product-c8y-iot >}} [tenant](#tenant).
 For example, devices connecting to the [MQTT Service](#mqtt-service) use the MQTT client identifier as their client ID.
 

--- a/content/glossary/c.md
+++ b/content/glossary/c.md
@@ -46,8 +46,8 @@ The child devices relationship is managed via the [Inventory API](https://cumulo
 ### Client ID {#client-id}
 
 A unique identifier for a device, client, or gateway connecting to a [protocol adapter](#protocol-adapter).
-The client ID should be unique within a {{< product-c8y-iot >}} [tenant](#tenant).
-For example, devices connecting to the [MQTT Service](#mqtt-service) will use the MQTT client identifier as their client ID.
+The client ID must be unique within a {{< product-c8y-iot >}} [tenant](#tenant).
+For example, devices connecting to the [MQTT Service](#mqtt-service) use the MQTT client identifier as their client ID.
 
 
 ### Cockpit application {#cockpit-application}

--- a/content/glossary/d.md
+++ b/content/glossary/d.md
@@ -115,6 +115,20 @@ The  device replacement process is centered around the [Identity API](https://{{
 {{< /c8y-details >}}
 
 
+### Device topic {#device-topic}
+
+A device topic is a [topic](#topic) used by a device connected to a [protocol adapter](#protocol-adapter).
+Typically, the topic will describe the type of data being sent and received by the device.
+For example, a metering device connected to the [MQTT Service](#mqtt-service) publishes messages on topics `meters/123456/current` and `meters/123456/temperature`.
+The naming and meaning of device topics is specific to the device type, protocol, and the application using the devices.
+See [Core MQTT topics](/device-integration/mqtt-service/#core-mqtt-topics) for another example of a topic schema used by MQTT devices, in this case devices that use the [SmartREST](#smartrest) device protocol.
+See the [MQTT protocol specification](https://docs.oasis-open.org/mqtt/mqtt/v5.0/os/mqtt-v5.0-os.html#_Toc3901241) for more information about MQTT topics.
+
+{{< c8y-details title="Developer details" >}}
+See [Connecting MQTT devices](/device-integration/mqtt-service/#connecting-devices) for more information about integrating devices with the MQTT Service.
+{{< /c8y-details >}}
+
+
 ### Digital twin {#digital-twin}
 
 A digital twin is a virtual representation of a physical asset or system that is continuously updated with real-time IoT data from connected [devices](#device). This data-driven digital counterpart enables monitoring, analysis, and optimization of physical assets by combining sensor [measurements](#measurement) with business context.  

--- a/content/glossary/d.md
+++ b/content/glossary/d.md
@@ -118,9 +118,10 @@ The  device replacement process is centered around the [Identity API](https://{{
 ### Device topic {#device-topic}
 
 A device topic is a [topic](#topic) used by a device connected to a [protocol adapter](#protocol-adapter).
-Typically, the topic will describe the type of data being sent and received by the device.
+Typically, the topic describes the type of data being sent and received by the device.
 For example, a metering device connected to the [MQTT Service](#mqtt-service) publishes messages on topics `meters/123456/current` and `meters/123456/temperature`.
 The naming and meaning of device topics is specific to the device type, protocol, and the application using the devices.
+
 See [Core MQTT topics](/device-integration/mqtt-service/#core-mqtt-topics) for another example of a topic schema used by MQTT devices, in this case devices that use the [SmartREST](#smartrest) device protocol.
 See the [MQTT protocol specification](https://docs.oasis-open.org/mqtt/mqtt/v5.0/os/mqtt-v5.0-os.html#_Toc3901241) for more information about MQTT topics.
 

--- a/content/glossary/m.md
+++ b/content/glossary/m.md
@@ -43,6 +43,19 @@ Measurements are managed via the [Measurement API](https://cumulocity.com/api/co
 {{< /c8y-details >}}
 
 
+### Messaging Service topic {#messaging-service-topic}
+
+A Messaging Service topic is a [topic](#topic) used by the [Messaging Service](#messaging-service) to pass messages between [protocol adapters](#protocol-adapter), microservices, and internal {{< product-c8y-iot >}} components.
+The Messaging Service uses its own topic namespace, with specific topics used by each of the services supported by the Messaging Service.
+For example, all messages published by devices using the [MQTT Service](#mqtt-service) are delivered to microservices on the `from-device` topic, regardless of the MQTT topic used.
+In this case, the MQTT topic will be passed as a metadata field on the message.
+Other protocol adapters follow the same convention for mapping their [device topics](#device-topic) to Messaging Service topics.
+
+{{< c8y-details title="Developer details" >}}
+See [Integrating with microservice and external applications](/device-integration/mqtt-service/#pulsar-client) for more information about building microservices to work with devices connected to the MQTT Service.
+{{< /c8y-details >}}
+
+
 ### Microfrontend {#microfrontend}
 
 Microfrontend refers to an architectural style for [web applications](#web-application) where the UI is decomposed into smaller, independently deployable [applications](#application) or plugins. {{< product-c8y-iot >}}'s web UI is built on this architecture with the [Web SDK](#web-sdk), allowing a "shell" application (like [Cockpit](#cockpit-application)) to be extended by loading "remote" modules (plugins) from other web applications.

--- a/content/glossary/p.md
+++ b/content/glossary/p.md
@@ -40,6 +40,15 @@ For REST, the processing mode is specified using the `X-Cumulocity-Processing-Mo
 {{< /c8y-details >}}  
 
 
+### Protocol adapter {#protocol-adapter}
+
+A service that allows devices using a specific protocol to connect to the {{< product-c8y-iot >}} platform.
+An adapter is *payload-agnostic*, meaning that it manages the communication with the devices and routes payloads to and from the [Messaging Service](#messaging-service) without translating between the device message format and the {{< product-c8y-iot >}} domain model.
+Contrast this with a [device agent](#device-agent) that does actively translate device messages to and from the {{< product-c8y-iot >}} domain model.
+The [MQTT Service](#mqtt-service) is a good example of a protocol adapter.
+It allows *any* device that uses the MQTT protocol to connect, but the mapping to {{< product-c8y-iot >}} measurements, alarms, etc. much be implemented by a separate microservice.
+
+
 ### Public Preview {#public-preview}
 
 Public Preview denotes a feature release stage in the [Continuous Deployment model](#continuous-deployment) where a new feature is made available to any customer who opts in to use it. Features in this stage are not yet considered generally available as opposed to [Private Preview](#private-preview) and [General Availability](#ga).

--- a/content/glossary/p.md
+++ b/content/glossary/p.md
@@ -42,7 +42,7 @@ For REST, the processing mode is specified using the `X-Cumulocity-Processing-Mo
 
 ### Protocol adapter {#protocol-adapter}
 
-A service that allows devices using a specific protocol to connect to the {{< product-c8y-iot >}} platform.
+A protocol adapter is a service that allows devices using a specific protocol to connect to the {{< product-c8y-iot >}} platform.
 An adapter is *payload-agnostic*, meaning that it manages the communication with the devices and routes payloads to and from the [Messaging Service](#messaging-service) without translating between the device message format and the {{< product-c8y-iot >}} domain model.
 Contrast this with a [device agent](#device-agent) that actively translates device messages to and from the {{< product-c8y-iot >}} domain model.
 The [MQTT Service](#mqtt-service) is a good example of a protocol adapter.

--- a/content/glossary/p.md
+++ b/content/glossary/p.md
@@ -46,7 +46,7 @@ A service that allows devices using a specific protocol to connect to the {{< pr
 An adapter is *payload-agnostic*, meaning that it manages the communication with the devices and routes payloads to and from the [Messaging Service](#messaging-service) without translating between the device message format and the {{< product-c8y-iot >}} domain model.
 Contrast this with a [device agent](#device-agent) that actively translates device messages to and from the {{< product-c8y-iot >}} domain model.
 The [MQTT Service](#mqtt-service) is a good example of a protocol adapter.
-It allows *any* device that uses the MQTT protocol to connect, but a separate microservice must implement the mapping to {{< product-c8y-iot >}} measurements, alarms, and events.
+It allows *any* device that uses the MQTT protocol to connect, but a separate microservice must implement the mapping to {{< product-c8y-iot >}} measurements, alarms, events and other data types.
 
 
 ### Public Preview {#public-preview}

--- a/content/glossary/p.md
+++ b/content/glossary/p.md
@@ -44,9 +44,9 @@ For REST, the processing mode is specified using the `X-Cumulocity-Processing-Mo
 
 A service that allows devices using a specific protocol to connect to the {{< product-c8y-iot >}} platform.
 An adapter is *payload-agnostic*, meaning that it manages the communication with the devices and routes payloads to and from the [Messaging Service](#messaging-service) without translating between the device message format and the {{< product-c8y-iot >}} domain model.
-Contrast this with a [device agent](#device-agent) that does actively translate device messages to and from the {{< product-c8y-iot >}} domain model.
+Contrast this with a [device agent](#device-agent) that actively translates device messages to and from the {{< product-c8y-iot >}} domain model.
 The [MQTT Service](#mqtt-service) is a good example of a protocol adapter.
-It allows *any* device that uses the MQTT protocol to connect, but the mapping to {{< product-c8y-iot >}} measurements, alarms, etc. much be implemented by a separate microservice.
+It allows *any* device that uses the MQTT protocol to connect, but a separate microservice must implement the mapping to {{< product-c8y-iot >}} measurements, alarms, and events.
 
 
 ### Public Preview {#public-preview}

--- a/content/glossary/t.md
+++ b/content/glossary/t.md
@@ -81,3 +81,13 @@ Thick Edge is an informal term for {{< product-c8y-iot >}} Edge, see [{{< produc
 {{< c8y-details title="Developer details" >}}
 thin-edge.io exposes a local {{< product-c8y-iot >}} proxy endpoint to give device components access to the full {{< product-c8y-iot >}} REST API.
 {{< /c8y-details >}}
+
+
+### Topic {#topic}
+
+A channel on which messages are sent and received, by a device connected to a [protocol adapter](#protocol-adapter) or by a microservice using the [Messaging Service](#messaging-service).
+With devices, the topic typically describes the kind of data that is being sent.
+For example, an MQTT device connected to the [MQTT Service](#mqtt-service) might publish messages on topics `meters/123456/current` and `meters/123456/temperature`.
+The Messaging Service uses its own topic namespace for passing messages between protocol adapters, microservices, and internal {{< product-c8y-iot >}} components.
+For example, all messages published by devices using the MQTT Service will be delivered to microservices on the `from-device` topic, regardless of the MQTT topic that was used.
+See [Core MQTT topics](/device-integration/mqtt-service/#core-mqtt-topics) for another example of a topic schema used by MQTT devices, in this case devices that use the [SmartREST](#smartrest) device protocol.

--- a/content/glossary/t.md
+++ b/content/glossary/t.md
@@ -85,9 +85,9 @@ thin-edge.io exposes a local {{< product-c8y-iot >}} proxy endpoint to give devi
 
 ### Topic {#topic}
 
-A channel on which messages are sent and received, by a device connected to a [protocol adapter](#protocol-adapter) or by a microservice using the [Messaging Service](#messaging-service).
-With devices, the topic typically describes the kind of data that is being sent.
-For example, an MQTT device connected to the [MQTT Service](#mqtt-service) might publish messages on topics `meters/123456/current` and `meters/123456/temperature`.
-The Messaging Service uses its own topic namespace for passing messages between protocol adapters, microservices, and internal {{< product-c8y-iot >}} components.
-For example, all messages published by devices using the MQTT Service will be delivered to microservices on the `from-device` topic, regardless of the MQTT topic that was used.
+A channel for messages sent and received by a device connected to a [protocol adapter](#protocol-adapter) or by a microservice using the [Messaging Service](#messaging-service).
+For devices, the topic typically describes the kind of data sent.
+For example, an MQTT device connected to the [MQTT Service](#mqtt-service) publishes messages on topics `meters/123456/current` and `meters/123456/temperature`.
+The Messaging Service uses its own topic namespace to pass messages between protocol adapters, microservices, and internal {{< product-c8y-iot >}} components.
+For example, all messages published by devices using the MQTT Service are delivered to microservices on the `from-device` topic, regardless of the MQTT topic used.
 See [Core MQTT topics](/device-integration/mqtt-service/#core-mqtt-topics) for another example of a topic schema used by MQTT devices, in this case devices that use the [SmartREST](#smartrest) device protocol.

--- a/content/glossary/t.md
+++ b/content/glossary/t.md
@@ -85,7 +85,7 @@ thin-edge.io exposes a local {{< product-c8y-iot >}} proxy endpoint to give devi
 
 ### Topic {#topic}
 
-A channel for messages sent and received by a device connected to a [protocol adapter](#protocol-adapter) or by a microservice using the [Messaging Service](#messaging-service).
+A topic is a channel for messages sent and received by a device connected to a [protocol adapter](#protocol-adapter) or by a microservice using the [Messaging Service](#messaging-service).
 For devices, the topic typically describes the kind of data sent.
 For example, a metering device connected to the [MQTT Service](#mqtt-service) publishes messages on topics `meters/123456/current` and `meters/123456/temperature`.
 The Messaging Service uses its own topic namespace to pass messages between protocol adapters, microservices, and internal {{< product-c8y-iot >}} components.

--- a/content/glossary/t.md
+++ b/content/glossary/t.md
@@ -87,7 +87,7 @@ thin-edge.io exposes a local {{< product-c8y-iot >}} proxy endpoint to give devi
 
 A channel for messages sent and received by a device connected to a [protocol adapter](#protocol-adapter) or by a microservice using the [Messaging Service](#messaging-service).
 For devices, the topic typically describes the kind of data sent.
-For example, an MQTT device connected to the [MQTT Service](#mqtt-service) publishes messages on topics `meters/123456/current` and `meters/123456/temperature`.
+For example, a metering device connected to the [MQTT Service](#mqtt-service) publishes messages on topics `meters/123456/current` and `meters/123456/temperature`.
 The Messaging Service uses its own topic namespace to pass messages between protocol adapters, microservices, and internal {{< product-c8y-iot >}} components.
 For example, all messages published by devices using the MQTT Service are delivered to microservices on the `from-device` topic, regardless of the MQTT topic used.
 See [Core MQTT topics](/device-integration/mqtt-service/#core-mqtt-topics) for another example of a topic schema used by MQTT devices, in this case devices that use the [SmartREST](#smartrest) device protocol.

--- a/content/glossary/t.md
+++ b/content/glossary/t.md
@@ -85,9 +85,6 @@ thin-edge.io exposes a local {{< product-c8y-iot >}} proxy endpoint to give devi
 
 ### Topic {#topic}
 
-A topic is a channel for messages sent and received by a device connected to a [protocol adapter](#protocol-adapter) or by a microservice using the [Messaging Service](#messaging-service).
-For devices, the topic typically describes the kind of data sent.
-For example, a metering device connected to the [MQTT Service](#mqtt-service) publishes messages on topics `meters/123456/current` and `meters/123456/temperature`.
-The Messaging Service uses its own topic namespace to pass messages between protocol adapters, microservices, and internal {{< product-c8y-iot >}} components.
-For example, all messages published by devices using the MQTT Service are delivered to microservices on the `from-device` topic, regardless of the MQTT topic used.
-See [Core MQTT topics](/device-integration/mqtt-service/#core-mqtt-topics) for another example of a topic schema used by MQTT devices, in this case devices that use the [SmartREST](#smartrest) device protocol.
+A topic is a channel for messages sent by one or more _publishers_ and received by one or more _subscribers_.
+Messages are delivered in the same order they were published, and will be reliably delivered to all subscribers.
+In {{< product-c8y-iot >}}, a topic can refer to a [device topic](#device-topic) or a [Messaging Service topic](#messaging-service-topic).


### PR DESCRIPTION
Following up on a suggestion from Ben, define a few more messaging-related concepts in a Cumulocity-centric way. I've reworked Ben's initial proposals for "Client ID" and "Topic", and added a new definition for "Protocol adapter".

I had a long conversation with Gemini to settle on "Protocol adapter" vs. all the other generic names we could use for those components. "Protocol gateway" was another option but we already use "gateway" elsewhere in the glossary with a slightly different meaning, and I didn't want to overload it. Basically want to distinguish between "agents", which explicitly map to and from the C8Y domain model, and "adapters", which just deal with a transport protocol and leave the mapping to something else, decoupled through the Messaging Service. But anyway, I'm open to alternative naming with good justifications.

Nitpick away...