### PR TITLE
docs: [CDH-6747] Document that empty JSON objects/arrays are omitted

### DIFF
--- a/content/datahub/streaming-lake-ingestion-bundle/using.md
+++ b/content/datahub/streaming-lake-ingestion-bundle/using.md
@@ -570,6 +570,8 @@ The columns represent the [properties of a {{< product-c8y-iot >}} operation](ht
 
 "Null" values are stored as Iceberg "null" values.
 
+Empty JSON objects (`{}`) and empty arrays (`[]`) carry no data to store. They are omitted from the input and treated the same as an absent or "null" property, rather than being converted to a value of the column's data type.
+
 {{< c8y-admon-info >}}
 For more information related to Iceberg data types, please refer to the [Iceberg specification](https://iceberg.apache.org/spec/#semi-structured-types). Note that there are various [structural limits](/service-terms/quotas/) that the service implements to ensure that common upstream query engines can interact with the data produced by the service.
 {{< /c8y-admon-info >}}


### PR DESCRIPTION
## Summary

- Documents that empty JSON objects (`{}`) and empty arrays (`[]`) are omitted from Streaming Lake Ingestion input and treated the same as an absent/`null` property, instead of being coerced into the target column's type.
- Based on the fix in [Cumulocity-IoT/iceflow#1001](https://github.com/Cumulocity-IoT/iceflow/pull/1001) ("omit empty JSON objects/arrays instead of coercing them").

## Where

Added to the "Data types" section of `using.md`, next to the existing note on how `null` values are handled.

## Test plan

- [x] Verified this behavior was previously undocumented (no mention of "empty" anywhere in the Streaming Lake Ingestion bundle).
- [ ] Confirm wording once iceflow#1001 is merged.
