### PR TITLE
MTM-67385: Add AI Agents component for release-note taxonomy

### DIFF
--- a/data/component.json
+++ b/data/component.json
@@ -299,6 +299,16 @@
           "label": "Platform services"
         }
       ]
+    },
+    {
+      "id": "component-VtytA3d55",
+      "option": "AI Agents",
+      "product_area": [
+        {
+          "value": "product_area-eC7h0SiQ2b",
+          "label": "Application enablement & solutions"
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Adds a new `AI Agents` component to `data/component.json`, under the existing `Application enablement & solutions` product area.

## Why
[MTM-67385](https://cumulocity.atlassian.net/browse/MTM-67385) automates release-notes PR creation for `c8y-ai-agents`. The two existing `ai-agents` change-log entries in this repo reused the generic `Web SDK` component (shared with many unrelated ui-c8y features), which isn't a good fit for an automated process that always pins the same component value. This adds a dedicated component instead.

This needs to merge and deploy before the `c8y-ai-agents` side automation is enabled, since that automation validates the `component` input against the live taxonomy published at `https://cumulocity.com/docs/change-logs/index.json`.

## Test plan
- [ ] JSON validated locally (`python3 -c "import json; json.load(open('data/component.json'))"`)
- [ ] Confirm `AI Agents` appears in the "Build artifact"/"Component" filter dropdown on the change-logs page once deployed
- [ ] Confirm `https://cumulocity.com/docs/change-logs/index.json` includes `AI Agents` under `component` post-deploy


[MTM-67385]: https://cumulocity.atlassian.net/browse/MTM-67385?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ