### PR TITLE
[GRAFT][release/y2025] Merge pull request #4981 from Cumulocity-IoT/no-issue_Fix-broken-links-in-develop-on-2026-07-30

### DIFF
--- a/broken-links-script/Extractlinks.js
+++ b/broken-links-script/Extractlinks.js
@@ -103,15 +103,22 @@ const resolveFullUrl = (link, relativePath, fileContent) => {
   if (/^https?:\/\//i.test(resolvedLink)) {
     return resolvedLink;
   }
-  // A link written with a leading "/" is root-relative (a shared page like
-  // "/legal-notices/..." or a cross-version reference like
-  // "/2025/edge-kubernetes/...") and resolves against the unversioned site
-  // root, not this branch's own version prefix - prefixing both would
-  // produce an invalid doubled path like ".../docs/2026/2025/...". Only
-  // links without a leading slash are meant to resolve against BASE_URL.
+  // A root-relative link that already names a version ("/2025/edge-kubernetes/...")
+  // is an explicit cross-version reference: it must resolve against the
+  // unversioned site root, because prefixing this branch's own version too
+  // would produce an invalid doubled path like ".../docs/2026/2025/...".
+  //
+  // Every other root-relative link ("/edge-kubernetes/datahub",
+  // "/legal-notices/copyright/") is an ordinary same-version internal link
+  // and resolves against BASE_URL, version prefix included. Stripping the
+  // prefix for those is what silently pointed release-branch content at the
+  // *current* published docs instead of that release's own, which 404s as
+  // soon as the release stops being current. Shared pages are mirrored under
+  // every version prefix, so keeping the prefix is safe for them too.
   if (resolvedLink.startsWith("/")) {
-    const rootUrl = BASE_URL.replace(/\/\d{4}$/, "");
-    return `${rootUrl}${resolvedLink}`.replace(/([^:]\/)\/+/g, '$1');
+    const isCrossVersion = /^\/\d{4}(\/|$)/.test(resolvedLink);
+    const base = isCrossVersion ? BASE_URL.replace(/\/\d{4}$/, "") : BASE_URL.replace(/\/$/, "");
+    return `${base}${resolvedLink}`.replace(/([^:]\/)\/+/g, '$1');
   }
   return `${BASE_URL.replace(/\/$/, "")}/${resolvedLink}`;
 };

--- a/broken-links-script/config.cjs
+++ b/broken-links-script/config.cjs
@@ -43,6 +43,21 @@ module.exports = {
     // latlong.net fails to load in Cypress (getting 403)
     "https://www.latlong.net/",
 
+    // unpkg.com returns 403 to automated requests from some GitHub Actions
+    // runner IPs for a whole job at a time: in run 30535957097 (2026-07-30)
+    // this exact URL failed all 11 attempts on both release/y2025 and
+    // release/y2026 while passing on develop in the same run, and returns 200
+    // from a normal network. Runner-IP reputation, not a broken link, and
+    // retries can't help because the block lasts the job's lifetime.
+    /^https:\/\/unpkg\.com\//,
+
+    // YouTube rate-limits automated requests per runner IP, answering with
+    // 429 and a redirect to google.com/sorry. In run 30535957097 (2026-07-30)
+    // this video failed all 11 attempts on release/y2025 while passing on
+    // both develop and release/y2026 in the same run, and returns 200 from a
+    // normal network - runner-IP rate-limiting, not a broken link.
+    /^https:\/\/www\.youtube\.com\/watch/,
+
     // oreilly.com's Akamai bot protection returns 403 for automated
     // requests consistently - reproduced outside CI too (curl gets 403 on
     // every attempt), and failed on every branch in both the 2026-07-13 and


### PR DESCRIPTION
# Backport

This will backport the following commits from `develop` to `release/y2025`:
 - [Merge pull request #4981 from Cumulocity-IoT/no-issue_Fix-broken-links-in-develop-on-2026-07-30](https://github.com/Cumulocity-IoT/c8y-docs/pull/4981)

<!--- Backport version: 12.0.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)