### PR TITLE
MTM-67112 Add database query execution timeout to service quotas

### DIFF
--- a/content/service-terms/quotas.md
+++ b/content/service-terms/quotas.md
@@ -49,9 +49,12 @@ The quotas listed here reflect the maximum values for the cloud subscriptions un
 
 ### REST API
 
-| Quota                | Type |     Value |
-| -------------------- | ---- | --------: |
-| API request duration | Hard | 5 minutes |
+| Quota                    | Type |     Value |
+| ------------------------ | ---- | --------: |
+| API request duration     | Hard | 5 minutes |
+| Database query execution | Hard | 2 minutes |
+
+The database query execution timeout applies to every individual database query triggered by an API request. This limit is independent of the API request duration timeout.
 
 ### Realtime APIs
 


### PR DESCRIPTION
The platform enforces a 2-minute execution timeout on every individual database query, independent of the existing 5-minute API request timeout. This limit was undocumented, which caused confusion when customers encountered timeout errors on valid but resource-intensive API requests (for example, measurement series aggregation over large date ranges).