### PR TITLE
Improve link-checker diagnostics, add fix-broken-links skill, fix cross-version link resolution

### DIFF
--- a/.claude/skills/fix-broken-links/SKILL.md
+++ b/.claude/skills/fix-broken-links/SKILL.md
@@ -1,0 +1,269 @@
+---
+name: fix-broken-links
+description: Investigate a Link Checker GitHub Actions workflow run (from a run URL, the current branch/PR, or a filed link-checker issue), find the root cause of each reported broken link, and fix it - by editing content, config.cjs (excludedLinks/resourceMocks), the cypress exception list, or the checker scripts themselves. Use when the user asks to investigate or fix broken links, a link-checker issue, or a failing/failed Link Checker workflow run.
+---
+
+# Fix Broken Links
+
+You are investigating one run of the `Link Checker` GitHub Actions workflow
+(`.github/workflows/link-checker.yml`), root-causing every reported failure,
+and fixing what's fixable - while also looking for chances to make the
+checker itself (`broken-links-script/`) more reliable so the same class of
+failure doesn't recur.
+
+Read `broken-links-script/README.md` first for how the checker works
+mechanically (extraction, Cypress validation, `config.cjs` knobs, local run
+commands). This skill assumes that context and focuses on the investigation
+and fix workflow, which the README intentionally does not cover in depth.
+
+## Step 0: Resolve the target run
+
+Figure out which workflow run to investigate, in this priority order:
+
+1. **User gave a direct link or run ID** - use it as-is.
+2. **User gave a link-checker GitHub issue** (title like "Weekly Link Check
+   Failed for `<branch>`") - the issue body contains the run URL. Fetch the
+   issue with `gh issue view <number>` to get it.
+3. **Neither given, infer from context**:
+   - If the current branch matches `no-issue_Fix-broken-links-in-<target>-on-<date>`,
+     `<target>` is the branch that was failing (`develop`, `release/y2025`,
+     `release/y2026`, ...) - find the relevant run with:
+     `gh run list --workflow "Link Checker" --branch <target> --limit 5`
+   - If there's an open PR on the current branch with the `broken-link-check`
+     label, look for the run tied to the PR-comment trigger instead
+     (`gh pr view --json comments` or `gh run list --workflow "Link Checker"`
+     filtered to the PR's head branch).
+   - Otherwise ask the user which run/branch to investigate rather than
+     guessing - do not silently pick an arbitrary run.
+
+Confirm the resolved run and target branch back to the user in one line
+before proceeding.
+
+## Step 1: Gather the failure data
+
+For the resolved run:
+
+```bash
+gh run view <run-id> --log-failed
+```
+
+and/or download the full log artifact (kept 8 days, named
+`cypress-log-<branch>`, sanitized `/` -> `-`):
+
+```bash
+gh run download <run-id> -n cypress-log-<sanitized-branch>
+```
+
+From the log, extract every failing URL and its failure mode. Failed tests
+end with `should validate URL: <url>:` - grep for that pattern to get a
+clean list. For each failing URL, also find the source Markdown file(s) - the
+test output includes `Cypress.env('sourceFiles', ...)`, so the failure
+message names the file(s) that link came from; cross-check against
+`broken-links-script/all_links.json` (regenerate it locally with
+`node Extractlinks.js` if it's not already present) if the log doesn't make
+the source obvious.
+
+If a PR-comment run exists for this failure, `broken-links-script/summarize-failures.cjs`
+already produced a compact "N of M failed" list with URLs - that's a fast
+way to get the failing-URL list without re-parsing the raw log yourself.
+
+Build a checklist of every distinct failing URL before triaging any of
+them - triage each one independently; don't stop at the first plausible
+explanation if several URLs are failing for unrelated reasons.
+
+## Step 2: Triage each failure
+
+For every failing URL, work out which case it is. Do not pattern-match on
+error text alone - confirm with evidence (curl, diagnostics mode, or reading
+the source Markdown) before deciding, especially before touching shared
+config that affects other links.
+
+### Case 1: The link is genuinely broken
+
+The target page 404s, DNS fails, or otherwise doesn't exist/isn't reachable
+in any environment. **Fix:** edit the source Markdown file to point at the
+correct URL (or remove the link if there's no longer a valid target).
+
+### Case 2: Fragment (`#section`) check fails
+
+The base page loads but the named anchor isn't found. Check whether:
+
+- the fragment/anchor name changed on the target page,
+- it's a GitHub link where the `user-content-` prefix handling matters,
+- the anchor was simply renamed or removed upstream.
+
+**Fix:** update the fragment in the source Markdown to match reality. Only
+exclude the link if the fragment truly cannot be resolved any other way.
+
+### Case 3: Works in a browser, times out in Cypress, and it's the *link's own* request/page that's blocked
+
+Distinguish this from Case 4 (below) carefully - they look similar but the
+fix is different:
+
+- **This case (Case 3)**: the link's own request/page-load is what
+  hangs or fails, with no separate sub-resource involved.
+- **Case 4**: the *link* responds fine, but the page it points to pulls in
+  some *other* (third-party) resource that hangs and blocks Cypress's `load`
+  event.
+
+Telltale sign of Case 3: **inconsistency across otherwise-identical runs or
+branches** - the same URL passes cleanly on one branch/run and fails
+completely on a sibling branch/run around the same time, or passes fast via
+`curl`/locally but times out only in CI. This pattern matches
+IP-reputation-based blocking of GitHub Actions' ephemeral runner IPs by the
+target site, not a real problem with the content. Retries won't help since
+the block persists for the whole job lifetime.
+
+To confirm Case 3 rather than Case 1 or Case 4:
+
+1. `curl -w '%{http_code} %{time_total}\n' -o /dev/null <url>` - fast/correct
+   here rules out "genuinely broken" but not Case 3 vs Case 4.
+2. Dispatch the workflow with `branch` + `urlsWith` + `diagnostics=true` on
+   the failing branch (see Step 3 below) to get a real CI data point.
+3. Compare against sibling branches/runs at the same time
+   (`gh run list --workflow "Link Checker"`, then
+   `gh run view <id> --log-failed`) - if the same URL passed cleanly on a
+   sibling job in the same run, that's strong evidence of runner-specific
+   blocking rather than a real content problem. In diagnostics-mode runs,
+   each job also logs a `runner-egress-ip` entry once - if the failing job's
+   IP differs from a passing sibling's, or turns up again on a later failing
+   run, that's a much more direct signal of IP-reputation blocking than
+   inferring it from timing alone.
+4. Check retry timing in the failed job's log: consistent spacing at exactly
+   the configured timeout on every attempt indicates a hard per-job block
+   (Case 3); a mix of fast passes and occasional slow attempts looks more
+   like genuine transient flakiness (still Case 3-ish, but worth noting in
+   the fix comment).
+
+**Fix:** add the URL to `excludedLinks` in `broken-links-script/config.cjs`,
+with a comment explaining why (site blocks automation / rate-limits /
+IP-reputation blocks CI runners specifically).
+
+### Case 4: Page loads but hangs on an unrelated third-party sub-resource
+
+The link's own URL responds quickly and correctly (verify with the `curl`
+timing above and/or diagnostics mode), but `cy.visit()` still times out
+waiting for `load` because the page embeds something slow/unreachable from
+CI (analytics, a widget, a tracking pixel). Also reach for this case when a
+link fails only in CI and doesn't reproduce locally at all - GitHub Actions
+runners have different network egress than a laptop.
+
+Confirm with diagnostics mode (Step 3) before mocking anything - it logs
+every network request's start/completion (a hang shows as a
+`network-start`/`request-start` entry with no matching `-done` entry) plus
+console errors/uncaught exceptions.
+
+**Fix:** add an entry to `resourceMocks` in `config.cjs`, matching the
+sub-resource's pattern (not the link's own URL), with a `reason` explaining
+what was hanging and why. If one specific link actually needs the real
+resource, use that mock's `overrides` array instead of weakening it for
+everyone. Do not add a mock here unless you've confirmed the failing
+resource is genuinely unrelated to the link's own validity.
+
+### Case 5: Harmless JavaScript exception on a `cumulocity.com` page
+
+Uncaught exceptions on any page outside `ownDomains` (`config.cjs`) are
+already tolerated automatically regardless of message text - nothing to do
+there. This case only applies when the exception happens on a
+**`cumulocity.com`-domain** page, the page still loads correctly, and the
+error is unrelated to link validity.
+
+**Fix:** add a message-matching entry to `cypress/support/e2e.js`'s
+`Cypress.on('uncaught:exception', ...)` handler, with the match narrow
+enough not to swallow real failures. Never add an entry for a third-party
+page (already handled) or for anything that looks like a real content or
+navigation failure.
+
+### Not a case above: a systemic/tooling gap
+
+If a failure doesn't fit Cases 1-5 - e.g. a new Hugo shortcode isn't
+resolved by `Extractlinks.js`'s `shortcodeMapping`, a new downloadable file
+extension isn't in `nonHtmlExtensions` in `cypress/e2e/link-checker.cy.js`,
+or the extraction/validation logic mishandles a URL shape it's never seen
+before - fix the script logic itself rather than working around it with
+config. Note these clearly to the user as a checker-reliability improvement,
+since they usually indicate other, not-yet-hit links share the same gap.
+
+## Step 3: Confirm with diagnostics mode when needed
+
+For Cases 3 and 4, don't guess from error text alone - dispatch the
+workflow with diagnostics on to get real evidence:
+
+```bash
+gh workflow run "Link Checker" \
+  -f branch=<failing-branch> \
+  -f urlsWith=<substring narrowing to just the failing URL(s)> \
+  -f diagnostics=true
+```
+
+Then pull the `cypress-log-<branch>` artifact from that run, or grep the log
+for `[DIAGNOSTIC]`. Each match is one JSON object (a `[DIAGNOSTIC]` prefix
+followed by `{type, link, url, ...}`) - extract and inspect them with:
+
+```bash
+grep '\[DIAGNOSTIC\]' cypress-output.log | sed 's/^.*\[DIAGNOSTIC\] //' | jq -s '.'
+```
+
+Entry `type`s: `network-start`/`network-done` (browser sub-resources during
+`cy.visit()`), `request-start`/`request-done` (the checker's own
+`cy.request()` calls), `console`, `uncaught-exception`, and one
+`runner-egress-ip` entry per job. This covers every network request's
+start/completion and console errors/uncaught exceptions, without changing
+pass/fail behavior.
+
+## Step 4: Look for the reliability angle, not just the one-off fix
+
+Once every individual failure is triaged, step back and check for patterns
+across the whole set:
+
+- Do several failures share a root cause (same third-party domain, same
+  shortcode, same file-extension category)? One `resourceMocks`/
+  `excludedLinks`/script fix may cover all of them instead of one entry per
+  URL.
+- Did the checker itself misreport something (wrong source file, wrong
+  resolved URL, a shortcode resolving incorrectly)? That's a bug in
+  `Extractlinks.js` or `cypress/e2e/link-checker.cy.js`, not a content or
+  config issue - fix it there so future runs don't need the same manual
+  triage.
+- Is `excludedLinks` or `resourceMocks` accumulating entries that no longer
+  have a clear reason attached? Flag stale-looking entries to the user
+  rather than leaving them for the next investigation to puzzle over.
+
+Call these out explicitly in your summary even if you don't end up changing
+anything, so the human maintainer knows what you considered.
+
+## Step 5: Apply and verify fixes
+
+1. Apply each fix in its correct location (source Markdown, `config.cjs`,
+   `cypress/support/e2e.js`, or the checker scripts).
+2. Re-run locally to confirm the specific fix:
+   `node Extractlinks.js && npx cypress run --browser chrome --headless`,
+   optionally narrowed with `--urls-with=<substring>` via
+   `node run.cjs --urls-with=<substring>`.
+3. If the fix touched `excludedLinks`, `resourceMocks`, the exception
+   handler, or script logic (as opposed to a single link's own content), run
+   the full unfiltered suite at least once before considering it safe -
+   locally if time allows, otherwise via `gh workflow run "Link Checker" -f branch=<branch>`
+   with no `urlsWith`.
+
+## Step 6: Branch and PR
+
+Once fixes are ready to commit:
+
+1. Create a branch named
+   `no-issue_Fix-broken-links-in-<target>-on-<YYYY-MM-DD>`, where `<target>`
+   is the branch that was actually failing (`develop`, `y2025`, `y2026`, ...
+   - matching the naming used for `release/y2025` etc., but without the
+   `release/` prefix) and the date is today's date. Confirm the current
+   branch doesn't already match this convention for the same target/date
+   before creating a new one (it may already have been created for this
+   investigation).
+2. Apply the fixes as commits on that branch.
+3. Open a PR against `develop` (or the target release branch, if the
+   failures are specific to a release branch and shouldn't go through
+   `develop`) summarizing, per fix: which URL/case it was, the root cause,
+   and where the fix landed (content vs. `config.cjs` vs. exception list vs.
+   script). Call out any reliability-angle findings from Step 4 that weren't
+   acted on, so a maintainer can decide on them separately.
+
+Always confirm with the user before pushing the branch or opening the PR.

--- a/.claude/skills/fix-broken-links/SKILL.md
+++ b/.claude/skills/fix-broken-links/SKILL.md
@@ -84,6 +84,22 @@ The target page 404s, DNS fails, or otherwise doesn't exist/isn't reachable
 in any environment. **Fix:** edit the source Markdown file to point at the
 correct URL (or remove the link if there's no longer a valid target).
 
+If the correct replacement isn't obvious - e.g. a marketing/campaign
+landing page, a private-preview access form, or anything else you can't
+confidently re-derive from the docs site's own structure - do not guess at
+a replacement URL. Instead:
+
+1. Find who originally added the link:
+   `git log --all --follow -S'<distinctive part of the URL>' --format="%H %an %ad" -- <file>`,
+   then resolve their GitHub handle for that commit:
+   `gh api repos/<owner>/<repo>/commits/<hash> -q '.author.login'`.
+2. Leave the link in place, but add an HTML comment directly after it in
+   the Markdown flagging the issue, e.g.:
+   `<!-- TODO(<github-handle>): This link returned 404 as of <date> (Link Checker run <run-url>). Please verify/update. -->`
+3. Once the PR is open (Step 6), add an inline review comment on that exact
+   line tagging the person and briefly explaining what needs verifying:
+   `gh api repos/<owner>/<repo>/pulls/<pr-number>/comments -f commit_id=<head-sha> -f path=<file> -F line=<line-number> -f side=RIGHT -f body="@<github-handle> this link 404s as of <date> - could you confirm the correct URL (or that it should be removed)?"`
+
 ### Case 2: Fragment (`#section`) check fails
 
 The base page loads but the named anchor isn't found. Check whether:
@@ -265,5 +281,8 @@ Once fixes are ready to commit:
    and where the fix landed (content vs. `config.cjs` vs. exception list vs.
    script). Call out any reliability-angle findings from Step 4 that weren't
    acted on, so a maintainer can decide on them separately.
+4. If any fix left a Case 1 TODO comment for the original author to verify
+   (see Case 1 above), add the inline PR review comment tagging them once
+   the PR exists and you have its number and head SHA.
 
 Always confirm with the user before pushing the branch or opening the PR.

--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -93,10 +93,17 @@ jobs:
           if [ -n "$URLS_WITH_INPUT" ]; then
             args+=("--urls-with=$URLS_WITH_INPUT")
           fi
+          : > cypress-output.log
           if [ "$DIAGNOSTICS_INPUT" = "true" ]; then
             args+=("--diagnostics")
+            # Runner IP is stamped once per job so Case 3 (IP-reputation
+            # blocking) can be confirmed by diffing this value across
+            # sibling branch runs in the same workflow run, instead of
+            # inferring it purely from retry timing.
+            egress_ip=$(curl -s --max-time 5 https://ifconfig.me || echo "unknown")
+            echo "[DIAGNOSTIC] {\"type\":\"runner-egress-ip\",\"branch\":\"${{ matrix.branch }}\",\"ip\":\"$egress_ip\"}" | tee -a cypress-output.log
           fi
-          npm test -- "${args[@]}" 2>&1 | tee cypress-output.log
+          npm test -- "${args[@]}" 2>&1 | tee -a cypress-output.log
 
       - name: Upload Cypress log
         if: always()

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ pdf-generator/node_modules/
 CLAUDE.md
 broken-links-script/cypress-output.log
 broken-links-script/pr-comment.md
+broken-links-script/all_links.json

--- a/broken-links-script/Extractlinks.js
+++ b/broken-links-script/Extractlinks.js
@@ -102,7 +102,17 @@ const resolveFullUrl = (link, relativePath, fileContent) => {
   if (/^https?:\/\//i.test(resolvedLink)) {
     return resolvedLink;
   }
-  return `${BASE_URL.replace(/\/$/, "")}/${resolvedLink.replace(/^\//, "")}`;
+  // A link written with a leading "/" is root-relative (a shared page like
+  // "/legal-notices/..." or a cross-version reference like
+  // "/2025/edge-kubernetes/...") and resolves against the unversioned site
+  // root, not this branch's own version prefix - prefixing both would
+  // produce an invalid doubled path like ".../docs/2026/2025/...". Only
+  // links without a leading slash are meant to resolve against BASE_URL.
+  if (resolvedLink.startsWith("/")) {
+    const rootUrl = BASE_URL.replace(/\/\d{4}$/, "");
+    return `${rootUrl}${resolvedLink}`.replace(/([^:]\/)\/+/g, '$1');
+  }
+  return `${BASE_URL.replace(/\/$/, "")}/${resolvedLink}`;
 };
 
 (() => {

--- a/broken-links-script/README.md
+++ b/broken-links-script/README.md
@@ -147,7 +147,7 @@ All optional - omit all of them to reproduce the default scheduled run.
 | --- | --- |
 | `branch` | Check only this branch instead of the default matrix |
 | `urlsWith` | Only check links containing this substring |
-| `diagnostics` | Verbose network + console logging (see "Case 5" below) |
+| `diagnostics` | Verbose network + console logging (see "Investigating and fixing a failing run" below) |
 
 ### Branches checked
 
@@ -247,7 +247,8 @@ mocked response instead of hitting the real network:
   this particular link — let it hit the real network."
 
 Only add a mock here once you've confirmed the flaky resource is genuinely
-unrelated to the link's own validity (see "Case 5" below for how to confirm
+unrelated to the link's own validity (see "Investigating and fixing a
+failing run" below, or the `fix-broken-links` skill, for how to confirm
 this) — don't reach for this to paper over an actually broken link.
 
 ### 3. Add known browser exceptions
@@ -311,178 +312,40 @@ const nonHtmlExtensions = ['.txt', '.json', '.pdf'];
 
 Use this when a link points to a file rather than a web page.
 
-## How to handle failing links
+## Investigating and fixing a failing run
 
-When a test fails, first identify the type of failure.
+When a link-check issue is filed or a run fails, the failure needs to be
+triaged (is the link actually broken? does it just fail in CI? is a
+third-party page throwing a harmless error?) before deciding where to apply
+a fix - in the Markdown content, `excludedLinks`, `resourceMocks`, the
+Cypress exception list, or the checker scripts themselves.
 
-### Case 1: The link is actually broken
+If you're working with Claude Code, the `fix-broken-links` skill
+(`.claude/skills/fix-broken-links/SKILL.md`) automates this: point it at a
+workflow run (or let it infer one from the current branch/PR/issue) and it
+will fetch the run's logs, triage each failure, apply the appropriate fix,
+and open a PR.
 
-Fix the link in the source Markdown file shown in the test output.
+To do it by hand, use the workflow's **diagnostics mode** to get real
+evidence instead of guessing from error text - dispatch "Link Checker"
+manually with `branch` (the failing branch), `urlsWith` (a substring
+narrowing it to the failing URL(s)), and `diagnostics: true`. This logs:
 
-The test already includes source file information using:
+* every network request's start/completion, for both browser sub-resources
+  during `cy.visit()` and the checker's own `cy.request()` calls (so a hang
+  shows as a `network-start`/`request-start` entry with no matching `-done`)
+* console errors/uncaught exceptions from the visited page
+* the runner's own egress IP, once per job - useful for confirming an
+  IP-reputation block (a failing branch's IP differs from a sibling
+  branch's, or matches a previously-blocked IP)
 
-```js
-Cypress.env('sourceFiles', item.files);
+without changing pass/fail behavior. Each diagnostic entry is logged as its
+own line, prefixed `[DIAGNOSTIC]` and followed by a JSON object (type,
+url/link, timestamps, status codes, etc.) - pull the results from the run's
+`cypress-log-<branch>` artifact (kept 8 days), or extract and parse them
+locally:
+
+```bash
+grep '\[DIAGNOSTIC\]' cypress-output.log | sed 's/^.*\[DIAGNOSTIC\] //' | jq -s '.'
 ```
-
-So the error message should help trace where the link came from.
-
-### Case 2: The link works manually but times out in Cypress
-
-If the site is slow, blocks bots, or is unstable, add it to `excludedLinks` in `config.cjs`.
-
-Add a short comment explaining why.
-
-Example:
-
-```js
-// Site blocks automation requests
-"https://example.com/protected-page",
-```
-
-### Case 3: The page loads but throws harmless JavaScript errors
-
-If this is on a third-party page (anything outside `cumulocity.com`),
-nothing to do - it's already tolerated automatically regardless of message
-text (see item 3 above). Only add an entry to `cypress/support/e2e.js` if
-the error is happening on a **`cumulocity.com`** page:
-
-```js
-if (err.message.includes('Some known harmless error on our own docs site')) {
-  return false;
-}
-```
-
-Only do this if the page still loads and the link is valid.
-
-### Case 4: Fragment check fails
-
-If the link contains `#fragment`, verify whether:
-
-* the fragment is correct
-* the target page still contains that anchor
-* the anchor name has changed
-* GitHub adds `user-content-` prefix handling
-
-If the page structure changed, update the source link instead of excluding it.
-
-### Case 5: The page loads but hangs on an unrelated third-party resource
-
-If `cy.visit()` times out waiting for `load`, but the URL itself responds
-quickly and correctly (check with `curl -w '%{http_code} %{time_total}'`),
-the page it points to is probably pulling in a slow/unreachable third-party
-resource (analytics, an embed, a tracking pixel) that blocks `load` even
-when it has nothing to do with the link being valid - or the page throws a
-console error/uncaught exception unrelated to the link's validity. This is
-also the case to reach for when a link fails only in CI and you can't
-reproduce it locally at all (different network egress on GitHub Actions
-runners than a local machine is a common cause).
-
-Use the workflow's **diagnostics mode** to confirm before mocking anything -
-no code changes needed. Dispatch the "Link Checker" workflow manually with:
-
-* `branch` set to the branch the failing link lives on
-* `urlsWith` set to a substring that narrows it down to just that URL (or a
-  small handful)
-* `diagnostics` set to `true`
-
-This logs every network request's start/completion (so a hang shows as a
-`START` with no matching `DONE`), plus any `console.error`/`console.warn`
-calls and uncaught exceptions from the page - all without changing pass/fail
-behavior. Grab the results either from the run's `cypress-log-<branch>`
-artifact (uploaded on every run, kept for 8 days) or by grepping the run's
-logs for `[DIAGNOSTIC]`.
-
-Once you've identified the exact resource or error, add it to
-`resourceMocks` in `config.cjs` (see item 2 above) rather than excluding the
-link.
-
-(For reference, the underlying instrumentation lives in
-`cypress/e2e/link-checker.cy.js` behind the `DIAGNOSTICS` flag -
-`applyDiagnosticNetworkLogging` and `visitWithDiagnostics` - in case it ever
-needs extending, e.g. to capture something beyond network/console activity.)
-
-### Case 6: The target URL itself is intermittently blocked (not a sub-resource)
-
-Easy to confuse with Case 5, but the fix is different, so check which one
-you actually have first:
-
-* **Case 5** (`resourceMocks` in `config.cjs`): the *link's own* response is fine
-  - it's some *other* resource the page pulls in that hangs/fails.
-* **Case 6** (this case, `excludedLinks`): the link's **own** request/page
-  load is what times out or fails - there's no sub-resource to mock, because
-  the thing that's blocked is the thing under test.
-
-The telltale sign of Case 6 is *inconsistency across otherwise-identical
-runs*: the same URL passes fine on one branch/run and fails completely on
-another run at roughly the same time, or passes fast locally/via `curl` but
-times out in CI. This pattern showed up for `logback.qos.ch`: in one
-historical run, `develop` and `release/y2025` passed it in 2-3s while
-`release/y2026` failed all 4 `logback.qos.ch` URLs, each exhausting all 10
-retries spaced ~10.3s apart (the exact request timeout, every single
-attempt). GitHub Actions assigns a fresh ephemeral IP per job - this pattern
-(one job's every single retry fails identically, at exactly the timeout
-duration, while a sibling job at the same time is fine) points to
-IP-reputation-based blocking on the target site's side, not anything wrong
-with our content. Retries don't help here since the block persists for the
-runner's whole job lifetime, so a longer timeout or more retries wouldn't
-fix it either - the only real fix is `excludedLinks`.
-
-To confirm you have Case 6 rather than Case 5 or a real break:
-
-1. `curl -w '%{http_code} %{time_total}\n' -o /dev/null <url>` - if it's
-   fast and correct from outside CI too, that only rules out "genuinely
-   broken," not Case 5 vs Case 6.
-2. Use diagnostics mode (`branch` + `urlsWith` + `diagnostics=true`) on the
-   failing branch to get one real CI-runner data point.
-3. **Look at other branches/runs around the same time** in the workflow run
-   history (`gh run list --workflow "Link Checker"`, then
-   `gh run view <id> --log-failed`) - if the same URL passed cleanly and
-   fast on a sibling matrix job in the very same run, that's strong evidence
-   you're looking at IP/runner-specific flakiness (Case 6), not a real
-   problem in the page's own content or an embedded resource.
-4. Check the retry timing in the failed job's log: consistent spacing at
-   exactly the configured timeout, on every single attempt, indicates a hard
-   per-job block (Case 6). A mix of fast passes and occasional slow/failed
-   attempts is more consistent with genuine transient network flakiness.
-
-Only add to `excludedLinks` once you've confirmed there's no specific
-sub-resource to mock (Case 5) and no content issue (Case 1/4) - this is the
-"nothing else fits" fallback the file's own comment describes it as.
-
-## Recommended maintenance process
-
-When a link-check issue is created:
-
-1. Open the failed workflow run.
-2. Check the failed URL.
-3. Identify the source Markdown file.
-4. If it's not obviously a real broken link/anchor (Case 1/4), don't guess -
-   reproduce with evidence rather than pattern-matching on the error text.
-   Dispatch the workflow with `branch` + `urlsWith` + `diagnostics=true` on
-   the actual failing branch (many of these failures don't reproduce
-   locally at all - CI runners have different network egress than a laptop).
-5. Decide which case it is (see "How to handle failing links" above for the
-   full decision criteria for each):
-
-   * a real broken link or anchor mismatch (Case 1/4)
-   * a timeout/block affecting the **target URL itself**, inconsistent
-     across sibling branches/runs at the same time (Case 6)
-   * a hang caused by an unrelated **sub-resource** on the target page
-     (Case 5)
-   * a harmless JavaScript exception - only actionable if it's on a
-     `cumulocity.com` page (Case 3); everything else is already handled
-6. Apply the fix in the correct place:
-
-   * source Markdown content
-   * `excludedLinks` in `config.cjs` (Case 2/6)
-   * `resourceMocks` in `config.cjs` (Case 5)
-   * exception handling in `cypress/support/e2e.js` (Case 3, `cumulocity.com` only)
-7. Re-run locally to confirm the specific fix.
-8. If the fix touched `excludedLinks`, `resourceMocks`, or the
-   exception-handling logic (as opposed to a single link's content), run the
-   **full, unfiltered** suite at least once (locally if time allows,
-   otherwise via CI dispatch with no `urlsWith` filter) before considering
-   it safe.
-9. Commit and push the fix.
 

--- a/broken-links-script/config.cjs
+++ b/broken-links-script/config.cjs
@@ -42,6 +42,13 @@ module.exports = {
 
     // latlong.net fails to load in Cypress (getting 403)
     "https://www.latlong.net/",
+
+    // oreilly.com's Akamai bot protection returns 403 for automated
+    // requests consistently - reproduced outside CI too (curl gets 403 on
+    // every attempt), and failed on every branch in both the 2026-07-13 and
+    // 2026-07-20 weekly runs. Not CI-specific flakiness - genuine anti-bot
+    // blocking of non-browser clients.
+    /oreilly\.com/,
   ],
 
   // Registry of third-party resources known to cause link-checker flakiness

--- a/broken-links-script/cypress/e2e/link-checker.cy.js
+++ b/broken-links-script/cypress/e2e/link-checker.cy.js
@@ -10,10 +10,15 @@ describe('Link and Routing Validation - Individual URL Checks', () => {
   // Diagnostics mode: verbose network + console logging to investigate a
   // failure that isn't reproducible locally. Enable via the workflow's
   // `diagnostics` dispatch input (combine with `branch` + `urlsWith` to
-  // scope it to one failing case) - see README.md "Case 5".
+  // scope it to one failing case) - see the `fix-broken-links` skill or
+  // README.md "Investigating and fixing a failing run".
   // Cypress coerces --env true/false into real booleans, but env vars set
   // another way could still arrive as the string "true" - handle both.
   const DIAGNOSTICS = String(Cypress.env('diagnostics')) === 'true';
+  // Each entry is a plain object, flushed as one NDJSON line per entry
+  // (see afterEach below) rather than one free-text blob per test - this
+  // lets entries be parsed/aggregated (e.g. grep '[DIAGNOSTIC]' log | sed
+  // 's/^.*\[DIAGNOSTIC\] //' | jq -s '...') instead of only eyeballed.
   let diagnosticLog = [];
   let currentUrl = null;
 
@@ -79,25 +84,44 @@ describe('Link and Routing Validation - Individual URL Checks', () => {
   // response - which, watching every single sub-resource on a page, is
   // routine transient noise unrelated to the link under test. req.on()
   // simply never fires for such a request, which for our purposes reads the
-  // same as a hang (START with no DONE) - the correct signal either way,
-  // without turning an unrelated resource's blip into a false failure.
+  // same as a hang (a 'network-start' entry with no matching 'network-done')
+  // - the correct signal either way, without turning an unrelated resource's
+  // blip into a false failure.
   const applyDiagnosticNetworkLogging = () => {
     if (!DIAGNOSTICS) return;
     cy.intercept('**', (req) => {
       try {
         const start = Date.now();
-        diagnosticLog.push(`START ${req.method} ${req.url}`);
+        diagnosticLog.push({ type: 'network-start', method: req.method, url: req.url, timestamp: new Date().toISOString() });
         req.on('response', (res) => {
           try {
-            diagnosticLog.push(`DONE ${res.statusCode} ${Date.now() - start}ms ${req.url}`);
+            diagnosticLog.push({ type: 'network-done', url: req.url, statusCode: res.statusCode, ms: Date.now() - start, timestamp: new Date().toISOString() });
           } catch (e) {
             // never let logging break the request, but don't lose the exception either
-            diagnosticLog.push(`[diagnostic logger error] ${e.message}`);
+            diagnosticLog.push({ type: 'logger-error', message: e.message, timestamp: new Date().toISOString() });
           }
         });
       } catch (e) {
         // ignore - request proceeds normally either way
       }
+    });
+  };
+
+  // Timing wrapper for cy.request() calls (npm registry lookups, non-HTML
+  // resource checks, GitHub blob-file existence checks, content-type
+  // sniffing). cy.intercept() only sees requests made by the browser
+  // page under test, not cy.request() (which Cypress proxies directly) -
+  // so without this, diagnostics mode saw nothing for any URL that never
+  // reaches a cy.visit(). Transparent pass-through (byte-for-byte
+  // cy.request(options)) when diagnostics is off.
+  const requestWithDiagnostics = (options) => {
+    if (!DIAGNOSTICS) return cy.request(options);
+    const url = typeof options === 'string' ? options : options.url;
+    const start = Date.now();
+    diagnosticLog.push({ type: 'request-start', url, timestamp: new Date().toISOString() });
+    return cy.request(options).then((response) => {
+      diagnosticLog.push({ type: 'request-done', url, statusCode: response.status, ms: Date.now() - start, timestamp: new Date().toISOString() });
+      return response;
     });
   };
 
@@ -116,10 +140,10 @@ describe('Link and Routing Validation - Individual URL Checks', () => {
         const original = win.console[level];
         win.console[level] = (...args) => {
           try {
-            diagnosticLog.push(`console.${level}: ${args.map(String).join(' ')}`);
+            diagnosticLog.push({ type: 'console', level, message: args.map(String).join(' '), timestamp: new Date().toISOString() });
           } catch (e) {
             // never let logging break the page, but don't lose the exception either
-            diagnosticLog.push(`[diagnostic logger error] ${e.message}`);
+            diagnosticLog.push({ type: 'logger-error', message: e.message, timestamp: new Date().toISOString() });
           }
           original.apply(win.console, args);
         };
@@ -188,7 +212,7 @@ describe('Link and Routing Validation - Individual URL Checks', () => {
   // listener (and duplicate log lines) for every URL under test.
   if (DIAGNOSTICS) {
     Cypress.on('uncaught:exception', (err) => {
-      diagnosticLog.push(`uncaught exception: ${err.message}`);
+      diagnosticLog.push({ type: 'uncaught-exception', message: err.message, timestamp: new Date().toISOString() });
     });
   }
 
@@ -230,7 +254,7 @@ describe('Link and Routing Validation - Individual URL Checks', () => {
         const encodedUrl = pkg ? url.replace(pkg, encodeURIComponent(pkg)) : url;
 
         if (pkg) {
-          cy.request({
+          requestWithDiagnostics({
             url: `https://registry.npmjs.org/${pkg}`,
             failOnStatusCode: false,
             headers: { Accept: 'application/vnd.npm.install-v1+json' }
@@ -247,9 +271,9 @@ describe('Link and Routing Validation - Individual URL Checks', () => {
 
       if (isNonHtmlResource) {
         cy.log(`Validating non-HTML resource: ${url}`);
-        cy.request({
+        requestWithDiagnostics({
           url: url,
-          failOnStatusCode: false 
+          failOnStatusCode: false
         }).then((response) => {
           expect(response.status).to.be.oneOf([200, 201, 202, 203, 204, 301, 302, 304]);
   
@@ -300,7 +324,7 @@ describe('Link and Routing Validation - Individual URL Checks', () => {
         const baseUrl = url.split('#')[0];
         const match = url.match(/#L(\d+)/);
         const lineNumber = match ? match[1] : null;
-        cy.request({ url: baseUrl, failOnStatusCode: false }).then((res) => {
+        requestWithDiagnostics({ url: baseUrl, failOnStatusCode: false }).then((res) => {
           expect(res.status, `GitHub blob file should exist: ${baseUrl}`)
             .to.be.oneOf([200, 301, 302]);
         });
@@ -327,7 +351,7 @@ describe('Link and Routing Validation - Individual URL Checks', () => {
         }
       }
       else {
-        cy.request({
+        requestWithDiagnostics({
           url: url,
           failOnStatusCode: false
         }).then((response) => {
@@ -350,7 +374,13 @@ describe('Link and Routing Validation - Individual URL Checks', () => {
   afterEach(() => {
     cy.log(`Progress: ${completedTests}/${totalTests}`);
     if (diagnosticLog.length) {
-      cy.task('log', `[DIAGNOSTIC]\n${diagnosticLog.join('\n')}`);
+      // One NDJSON line per entry, each tagged with the URL under test
+      // (`link`) so entries can be grouped/filtered after the fact even
+      // though a single test can log several sub-resource requests -
+      // e.g.: grep '\[DIAGNOSTIC\]' log | sed 's/^.*\[DIAGNOSTIC\] //' | jq -s '.'
+      diagnosticLog.forEach((entry) => {
+        cy.task('log', `[DIAGNOSTIC] ${JSON.stringify({ link: currentUrl, ...entry })}`);
+      });
       diagnosticLog = [];
     }
   });


### PR DESCRIPTION
## Summary
- Add a `fix-broken-links` Claude Code skill (`.claude/skills/fix-broken-links/SKILL.md`) covering resolving a target Link Checker run, triaging each failure into its root-cause case, applying the right fix, and opening a PR - including a new procedure for Case 1 failures where the correct replacement URL isn't obvious (tag the original author via an inline PR comment instead of guessing).
- Trim `broken-links-script/README.md` back to a human-focused overview and point at the new skill for investigating a failing run.
- Enhance diagnostics mode: diagnostic log entries are now structured NDJSON instead of free text, `cy.request()`-based checks (npm registry, non-HTML resources, GitHub blob files, content-type sniffing) are now instrumented (previously only `cy.visit()` paths produced any diagnostic data), and each diagnostics-mode job now logs its runner egress IP once (helps confirm IP-reputation blocking, e.g. Case 3).
- Exclude `oreilly.com` from the link checker - its Akamai bot protection returns a consistent 403 for automated requests (reproduces via `curl` too), and failed on every branch in the last two weekly runs.
- Fix `Extractlinks.js`'s `resolveFullUrl()`: a relative link starting with `/` (root-relative, e.g. a cross-version reference like `/2025/edge-kubernetes/...`) was being concatenated onto this branch's own versioned `BASE_URL`, producing an invalid doubled path on release branches (`.../docs/2026/2025/...`). Leading-slash links now resolve against the unversioned site root instead.

## Context
Investigated from Link Checker run https://github.com/Cumulocity-IoT/c8y-docs/actions/runs/29828318770, which failed on all three matrix branches (`develop`, `release/y2025`, `release/y2026`). The `oreilly.com` and `Extractlinks.js` fixes here address the parts of that failure common to `develop`; branch-specific fixes for `release/y2025` and `release/y2026` are being raised as separate PRs against those branches.

## Test plan
- [x] `node Extractlinks.js` runs cleanly on `develop`, regenerating `all_links.json`
- [x] Verified `resolveFullUrl()`'s new branch against sample inputs (root-relative cross-version link, unversioned shared page, plain relative link) resolves to the expected URLs
- [x] Confirmed `oreilly.com` link is matched by the new `excludedLinks` regex
- [x] CI: full Link Checker run on this branch (it've been run and returned failures, but will address them separately, also to test the whole workflow with the skill)

🤖 Generated with [Claude Code](https://claude.com/claude-code)