### PR TITLE
docs(cockpit): update export schedule email default link to login app

### DIFF
--- a/content/cockpit/exports-bundle/managing-exports.md
+++ b/content/cockpit/exports-bundle/managing-exports.md
@@ -170,8 +170,8 @@ Optionally, add the email address of the sender for reply.
 
 Specify the subject of the email. This field is pre-filled, but may be modified.
 
-Enter the actual email message. Available placeholders are {host}, {binaryId}. The default value is "File with exported data can be downloaded from {host}/inventory/binaries/{binaryId}".
-Note that to create a clickable link in the email, you must add "https://" to the link. For example: "A file with exported data can be downloaded from https://{tenant-domain}/inventory/binaries/{binaryId}."
+Enter the actual email message. Available placeholders are {host}, {binaryId}. The default value is "File with exported data can be downloaded from {host}/apps/login/index.html#/?download={binaryId}".
+Note that to create a clickable link in the email, you must add "https://" to the link. For example: "A file with exported data can be downloaded from https://{tenant-domain}/apps/login/index.html#/?download={binaryId}."
 
 {{< c8y-admon-info >}}
 Note that the corresponding emails are sent with "text/html" as the `Content-Type` header.

--- a/content/cockpit/exports-bundle/managing-exports.md
+++ b/content/cockpit/exports-bundle/managing-exports.md
@@ -170,8 +170,8 @@ Optionally, add the email address of the sender for reply.
 
 Specify the subject of the email. This field is pre-filled, but may be modified.
 
-Enter the actual email message. Available placeholders are {host}, {binaryId}. The default value is "File with exported data can be downloaded from {host}/apps/login/index.html#/?download={binaryId}".
-Note that to create a clickable link in the email, you must add "https://" to the link. For example: "A file with exported data can be downloaded from https://{tenant-domain}/apps/login/index.html#/?download={binaryId}."
+Enter the actual email message. Available placeholders are {host}, {binaryId}. The default value is "File with exported data can be downloaded from {host}/apps/public/login/index.html#/?download={binaryId}".
+Note that to create a clickable link in the email, you must add "https://" to the link. For example: "A file with exported data can be downloaded from https://{tenant-domain}/apps/public/login/index.html#/?download={binaryId}."
 
 {{< c8y-admon-info >}}
 Note that the corresponding emails are sent with "text/html" as the `Content-Type` header.


### PR DESCRIPTION
## Summary
- [MTM-67167](https://cumulocity.atlassian.net/browse/MTM-67167) adds a dedicated `?download=` view to the `login` app. Support for the param in `cockpit`/`administration`/`devicemanagement` is deprecated and will be removed after the 2027 yearly release.
- `content/cockpit/exports-bundle/managing-exports.md`: updates the "To schedule an export" section's description of the default email message and its clickable-link example so they point at `{tenant-domain}/apps/public/login/index.html#/?download={binaryId}` instead of the raw `/inventory/binaries/{binaryId}` REST path.

## Context
Companion doc change to the rollout in:
- [cumulocity-ui#12365](https://github.com/Cumulocity-IoT/cumulocity-ui/pull/12365)
- [c8y-docs-ops#1496](https://github.com/Cumulocity-IoT/c8y-docs-ops/pull/1496)
- [cumulocity-agents#1963](https://github.com/Cumulocity-IoT/cumulocity-agents/pull/1963)
- [cumulocity-core#4692](https://github.com/Cumulocity-IoT/cumulocity-core/pull/4692)

## Note
Left two pre-existing, unrelated inaccuracies in this paragraph untouched (out of scope here, flagging for awareness):
- The doc says the default text uses the `{host}` placeholder, but the actual backend default (`cumulocity-core-default.properties`) uses `{tenant-domain}`.
- The "you must add https:// to the link" note may be stale — `ExportEmailBuilder` already forces `https://` on both `{host}` and `{tenant-domain}` substitutions via `forceHttps()`.

## Test plan
- [ ] Docs build/preview renders the updated section correctly


[MTM-67167]: https://cumulocity.atlassian.net/browse/MTM-67167?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ