### PR TITLE
CIE-5635 - Add caution note for SELinux configuration

### DIFF
--- a/content/edge/installing-edge-bundle/install-edge-with-c8yedge-cli.md
+++ b/content/edge/installing-edge-bundle/install-edge-with-c8yedge-cli.md
@@ -64,7 +64,7 @@ The offline package can be used for either an initial installation, or an upgrad
 {{< c8y-admon-caution >}}
 **SELinux Configuration Responsibility**
 
-If SELinux is enabled, ensuring all required configurations are in place for K3s is strictly the customer's responsibility. SELinux introduces host-specific variables like `fapolicyd`, custom policies, and dynamic context labeling that our tooling cannot fully account for. Customers must properly prepare and validate their SELinux environment prior to deploying Cumulocity IoT Edge (c8yedge).
+If SELinux is enabled, ensuring all required configurations are in place for K3s is strictly the customer's responsibility. SELinux introduces host-specific variables like `fapolicyd`, custom policies, and dynamic context labeling that our tooling cannot fully account for. Customers must properly prepare and validate their SELinux environment prior to deploying {{< company-c8y >}} Edge (c8yedge).
 {{< /c8y-admon-caution >}}
 
 The c8yedge tool installs [Lightweight Kubernetes (K3s)](https://docs.k3s.io/), which has prerequisites for running in an airgapped environment. If your environment has no network interface with a default route, or SELinux is enabled, pay attention to and follow the two relevant sections under [Prerequisites](https://docs.k3s.io/installation/airgap#prerequisites).

--- a/content/edge/installing-edge-bundle/install-edge-with-c8yedge-cli.md
+++ b/content/edge/installing-edge-bundle/install-edge-with-c8yedge-cli.md
@@ -25,7 +25,7 @@ For example, you could install and customize Edge on a VM in your development en
 {{< c8y-admon-caution >}}
 **Host security hardening**
 
-{{< product-c8y-iot >}} Edge (c8yedge) also supports hosts with standard SELinux to the extent supported by [K3s](https://docs.k3s.io/advanced#selinux-support).
+Installing {{< product-c8y-iot >}} Edge with c8yedge also supports hosts with standard SELinux to the extent supported by [K3s](https://docs.k3s.io/advanced#selinux-support).
 
 Additional host hardening, such as custom SELinux policies, AppArmor, Smack, fapolicyd, or similar controls, is the customer's responsibility. These host-specific security mechanisms can interfere with Kubernetes, the container runtime, or networking required by c8yedge. Validate your hardened environment to facilitate c8yedge operations.
 {{< /c8y-admon-caution >}}

--- a/content/edge/installing-edge-bundle/install-edge-with-c8yedge-cli.md
+++ b/content/edge/installing-edge-bundle/install-edge-with-c8yedge-cli.md
@@ -64,7 +64,7 @@ The offline package can be used for either an initial installation, or an upgrad
 {{< c8y-admon-caution >}}
 **SELinux configuration responsibility**
 
-If SELinux is enabled, ensuring all required configurations are in place for K3s is strictly the customer's responsibility. SELinux introduces host-specific variables like `fapolicyd`, custom policies, and dynamic context labeling that our tooling cannot fully account for. Customers must properly prepare and validate their SELinux environment prior to deploying {{< company-c8y >}} Edge (c8yedge).
+If SELinux is enabled, it is the customer's responsibility to ensure that all required configurations are in place for K3s. SELinux introduces host-specific variables such as `fapolicyd`, custom policies, and dynamic context labeling that {{< company-c8y >}}'s tooling cannot fully account for. Customers must properly prepare and validate their SELinux environment prior to deploying {{< product-c8y-iot >}} Edge (c8yedge).
 {{< /c8y-admon-caution >}}
 
 The c8yedge tool installs [Lightweight Kubernetes (K3s)](https://docs.k3s.io/), which has prerequisites for running in an airgapped environment. If your environment has no network interface with a default route, or SELinux is enabled, pay attention to and follow the two relevant sections under [Prerequisites](https://docs.k3s.io/installation/airgap#prerequisites).

--- a/content/edge/installing-edge-bundle/install-edge-with-c8yedge-cli.md
+++ b/content/edge/installing-edge-bundle/install-edge-with-c8yedge-cli.md
@@ -62,7 +62,7 @@ The tool generates a tarball suffixed with the specific version of Edge download
 The offline package can be used for either an initial installation, or an upgrade of an existing installation. You need to transfer this file, as well as the c8yedge tool, into your airgapped environment.
 
 {{< c8y-admon-caution >}}
-**SELinux Configuration Responsibility**
+**SELinux configuration responsibility**
 
 If SELinux is enabled, ensuring all required configurations are in place for K3s is strictly the customer's responsibility. SELinux introduces host-specific variables like `fapolicyd`, custom policies, and dynamic context labeling that our tooling cannot fully account for. Customers must properly prepare and validate their SELinux environment prior to deploying {{< company-c8y >}} Edge (c8yedge).
 {{< /c8y-admon-caution >}}

--- a/content/edge/installing-edge-bundle/install-edge-with-c8yedge-cli.md
+++ b/content/edge/installing-edge-bundle/install-edge-with-c8yedge-cli.md
@@ -27,7 +27,7 @@ For example, you could install and customize Edge on a VM in your development en
 
 Installing {{< product-c8y-iot >}} Edge with c8yedge also supports hosts with standard SELinux to the extent supported by [K3s](https://docs.k3s.io/advanced#selinux-support).
 
-Additional host hardening, such as custom SELinux policies, AppArmor, Smack, fapolicyd, or similar controls, is the customer's responsibility. These host-specific security mechanisms can interfere with Kubernetes, the container runtime, or networking required by c8yedge. Validate your hardened environment to facilitate c8yedge operations.
+Additional host hardening, such as custom SELinux policies, AppArmor, Smack, fapolicyd, or similar controls, is the customer's responsibility. These host-specific security mechanisms can interfere with Kubernetes, the container runtime, or networking required by c8yedge. 
 {{< /c8y-admon-caution >}}
 
 ### Downloading c8yedge

--- a/content/edge/installing-edge-bundle/install-edge-with-c8yedge-cli.md
+++ b/content/edge/installing-edge-bundle/install-edge-with-c8yedge-cli.md
@@ -61,6 +61,12 @@ The tool generates a tarball suffixed with the specific version of Edge download
 
 The offline package can be used for either an initial installation, or an upgrade of an existing installation. You need to transfer this file, as well as the c8yedge tool, into your airgapped environment.
 
+{{< c8y-admon-caution >}}
+**SELinux Configuration Responsibility**
+
+If SELinux is enabled, ensuring all required configurations are in place for K3s is strictly the customer's responsibility. SELinux introduces host-specific variables like `fapolicyd`, custom policies, and dynamic context labeling that our tooling cannot fully account for. Customers must properly prepare and validate their SELinux environment prior to deploying Cumulocity IoT Edge (c8yedge).
+{{< /c8y-admon-caution >}}
+
 The c8yedge tool installs [Lightweight Kubernetes (K3s)](https://docs.k3s.io/), which has prerequisites for running in an airgapped environment. If your environment has no network interface with a default route, or SELinux is enabled, pay attention to and follow the two relevant sections under [Prerequisites](https://docs.k3s.io/installation/airgap#prerequisites).
 
 Once in the airgapped environment, run the installation command referencing the offline package file the tool generated earlier:

--- a/content/edge/installing-edge-bundle/install-edge-with-c8yedge-cli.md
+++ b/content/edge/installing-edge-bundle/install-edge-with-c8yedge-cli.md
@@ -22,6 +22,14 @@ Although the virtual or physical nature of the platform is unimportant to Edge, 
 For example, you could install and customize Edge on a VM in your development environment. You can then then hand-off a self-contained VM image to be installed at a remote site in a reliable and reproducable way.
 {{< /c8y-admon-info >}}
 
+{{< c8y-admon-caution >}}
+**Host security hardening**
+
+{{< product-c8y-iot >}} Edge (c8yedge) also supports hosts with standard SELinux to the extent supported by [K3s](https://docs.k3s.io/advanced#selinux-support).
+
+Additional host hardening, such as custom SELinux policies, AppArmor, Smack, fapolicyd, or similar controls, is the customer's responsibility. These host-specific security mechanisms can interfere with Kubernetes, the container runtime, or networking required by c8yedge. Validate your hardened environment to facilitate c8yedge operations.
+{{< /c8y-admon-caution >}}
+
 ### Downloading c8yedge
 You can download the tool from the [{{< company-c8y >}} Download Center](https://download.cumulocity.com/Cumulocity-Edge) or by running the following commands:
 
@@ -60,12 +68,6 @@ c8yedge package
 The tool generates a tarball suffixed with the specific version of Edge downloaded (for example, `c8yedge-{{< c8y-edge-current-version >}}_0_0.tar`). By default, this file is created in your current directory and contains the latest release of Edge {{< c8y-edge-current-version >}}. You can discover more options with `c8yedge package --help`, such as the ability to package a very specific version.
 
 The offline package can be used for either an initial installation, or an upgrade of an existing installation. You need to transfer this file, as well as the c8yedge tool, into your airgapped environment.
-
-{{< c8y-admon-caution >}}
-**SELinux Configuration Responsibility**
-
-If SELinux is enabled, ensuring all required configurations are in place for K3s is strictly the customer's responsibility. SELinux introduces host-specific variables like `fapolicyd`, custom policies, and dynamic context labeling that our tooling cannot fully account for. Customers must properly prepare and validate their SELinux environment prior to deploying Cumulocity IoT Edge (c8yedge).
-{{< /c8y-admon-caution >}}
 
 The c8yedge tool installs [Lightweight Kubernetes (K3s)](https://docs.k3s.io/), which has prerequisites for running in an airgapped environment. If your environment has no network interface with a default route, or SELinux is enabled, pay attention to and follow the two relevant sections under [Prerequisites](https://docs.k3s.io/installation/airgap#prerequisites).
 


### PR DESCRIPTION
This pull request adds an important caution regarding SELinux configuration responsibilities to the installation documentation for Edge with `c8yedge` cli. The new section clarifies that customers are responsible for ensuring all SELinux requirements are met when deploying Cumulocity IoT Edge, as the tooling cannot fully handle SELinux-specific configurations.

Documentation updates:

* Added a caution admonition to `install-edge-with-c8yedge-cli.md` explicitly stating that SELinux configuration for K3s is the customer's responsibility, highlighting the need to prepare and validate the SELinux environment before deploying Cumulocity IoT Edge.