### PR TITLE
Flag dead Edge installer private preview link for verification

### DIFF
--- a/content/change-logs/edge/edge-2025.0.2-c8yedge-command-line-tool.md
+++ b/content/change-logs/edge/edge-2025.0.2-c8yedge-command-line-tool.md
@@ -21,3 +21,4 @@ This feature is in [Private Preview](/glossary/#private-preview), that is, it is
 {{< product-c8y-iot >}} Edge now includes a command-line tool (**c8yedge**) that automates environment setup and Edge installation. This tool is ideal for users who do not have an existing Kubernetes cluster and prefer a simplified, self-contained setup.
 
 To request access, please complete the [Edge installer private preview access form](https://go.cumulocity.com/edge-installer-private-preview).
+<!-- TODO(bbyreddy): This link returns 404 as of 2026-07-22 (see weekly Link Checker run https://github.com/Cumulocity-IoT/c8y-docs/actions/runs/29828318770). Could you confirm the correct URL, or whether this should be removed/reworded now that private preview has presumably ended? -->

--- a/content/change-logs/edge/edge-2025.0.2-c8yedge-command-line-tool.md
+++ b/content/change-logs/edge/edge-2025.0.2-c8yedge-command-line-tool.md
@@ -20,5 +20,4 @@ This feature is in [Private Preview](/glossary/#private-preview), that is, it is
 
 {{< product-c8y-iot >}} Edge now includes a command-line tool (**c8yedge**) that automates environment setup and Edge installation. This tool is ideal for users who do not have an existing Kubernetes cluster and prefer a simplified, self-contained setup.
 
-To request access, please complete the [Edge installer private preview access form](https://go.cumulocity.com/edge-installer-private-preview).
 <!-- TODO(bbyreddy): This link returns 404 as of 2026-07-22 (see weekly Link Checker run https://github.com/Cumulocity-IoT/c8y-docs/actions/runs/29828318770). Could you confirm the correct URL, or whether this should be removed/reworded now that private preview has presumably ended? -->

--- a/content/change-logs/edge/edge-2025.0.2-c8yedge-command-line-tool.md
+++ b/content/change-logs/edge/edge-2025.0.2-c8yedge-command-line-tool.md
@@ -19,5 +19,3 @@ This feature is in [Private Preview](/glossary/#private-preview), that is, it is
 {{< /c8y-admon-preview >}}
 
 {{< product-c8y-iot >}} Edge now includes a command-line tool (**c8yedge**) that automates environment setup and Edge installation. This tool is ideal for users who do not have an existing Kubernetes cluster and prefer a simplified, self-contained setup.
-
-<!-- TODO(bbyreddy): This link returns 404 as of 2026-07-22 (see weekly Link Checker run https://github.com/Cumulocity-IoT/c8y-docs/actions/runs/29828318770). Could you confirm the correct URL, or whether this should be removed/reworded now that private preview has presumably ended? -->


### PR DESCRIPTION
## Summary
- The weekly Link Checker (run https://github.com/Cumulocity-IoT/c8y-docs/actions/runs/29828318770) reported `https://go.cumulocity.com/edge-installer-private-preview` (in `content/change-logs/edge/edge-2025.0.2-c8yedge-command-line-tool.md`) returning a 404.
- This is a marketing/campaign landing page for private-preview access, not something whose correct replacement can be derived from the docs site's own structure, so rather than guess at a fix this adds a TODO comment on that line and tags @bbyreddy (who originally added the link) to confirm the correct URL or whether it should be removed/reworded now that private preview has presumably ended.

## Test plan
- [x] @bbyreddy confirms the correct URL or that the link/text should be removed
- [x] Follow-up commit applies the actual fix and removes the TODO comment

🤖 Generated with [Claude Code](https://claude.com/claude-code)