### PR TITLE
feat: add RFC 9116 security.txt

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -17,7 +17,7 @@ enableGitInfo          = true
   sectors = "sector"
 
 [outputs]
-  home = ["HTML", "llmstxt", "llms-full"]
+  home = ["HTML", "llmstxt", "llms-full", "securitytxt"]
 
 [outputFormats.llmstxt]
   mediaType    = "text/plain"
@@ -29,6 +29,15 @@ enableGitInfo          = true
 [outputFormats.llms-full]
   mediaType    = "text/plain"
   baseName     = "llms-full"
+  isPlainText  = true
+  notAlternative = true
+  suffixes     = ["txt"]
+
+# RFC 9116 security.txt, rendered by layouts/index.securitytxt.txt
+[outputFormats.securitytxt]
+  mediaType    = "text/plain"
+  baseName     = "security"
+  path         = ".well-known"
   isPlainText  = true
   notAlternative = true
   suffixes     = ["txt"]

--- a/layouts/index.securitytxt.txt
+++ b/layouts/index.securitytxt.txt
@@ -1,0 +1,27 @@
+{{- /*
+Renders /.well-known/security.txt as defined by RFC 9116
+(https://www.rfc-editor.org/rfc/rfc9116).
+
+The Expires field is generated at build time and always points 11 months into
+the future, so every deployment pushes the expiry date forward and the file
+never goes stale on its own. RFC 9116 recommends a value less than a year
+ahead, hence 11 rather than 12 months.
+*/ -}}
+{{- $expires := now.UTC.AddDate 0 11 0 -}}
+# Cumulocity vulnerability disclosure contact information.
+# Format defined by RFC 9116 (https://www.rfc-editor.org/rfc/rfc9116).
+#
+# If you believe you have found a security vulnerability in a Cumulocity
+# product or service, please report it to the contact below and follow the
+# responsible disclosure policy linked in the Policy field.
+#
+# This file is generated on every build; do not edit it in the deployed site.
+# Source: layouts/index.securitytxt.txt in github.com/Cumulocity-IoT/c8y-docs
+
+Contact: mailto:csirt@cumulocity.com
+Contact: https://cumulocity.com/docs/legal-notices/responsible-disclosure-policy/
+Expires: {{ $expires.Format "2006-01-02" }}T00:00:00.000Z
+Policy: https://cumulocity.com/docs/legal-notices/responsible-disclosure-policy/
+Preferred-Languages: en
+Canonical: https://cumulocity.com/.well-known/security.txt
+Canonical: https://cumulocity.com/docs/.well-known/security.txt


### PR DESCRIPTION
## What

Adds a machine-readable vulnerability disclosure contact file ([RFC 9116](https://www.rfc-editor.org/rfc/rfc9116)) so security researchers and automated scanners can find the right reporting channel without guessing.

Contact is `csirt@cumulocity.com` — the address our [Responsible Disclosure Policy](https://cumulocity.com/docs/legal-notices/responsible-disclosure-policy/) already names — with the policy page itself listed as a second `Contact` URI so a human landing there gets the full reporting instructions.

## How

Rather than a static file, it is rendered as a Hugo output format on the home page:

- `config.toml` — new `[outputFormats.securitytxt]` (`path = ".well-known"`, `baseName = "security"`), added to `home` outputs
- `layouts/index.securitytxt.txt` — the template

Output lands at `public/.well-known/security.txt`, i.e. **https://cumulocity.com/docs/.well-known/security.txt**.

The reason for generating it instead of committing a static file is the mandatory `Expires` field. RFC 9116 requires exactly one, and recommends a value less than a year in the future. A hardcoded date silently goes stale and turns the file into a compliance failure, so the template derives it at build time as `now + 11 months`. Every deployment pushes the expiry forward on its own.

Rendered output:

```
Contact: mailto:csirt@cumulocity.com
Contact: https://cumulocity.com/docs/legal-notices/responsible-disclosure-policy/
Expires: <build date + 11 months>T00:00:00.000Z
Policy: https://cumulocity.com/docs/legal-notices/responsible-disclosure-policy/
Preferred-Languages: en
Canonical: https://cumulocity.com/.well-known/security.txt
Canonical: https://cumulocity.com/docs/.well-known/security.txt
```

`Contact` values are in order of preference per RFC 9116 §2.5.3, which permits both `mailto:` and `https:` URIs.

## Verified

- Built with Hugo 0.132.2 (the version pinned in `staging.yml`) — `path` on output formats is supported there, and the file is emitted at `public/.well-known/security.txt`
- Field syntax checked against RFC 9116: `Contact` present, exactly one `Expires` in RFC 3339 form and under a year out, at most one `Preferred-Languages`, trailing newline present

## Follow-ups outside this repo

Two things this PR cannot fix on its own:

1. **Root path.** RFC 9116 requires the file at `https://cumulocity.com/.well-known/security.txt`. This repo only publishes under `/docs`, and `https://cumulocity.com/.well-known/security.txt` currently returns 404. A `301` from the corporate site root to `/docs/.well-known/security.txt` makes this compliant (RFC 9116 §3 permits redirects); otherwise the file needs to live in whatever serves the root of `cumulocity.com`. Both locations are already listed as `Canonical` in anticipation of the redirect.
2. **Content type.** RFC 9116 wants `text/plain; charset=utf-8`. Our web server currently serves `.txt` as bare `text/plain` (see `/docs/llms.txt`) — a server-side charset addition would close that gap.

Optional: RFC 9116 §2.3 recommends an OpenPGP cleartext signature plus an `Encryption` field. Not included, as that needs a published key.