### PR TITLE
Add ONNX block model extension update changelog

### DIFF
--- a/content/change-logs/analytics/apama-in-c8y-20260729-ONNX-block-supports-standalone-onnx-file.md
+++ b/content/change-logs/analytics/apama-in-c8y-20260729-ONNX-block-supports-standalone-onnx-file.md
@@ -1,5 +1,5 @@
 ---
-date: 2026-08-28
+date:
 title: ONNX block in Analytics Builder now requires file extension in model name
 change_type:
   - value: change-3BQrQ6adS

--- a/content/change-logs/analytics/apama-in-c8y-20260729-ONNX-block-supports-standalone-onnx-file.md
+++ b/content/change-logs/analytics/apama-in-c8y-20260729-ONNX-block-supports-standalone-onnx-file.md
@@ -1,6 +1,6 @@
 ---
 date:
-title: ONNX block in Analytics Builder now supports standalone .onnx model files
+title: ONNX block in Analytics Builder now requires file extension in model name
 change_type:
   - value: change-3BQrQ6adS
     label: API change

--- a/content/change-logs/analytics/apama-in-c8y-20260729-ONNX-block-supports-standalone-onnx-file.md
+++ b/content/change-logs/analytics/apama-in-c8y-20260729-ONNX-block-supports-standalone-onnx-file.md
@@ -1,5 +1,5 @@
 ---
-date:
+date: 2026-08-28
 title: ONNX block in Analytics Builder now requires file extension in model name
 change_type:
   - value: change-3BQrQ6adS
@@ -23,4 +23,4 @@ The `ONNX model name` parameter must now include an explicit `.onnx` or `.zip` f
 
 Previously, `<modelName>`, `<modelName>.onnx`, and `<modelName>.zip` were always resolved by extracting a `<modelName>.zip` archive and looking for `<modelName>.onnx` inside.
 
-**This is a breaking change** for existing models that omit the file extension, or that use a `.onnx` extension but have only a `.zip` file uploaded to the Files repository. In both cases, the block now looks for a standalone `.onnx` binary instead of extracting a zip archive. To migrate, ensure the file extension used in your Analytics Builder model matches the type of file you have uploaded.
+**This is a breaking change** for existing models that omit the file extension, or that use a `.onnx` extension to extract a model from a `.zip` file uploaded to the Files repository. To migrate, ensure the file extension used in your Analytics Builder model matches the type of file you have uploaded.

--- a/content/change-logs/analytics/apama-in-c8y-20260729-ONNX-block-supports-standalone-onnx-file.md
+++ b/content/change-logs/analytics/apama-in-c8y-20260729-ONNX-block-supports-standalone-onnx-file.md
@@ -23,4 +23,6 @@ The `ONNX model name` parameter must now include an explicit `.onnx` or `.zip` f
 
 Previously, `<modelName>`, `<modelName>.onnx`, and `<modelName>.zip` were always resolved by extracting a `<modelName>.zip` archive and looking for `<modelName>.onnx` inside.
 
-**This is a breaking change** for existing models that omit the file extension, or that use a `.onnx` extension to extract a model from a `.zip` file uploaded to the Files repository. To migrate, ensure the file extension used in your Analytics Builder model matches the type of file you have uploaded.
+{{< c8y-admon-important >}}
+This is a breaking change for existing models that omit the file extension, or that use a `.onnx` extension to extract a model from a `.zip` file uploaded to the Files repository. To migrate, ensure the file extension used in your Analytics Builder model matches the type of file you have uploaded.
+{{< /c8y-admon-important >}}

--- a/content/change-logs/analytics/apama-in-c8y-20260729-ONNX-block-supports-standalone-onnx-file.md
+++ b/content/change-logs/analytics/apama-in-c8y-20260729-ONNX-block-supports-standalone-onnx-file.md
@@ -1,0 +1,26 @@
+---
+date:
+title: ONNX block in Analytics Builder now supports standalone .onnx model files
+change_type:
+  - value: change-3BQrQ6adS
+    label: API change
+product_area: Analytics
+component:
+  - value: component-M5-cepIIS
+    label: Streaming Analytics
+build_artifact:
+  - value: tc-KXXmo2SUR
+    label: apama-in-c8y
+ticket: PAB-5326
+version: 27.180.0
+---
+
+The ONNX block (Public Preview) in Analytics Builder now supports models uploaded to the Cumulocity Files repository as a standalone `.onnx` file. Previously, the block only supported models packaged inside a `.zip` archive.
+
+The `ONNX model name` parameter must now include an explicit `.onnx` or `.zip` file extension:
+* `<modelName>.onnx` looks for a standalone `<modelName>.onnx` file.
+* `<modelName>.zip` extracts the archive and looks for `<modelName>.onnx` inside it.
+
+Previously, `<modelName>`, `<modelName>.onnx`, and `<modelName>.zip` were always resolved by extracting a `<modelName>.zip` archive and looking for `<modelName>.onnx` inside.
+
+**This is a breaking change** for existing models that omit the file extension, or that use a `.onnx` extension but have only a `.zip` file uploaded to the Files repository. In both cases, the block now looks for a standalone `.onnx` binary instead of extracting a zip archive. To migrate, ensure the file extension used in your Analytics Builder model matches the type of file you have uploaded.


### PR DESCRIPTION
The ONNX block now supports models uploaded to the Cumulocity Files repository as a standalone `.onnx` file, as well as the existing `.zip` archive.

The `ONNX model name` parameter must now include an explicit `.onnx` or `.zip` file extension:
* `<modelName>.onnx` looks for a standalone `<modelName>.onnx` file.
* `<modelName>.zip` extracts the archive and looks for `<modelName>.onnx` inside it.