### PR TITLE
Fix dataprep changelog (release date and cloned app note)

### DIFF
--- a/content/change-logs/device-management/data-preparation-now-available-in-public-preview.md
+++ b/content/change-logs/device-management/data-preparation-now-available-in-public-preview.md
@@ -29,9 +29,7 @@ Key capabilities include:
 - A rule editor with live testing against sample data before deployment.
 - Draft and deployed states for safe iteration without affecting live traffic.
 
-To enable Data Preparation, open the right drawer (by clicking on your username initials) in the Administration application and select **Manage preview features**. Then activate the toggle next to **Data Preparation**.
-
-If you use a custom or duplicated application (for example, a duplicate of Cockpit or Administration), upgrade to the latest Web SDK or duplicate the application again. Otherwise, the Data Preparation icon does not appear in the app switcher in those applications.
+To enable Data Preparation, open the right drawer (by clicking on your username initials) in the Administration application and select **Manage preview features**. Then activate the toggle next to **Data Preparation**. If you use a custom or duplicated application (for example, a duplicate of Cockpit or Administration), upgrade to the latest Web SDK or duplicate the application again. Otherwise, the Data Preparation icon does not appear in the app switcher in those applications.
 
 For details, see [Data Preparation](/data-preparation/).
 

--- a/content/change-logs/device-management/data-preparation-now-available-in-public-preview.md
+++ b/content/change-logs/device-management/data-preparation-now-available-in-public-preview.md
@@ -1,5 +1,5 @@
 ---
-date: "2026-06-01"
+date: "2026-07-01"
 title: "Data Preparation now available in Public Preview"
 product_area: "Device management & connectivity"
 change_type:
@@ -31,4 +31,7 @@ Key capabilities include:
 
 To enable Data Preparation, open the right drawer (by clicking on your username initials) in the Administration application and select **Manage preview features**. Then activate the toggle next to **Data Preparation**.
 
+If you use any custom or cloned application (for example a clone of Cockpit or Administration), you may need to upgrade to the latest Web SDK or re-clone the application so that the Data Preparation icon appears in the app switcher from those applications. 
+
 For details, see [Data Preparation](/data-preparation/).
+

--- a/content/change-logs/device-management/data-preparation-now-available-in-public-preview.md
+++ b/content/change-logs/device-management/data-preparation-now-available-in-public-preview.md
@@ -31,7 +31,7 @@ Key capabilities include:
 
 To enable Data Preparation, open the right drawer (by clicking on your username initials) in the Administration application and select **Manage preview features**. Then activate the toggle next to **Data Preparation**.
 
-If you use any custom or cloned application (for example a clone of Cockpit or Administration), you may need to upgrade to the latest Web SDK or re-clone the application so that the Data Preparation icon appears in the app switcher from those applications. 
+If you use a custom or duplicated application (for example, a duplicate of Cockpit or Administration), upgrade to the latest Web SDK or duplicate the application again. Otherwise, the Data Preparation icon does not appear in the app switcher in those applications.
 
 For details, see [Data Preparation](/data-preparation/).
 


### PR DESCRIPTION
Updated the release date (it was incorrect - this wasn't released in June!) and added a small but important missing note about dataprpe not showing in the app switcher if your application has an old web sdk version

The specific version required is https://github.com/Cumulocity-IoT/cumulocity-ui/releases/tag/r1023.81.0 but not sure if we should be that detailed, I don't want to make a big deal of it