### PR TITLE
MTM-66671 Announcement regarding deprecation of tenant options in request headers

### DIFF
--- a/content/change-logs/platform-services/cumulocity-2026-230-0-no-tenant-options-as-headers-in-proxy.md
+++ b/content/change-logs/platform-services/cumulocity-2026-230-0-no-tenant-options-as-headers-in-proxy.md
@@ -21,7 +21,7 @@ environment_availability:
   - label: us.cumulocity.com
   - label: cumulocity.com
 ---
-The deprecation of attaching microservices' tenant options as request headers by the microservices proxy was under [Public Preview](/change-logs/?change-type=.change-type-announcement#cumulocity-2025-322-0-deprecation-of-tenant-options-in-request-headers), and is now to Generally Available (GA) for CD versions 2026.230.0 and higher, and will be present in the 2027 annual release.
+The deprecation of attaching microservices' tenant options as request headers by the microservices proxy was under [Public Preview](/change-logs/?change-type=.change-type-announcement#cumulocity-2025-322-0-deprecation-of-tenant-options-in-request-headers), and is now Generally Available (GA) for CD versions 2026.230.0 and higher, and will be present in the 2027 annual release.
 
 Until now, tenant options were attached to each microservice request unless this functionality was explicitly disabled via a feature toggle. The microservice proxy added the tenant options to the request headers and forwarded the request to the respective microservice. This functionality is now disabled per default. Tenant options are longer be attached as headers to requests to microservices. The retrieval of the tenant options remains possible through the endpoint <TENANT_DOMAIN>/application/currentApplication/settings.
 

--- a/content/change-logs/platform-services/cumulocity-2026-230-0-no-tenant-options-as-headers-in-proxy.md
+++ b/content/change-logs/platform-services/cumulocity-2026-230-0-no-tenant-options-as-headers-in-proxy.md
@@ -1,0 +1,33 @@
+---
+date: '2026-07-21'
+title: Tenant options are not attached as headers by microservices proxy 
+product_area: Platform services
+change_type:
+  - value: change-inv-3bw8e
+    label: Announcement 
+component:
+  - value: component-JlFdtOPva
+    label: REST API
+build_artifact:
+  - value: tc-QHwMfWtBk7
+    label: cumulocity
+ticket: MTM-66671 
+version: 2026.230.0
+environment_availability:
+  - label: eu-latest.cumulocity.com
+  - label: apj.cumulocity.com
+  - label: jp.cumulocity.com
+  - label: emea.cumulocity.com
+  - label: us.cumulocity.com
+  - label: cumulocity.com
+---
+The deprecation of attaching microservices' tenant options as headers by the microservices proxy was under [Public Preview](/change-logs/?change-type=.change-type-announcement#cumulocity-2025-322-0-deprecation-of-tenant-options-in-request-headers), and is now to Generally Available (GA) for CD versions 2026.230.0 and higher, and in the 2027 annual release.
+
+Until now, tenant options were attached to each microservice request unless this functionality was explicitly disabled via a feature toggle. The microservice proxy added the tenant options to the request headers and forwarded the request to the respective microservice. This functionality is now disabled per default. Tenant options will no longer be attached as headers to requests to microservices. The retrieval of the tenant options will remain possible through the endpoint <TENANT_DOMAIN>/application/currentApplication/settings.
+
+This change is now present by default. The old behaviour can still be enabled via a feature toggle core.ms-proxy.no-tenant-options-in-headers.
+
+{{< c8y-admon-caution >}}
+Migration from Public Preview to General Availability - action required.
+If you are relying on the attachment of tenant options as headers to the microservice requests, you need to change this behaviour respectively for cumulocity core CD versions higher than 2026.230.0 and 2027 annual release.
+{{< /c8y-admon-caution >}}

--- a/content/change-logs/platform-services/cumulocity-2026-230-0-no-tenant-options-as-headers-in-proxy.md
+++ b/content/change-logs/platform-services/cumulocity-2026-230-0-no-tenant-options-as-headers-in-proxy.md
@@ -17,7 +17,7 @@ environment_availability:
 ---
 The deprecation of attaching microservices' tenant options as request headers by the microservices proxy was under [Public Preview](/change-logs/?change-type=.change-type-announcement#cumulocity-2025-322-0-deprecation-of-tenant-options-in-request-headers), and is now Generally Available (GA) for CD versions 2026.230.0 and higher, and will be present in the 2027 annual release.
 
-Until now, tenant options were attached to each microservice request unless this functionality was explicitly disabled via a feature toggle. The microservice proxy added the tenant options to the request headers and forwarded the request to the respective microservice. This functionality is now disabled by default. Tenant options are longer be attached as headers to requests to microservices. The retrieval of the tenant options remains possible through the endpoint <TENANT_DOMAIN>/application/currentApplication/settings.
+Until now, tenant options were attached to each microservice request unless this functionality was explicitly disabled via a feature toggle. The microservice proxy added the tenant options to the request headers and forwarded the request to the respective microservice. This functionality is now disabled by default. Tenant options are no longer attached as headers to requests to microservices. The retrieval of the tenant options remains possible through the endpoint <TENANT_DOMAIN>/application/currentApplication/settings.
 
 This change is now available by default. The old behaviour can still be enabled via the feature toggle `core.ms-proxy.no-tenant-options-in-headers`.
 

--- a/content/change-logs/platform-services/cumulocity-2026-230-0-no-tenant-options-as-headers-in-proxy.md
+++ b/content/change-logs/platform-services/cumulocity-2026-230-0-no-tenant-options-as-headers-in-proxy.md
@@ -19,7 +19,7 @@ The deprecation of attaching microservices' tenant options as request headers by
 
 Until now, tenant options were attached to each microservice request unless this functionality was explicitly disabled via a feature toggle. The microservice proxy added the tenant options to the request headers and forwarded the request to the respective microservice. This functionality is now disabled by default. Tenant options are no longer attached as headers to requests to microservices. The retrieval of the tenant options remains possible through the endpoint <TENANT_DOMAIN>/application/currentApplication/settings.
 
-This change is now available by default. The old behaviour can still be enabled via the feature toggle `core.ms-proxy.no-tenant-options-in-headers`.
+This change is now available by default.
 
 {{< c8y-admon-caution >}}
 Migration from Public Preview to General Availability - action required.

--- a/content/change-logs/platform-services/cumulocity-2026-230-0-no-tenant-options-as-headers-in-proxy.md
+++ b/content/change-logs/platform-services/cumulocity-2026-230-0-no-tenant-options-as-headers-in-proxy.md
@@ -1,6 +1,6 @@
 ---
 date: '2026-07-21'
-title: Tenant options are not attached as headers by microservices proxy 
+title: Tenant options are not attached as request headers by microservices proxy 
 product_area: Platform services
 change_type:
   - value: change-inv-3bw8e
@@ -21,11 +21,11 @@ environment_availability:
   - label: us.cumulocity.com
   - label: cumulocity.com
 ---
-The deprecation of attaching microservices' tenant options as headers by the microservices proxy was under [Public Preview](/change-logs/?change-type=.change-type-announcement#cumulocity-2025-322-0-deprecation-of-tenant-options-in-request-headers), and is now to Generally Available (GA) for CD versions 2026.230.0 and higher, and in the 2027 annual release.
+The deprecation of attaching microservices' tenant options as request headers by the microservices proxy was under [Public Preview](/change-logs/?change-type=.change-type-announcement#cumulocity-2025-322-0-deprecation-of-tenant-options-in-request-headers), and is now to Generally Available (GA) for CD versions 2026.230.0 and higher, and will be present in the 2027 annual release.
 
-Until now, tenant options were attached to each microservice request unless this functionality was explicitly disabled via a feature toggle. The microservice proxy added the tenant options to the request headers and forwarded the request to the respective microservice. This functionality is now disabled per default. Tenant options will no longer be attached as headers to requests to microservices. The retrieval of the tenant options will remain possible through the endpoint <TENANT_DOMAIN>/application/currentApplication/settings.
+Until now, tenant options were attached to each microservice request unless this functionality was explicitly disabled via a feature toggle. The microservice proxy added the tenant options to the request headers and forwarded the request to the respective microservice. This functionality is now disabled per default. Tenant options are longer be attached as headers to requests to microservices. The retrieval of the tenant options remains possible through the endpoint <TENANT_DOMAIN>/application/currentApplication/settings.
 
-This change is now present by default. The old behaviour can still be enabled via a feature toggle core.ms-proxy.no-tenant-options-in-headers.
+This change is now available per default. The old behaviour can still be enabled via a feature toggle core.ms-proxy.no-tenant-options-in-headers.
 
 {{< c8y-admon-caution >}}
 Migration from Public Preview to General Availability - action required.

--- a/content/change-logs/platform-services/cumulocity-2026-230-0-no-tenant-options-as-headers-in-proxy.md
+++ b/content/change-logs/platform-services/cumulocity-2026-230-0-no-tenant-options-as-headers-in-proxy.md
@@ -1,5 +1,5 @@
 ---
-date: '2026-07-21'
+date: 
 title: Tenant options are not attached as request headers by microservices proxy 
 product_area: Platform services
 change_type:
@@ -14,16 +14,10 @@ build_artifact:
 ticket: MTM-66671 
 version: 2026.230.0
 environment_availability:
-  - label: eu-latest.cumulocity.com
-  - label: apj.cumulocity.com
-  - label: jp.cumulocity.com
-  - label: emea.cumulocity.com
-  - label: us.cumulocity.com
-  - label: cumulocity.com
 ---
 The deprecation of attaching microservices' tenant options as request headers by the microservices proxy was under [Public Preview](/change-logs/?change-type=.change-type-announcement#cumulocity-2025-322-0-deprecation-of-tenant-options-in-request-headers), and is now Generally Available (GA) for CD versions 2026.230.0 and higher, and will be present in the 2027 annual release.
 
-Until now, tenant options were attached to each microservice request unless this functionality was explicitly disabled via a feature toggle. The microservice proxy added the tenant options to the request headers and forwarded the request to the respective microservice. This functionality is now disabled per default. Tenant options are longer be attached as headers to requests to microservices. The retrieval of the tenant options remains possible through the endpoint <TENANT_DOMAIN>/application/currentApplication/settings.
+Until now, tenant options were attached to each microservice request unless this functionality was explicitly disabled via a feature toggle. The microservice proxy added the tenant options to the request headers and forwarded the request to the respective microservice. This functionality is now disabled by default. Tenant options are longer be attached as headers to requests to microservices. The retrieval of the tenant options remains possible through the endpoint <TENANT_DOMAIN>/application/currentApplication/settings.
 
 This change is now available by default. The old behaviour can still be enabled via the feature toggle `core.ms-proxy.no-tenant-options-in-headers`.
 

--- a/content/change-logs/platform-services/cumulocity-2026-230-0-no-tenant-options-as-headers-in-proxy.md
+++ b/content/change-logs/platform-services/cumulocity-2026-230-0-no-tenant-options-as-headers-in-proxy.md
@@ -25,7 +25,7 @@ The deprecation of attaching microservices' tenant options as request headers by
 
 Until now, tenant options were attached to each microservice request unless this functionality was explicitly disabled via a feature toggle. The microservice proxy added the tenant options to the request headers and forwarded the request to the respective microservice. This functionality is now disabled per default. Tenant options are longer be attached as headers to requests to microservices. The retrieval of the tenant options remains possible through the endpoint <TENANT_DOMAIN>/application/currentApplication/settings.
 
-This change is now available per default. The old behaviour can still be enabled via a feature toggle core.ms-proxy.no-tenant-options-in-headers.
+This change is now available by default. The old behaviour can still be enabled via the feature toggle `core.ms-proxy.no-tenant-options-in-headers`.
 
 {{< c8y-admon-caution >}}
 Migration from Public Preview to General Availability - action required.


### PR DESCRIPTION
[This PR is in the context of https://cumulocity.atlassian.net/browse/MTM-66671](https://cumulocity.atlassian.net/browse/MTM-66671)
It documents the transition from PP to GA for the feature to disable attaching of tenant options as request headers by microservices proxy. 

The actual transitions is done in the cumulocity-helm_charts repo: 
* https://github.com/Cumulocity-IoT/cumulocity-helm_charts/pull/587