### PR TITLE
no-issue: Fix broken javadoc.io link in Microservice SDK docs

### DIFF
--- a/content/microservice-sdk/java-bundle/developing-microservice.md
+++ b/content/microservice-sdk/java-bundle/developing-microservice.md
@@ -986,7 +986,7 @@ The following locations are searched for the logback configuration file:
 
 A Spring Boot library was upgraded to 2.5.8, hence upgrading Microservice SDK to 10.13+ may require some additional development.
 
-* The `content(matcher)` method of RestAssured has been replaced with `body(matcher)`, see [RequestSpecification#content()](https://javadoc.io/doc/io.rest-assured/rest-assured/3.0.0/io/restassured/specification/RequestSpecification.html#content-byte:A-)
+* The `content(matcher)` method of RestAssured has been replaced with `body(matcher)`, see [RequestSpecification#content()](https://javadoc.io/static/io.rest-assured/rest-assured/3.0.0/io/restassured/specification/RequestSpecification.html#content-byte:A-)
 * Spring Boot BOM does not define a version for joda-time, you may need to explicitly define version.
 
   Maven example:


### PR DESCRIPTION
Fixes the single failure from Link Checker run [31050522304](https://github.com/Cumulocity-IoT/c8y-docs/actions/runs/31050522304) (PR-label trigger on `backport/release/y2026/pr-4981`).

## The two links

Please open both and compare:

| | URL |
| --- | --- |
| Before | https://javadoc.io/doc/io.rest-assured/rest-assured/3.0.0/io/restassured/specification/RequestSpecification.html#content-byte:A- |
| After | https://javadoc.io/static/io.rest-assured/rest-assured/3.0.0/io/restassured/specification/RequestSpecification.html#content-byte:A- |

The "before" link lands on javadoc.io's version-listing page for the artifact;
<img width="1510" height="657" alt="2026-08-07_12-11" src="https://github.com/user-attachments/assets/9456acf7-5981-498a-9d45-3e71a7e15800" />
the "after" link opens the REST Assured 3.0.0 `RequestSpecification` javadoc scrolled to the deprecated `content(byte[])` method, which is what the sentence refers to.
<img width="1546" height="1022" alt="2026-08-07_12-11_1" src="https://github.com/user-attachments/assets/5a1fe2ca-8442-4a35-8285-bb29cdcc91cc" />

## Failure and root cause

`content/microservice-sdk/java-bundle/developing-microservice.md` — Cypress timed out waiting for the page `load` event on all 11 attempts.

javadoc.io's version-pinned `/doc/` deep link does not reliably serve the class page. It currently answers `303 → /versions/io.rest-assured/rest-assured` (occasionally `522`) — a Vue app pulling jsdelivr/cdnjs/jQuery/Bootstrap/GTM, which is what blocked the `load` event. The `#content-byte:A-` anchor does not exist on that listing page either.

Not CI-specific: reproduced with `curl` outside CI. The `/static/` URL serves the real generated javadoc — 5/5 requests `200` in ~0.12s — and does contain `name="content-byte:A-"`.

## Fix

Content only: `/doc/` → `/static/` for that one link. No `config.cjs`, exception-list or script changes.

Verified locally: `node Extractlinks.js && node run.cjs --urls-with=javadoc.io` → 1 passing (fragment check included).

## Other branches

The identical link is present on `release/y2026` and `release/y2025` too, so both should get this via the usual graft/backport.