### PR TITLE
Update Edge operator overview with clearer positioning and IT security benefit

### DIFF
--- a/content/edge/edge-introduction-bundle/edge-operator.md
+++ b/content/edge/edge-introduction-bundle/edge-operator.md
@@ -4,7 +4,7 @@ title: Overview
 layout: redirect
 ---
 
-Edge is a single-server variant of the {{< product-c8y-iot >}} platform designed for easy, self-service operations, offering the flexibility to deploy anywhere from a standard local network to fully offline, air-gapped environments. Because it shares the same architecture as the {{< product-c8y-iot >}} cloud, it enables a "develop once, deploy anywhere" approach, allowing cloud-built solutions, customizations, and extensions to be seamlessly ported to the edge.
+Edge is a single-server deployment of the {{< product-c8y-iot >}} platform, designed for simple deployment and self-service operation. It can be deployed anywhere, from a standard local network to fully offline, air-gapped environments. Because it shares the same architecture as the {{< product-c8y-iot >}} cloud, it enables a "develop once, deploy anywhere" approach, allowing cloud-developed solutions, customizations, and extensions to be seamlessly deployed at the edge.
 
 Reasons for using an onsite installation of Edge include:
 

--- a/content/edge/edge-introduction-bundle/edge-operator.md
+++ b/content/edge/edge-introduction-bundle/edge-operator.md
@@ -4,13 +4,14 @@ title: Overview
 layout: redirect
 ---
 
-Edge is a cloud-native solution for the delivery, deployment, and management of the single-server variant of the {{< product-c8y-iot >}} platform. In contrast to the {{< product-c8y-iot >}} platform, which is available in the cloud (for example, using AWS, Azure, or other data centers), Edge is installed in factories, that is, in the same site ("onsite") in which the IoT assets are located.
+Edge is a single-server variant of the {{< product-c8y-iot >}} platform designed for easy, self-service operations, offering the flexibility to deploy anywhere from a standard local network to fully offline, air-gapped environments. Because it shares the exact same architecture as the {{< product-c8y-iot >}} cloud, it enables a "develop once, deploy anywhere" approach where cloud-built solutions, customizations, and extensions can be seamlessly ported to the edge.
 
 Reasons for using an onsite installation of Edge include:
 
 * **Autonomy**: Even if there is no cloud connection, tasks like data collection and data analysis can still be performed.
 * **Data reduction**: Data is analyzed and aggregated close to assets, and thus less data needs to be sent to the cloud.
 * **Reactivity**: Both Edge and the {{< product-c8y-iot >}} platform include real-time streaming analytics engines. However, placing the rule execution in Edge reduces latency, because the round-trip to cloud is omitted.
+* **IT Security**: Processing and storing data locally keeps sensitive information strictly within your own network perimeter, reducing exposure to external threats and simplifying compliance with strict data privacy regulations.
 
 Features of Edge include:
 

--- a/content/edge/edge-introduction-bundle/edge-operator.md
+++ b/content/edge/edge-introduction-bundle/edge-operator.md
@@ -4,7 +4,7 @@ title: Overview
 layout: redirect
 ---
 
-Edge is a single-server variant of the {{< product-c8y-iot >}} platform designed for easy, self-service operations, offering the flexibility to deploy anywhere from a standard local network to fully offline, air-gapped environments. Because it shares the exact same architecture as the {{< product-c8y-iot >}} cloud, it enables a "develop once, deploy anywhere" approach where cloud-built solutions, customizations, and extensions can be seamlessly ported to the edge.
+Edge is a single-server variant of the {{< product-c8y-iot >}} platform designed for easy, self-service operations, offering the flexibility to deploy anywhere from a standard local network to fully offline, air-gapped environments. Because it shares the same architecture as the {{< product-c8y-iot >}} cloud, it enables a "develop once, deploy anywhere" approach, allowing cloud-built solutions, customizations, and extensions to be seamlessly ported to the edge.
 
 Reasons for using an onsite installation of Edge include:
 

--- a/content/edge/edge-introduction-bundle/edge-operator.md
+++ b/content/edge/edge-introduction-bundle/edge-operator.md
@@ -11,7 +11,7 @@ Reasons for using an onsite installation of Edge include:
 * **Autonomy**: Even if there is no cloud connection, tasks like data collection and data analysis can still be performed.
 * **Data reduction**: Data is analyzed and aggregated close to assets, and thus less data needs to be sent to the cloud.
 * **Reactivity**: Both Edge and the {{< product-c8y-iot >}} platform include real-time streaming analytics engines. However, placing the rule execution in Edge reduces latency, because the round-trip to cloud is omitted.
-* **IT Security**: Processing and storing data locally keeps sensitive information strictly within your own network perimeter, reducing exposure to external threats and simplifying compliance with strict data privacy regulations.
+* **IT Security**: Processing and storing data locally keeps sensitive information strictly within your own network perimeter, reducing exposure to external threats and helping meet data sovereignty and regulatory requirements.
 
 Features of Edge include:
 


### PR DESCRIPTION
## Summary

- Rewrites the Edge intro paragraph to highlight self-service operations and the "develop once, deploy anywhere" approach
- Adds **IT Security** as an explicit bullet point reason for onsite deployment (data stays within network perimeter, simplifies compliance)

## Test plan

- [ ] Verify prose renders correctly on the Edge overview page
- [ ] Check shortcodes expand properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)