### PR TITLE
fix: Address broken links script false negatives and fix MQTT doc link

### DIFF
--- a/broken-links-script/cypress/e2e/link-checker.cy.js
+++ b/broken-links-script/cypress/e2e/link-checker.cy.js
@@ -25,7 +25,8 @@ describe('Link and Routing Validation - Individual URL Checks', () => {
     // Timeout links
     "https://openjdk.org/jeps/252",
 
-
+    // latlong.net fails to load in Cypress (getting 403)
+    "https://www.latlong.net/",
   ];
 
 

--- a/broken-links-script/cypress/e2e/link-checker.cy.js
+++ b/broken-links-script/cypress/e2e/link-checker.cy.js
@@ -1,6 +1,11 @@
-const urls = require('../../all_links.json');
+const allUrls = require('../../all_links.json');
 
 describe('Link and Routing Validation - Individual URL Checks', () => {
+  const urlsWith = Cypress.env('urlsWith') || null;
+  const urls = urlsWith
+    ? allUrls.filter(item => item.link.includes(urlsWith))
+    : allUrls;
+
   let completedTests = 0;
   const totalTests = urls.length;
 
@@ -109,7 +114,7 @@ describe('Link and Routing Validation - Individual URL Checks', () => {
     );
 
   urls.forEach((item) => {
-    if (isExcluded(item.link)) {
+    if (!urlsWith && isExcluded(item.link)) {
       it.skip(`should validate URL (excluded): ${item.link}`, () => {});
       return;
     }

--- a/broken-links-script/cypress/support/e2e.js
+++ b/broken-links-script/cypress/support/e2e.js
@@ -111,5 +111,11 @@ Cypress.on('uncaught:exception', (err) => {
     if (err.message.includes("Unexpected token '&'")) {
       return false;
     }
+    if (err.message.includes("An unknown error has occurred")) {
+      return false;
+    }
+    if (err.message.includes("Identifier 'OneCloudUtil' has already been declared")) {
+      return false;
+    }
   });
   

--- a/broken-links-script/package.json
+++ b/broken-links-script/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "type": "module",
   "scripts": {
-    "test": "node Extractlinks.js && npx cypress run --browser chrome --headless"
+    "test": "node run.cjs"
   },
   "author": "",
   "license": "ISC",

--- a/broken-links-script/run.cjs
+++ b/broken-links-script/run.cjs
@@ -1,0 +1,16 @@
+#!/usr/bin/env node
+// Wrapper that runs Extractlinks.js then Cypress, forwarding --urls-with=<value>
+// to Cypress via --env urlsWith=<value>.
+const { spawnSync } = require('child_process');
+
+const urlsWithArg = process.argv.find(a => a.startsWith('--urls-with='));
+const urlsWith = urlsWithArg ? urlsWithArg.slice('--urls-with='.length) : null;
+
+const extract = spawnSync('node', ['Extractlinks.js'], { stdio: 'inherit' });
+if (extract.status !== 0) process.exit(extract.status ?? 1);
+
+const cypressArgs = ['cypress', 'run', '--browser', 'chrome', '--headless'];
+if (urlsWith) cypressArgs.push('--env', `urlsWith=${urlsWith}`);
+
+const result = spawnSync('npx', cypressArgs, { stdio: 'inherit' });
+process.exit(result.status ?? 1);

--- a/content/device-integration/mqtt-bundle/implementation.md
+++ b/content/device-integration/mqtt-bundle/implementation.md
@@ -25,7 +25,7 @@ Port 8883 supports two types of SSL: two-way SSL using certificates for client a
 Both methods are always enabled, and the one that will be used depends on whether the client provides a certificate at connection time.
 If the client provides a certificate, it will be used to authenticate the client.
 Otherwise, the client is expected to provide a username and password for authentication, in the MQTT `CONNECT` packet.
-See [MQTT authentication](#mqtt-authentication) and [device certificates](/device-certificate-authentication/#device-certificates) for more details.
+See [MQTT authentication](#mqtt-authentication) and [device certificates](/device-certificate-authentication/device-certificates/) for more details.
 
 {{< c8y-admon-info >}}
 To use WebSockets you must connect to the path <kbd>/mqtt</kbd> and follow the [MQTT standard](http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/os/mqtt-v3.1.1-os.html#_Toc398718127) for WebSocket communication.


### PR DESCRIPTION
- Skip latlong.net in Cypress (anti-bot protection causes false negatives)
- Suppress uncaught JS exceptions from tested pages causing false negatives
- Fix broken device-certificates anchor link in MQTT implementation doc

---

To check only links matching a specific substring (e.g. a domain), bypassing the exclusion list:

```bash
npm test -- --urls-with="latlong.net"
```

This filters the extracted links to only those containing the given text and forces them to be checked even if they appear in the exclusion list.